### PR TITLE
Make initial entity refresh non-blocking during setup

### DIFF
--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -73,7 +73,7 @@ class BragerStatusBinarySensor(BinarySensorEntity):
     async def async_added_to_hass(self) -> None:
         """Attach runtime listener when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
-        await self.async_update()
+        self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
         """Detach runtime listener before entity removal."""

--- a/custom_components/habragerone/number.py
+++ b/custom_components/habragerone/number.py
@@ -80,7 +80,7 @@ class BragerSymbolNumber(NumberEntity):
     async def async_added_to_hass(self) -> None:
         """Attach runtime listener when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
-        await self.async_update()
+        self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
         """Detach runtime listener before entity removal."""

--- a/custom_components/habragerone/select.py
+++ b/custom_components/habragerone/select.py
@@ -79,7 +79,7 @@ class BragerSymbolSelect(SelectEntity):
     async def async_added_to_hass(self) -> None:
         """Attach runtime listener when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
-        await self.async_update()
+        self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
         """Detach runtime listener before entity removal."""

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -85,7 +85,7 @@ class BragerSymbolSensor(SensorEntity):
     async def async_added_to_hass(self) -> None:
         """Subscribe to push updates when entity is added to HA."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
-        await self.async_update()
+        self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
         """Detach runtime listener when entity is removed from HA."""

--- a/custom_components/habragerone/switch.py
+++ b/custom_components/habragerone/switch.py
@@ -73,7 +73,7 @@ class BragerSymbolSwitch(SwitchEntity):
     async def async_added_to_hass(self) -> None:
         """Attach runtime listener when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
-        await self.async_update()
+        self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
         """Detach runtime listener before entity removal."""


### PR DESCRIPTION
## Summary
- remove awaited initial `async_update()` calls from entity `async_added_to_hass` handlers
- schedule first refresh asynchronously with `async_schedule_update_ha_state(True)` across sensor/binary_sensor/switch/number/select
- keep existing runtime-listener driven updates unchanged

## Test plan
- [x] `uv run poe lint`
- [x] `uv run poe typecheck`
- [x] `uv run pytest -q tests`

## Related issues
- closes #35
- closes #36