### PR TITLE
Release 2026.4.3 with py-bragerone reconnect fix

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -14,7 +14,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.4.2"
+    "py-bragerone==2026.4.3"
   ],
-  "version": "2026.4.2"
+  "version": "2026.4.3"
 }


### PR DESCRIPTION
## Summary
- bump `custom_components/habragerone/manifest.json` requirement to `py-bragerone==2026.4.3`
- bump integration version to `2026.4.3`
- consume py-bragerone websocket self-healing reconnect fix for long-running HA sessions

## Test plan
- [x] validate `manifest.json` structure locally
- [ ] CI green on this PR
- [ ] smoke test in HA after merge


Made with [Cursor](https://cursor.com)