### PR TITLE
fix(ha): use git requirement for py-bragerone and bump version

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -14,7 +14,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone@https://github.com/marpi82/py-bragerone/archive/refs/tags/2026.2.0b1.zip"
+    "git+https://github.com/marpi82/py-bragerone.git@2026.2.0b1"
   ],
-  "version": "2026a2"
+  "version": "2026a3"
 }


### PR DESCRIPTION
This pull request updates the dependency installation method and versioning for the `habragerone` custom component.

Dependency and version management updates:

* Changed the `py-bragerone` dependency in `manifest.json` to use a Git URL (`git+https://github.com/marpi82/py-bragerone.git@2026.2.0b1`) instead of a direct zip archive, improving maintainability and compatibility.
* Updated the version of the custom component from `2026a2` to `2026a3` in `manifest.json`.