### PR TITLE
Fix invalid VCS requirement format in manifest

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -14,7 +14,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "git+https://github.com/marpi82/py-bragerone.git@2026.2.0b1"
+    "py-bragerone@git+https://github.com/marpi82/py-bragerone.git@2026.2.0b1"
   ],
   "version": "2026a3"
 }


### PR DESCRIPTION
## Summary\n- fix invalid Home Assistant requirement string by adding package name for VCS URL\n- switch from raw git URL to named requirement format: py-bragerone@git+https://...\n\n## Why\nHome Assistant/packaging rejects bare VCS requirement entries ("Invalid requirement 'git+..."), but accepts named direct references.\n\n## Validation\n- packaging.Requirement parses the new requirement string\n- pip install works with the new string\n