### PR TITLE
Align manifest to 2026.4.4

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -14,7 +14,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.4.3"
+    "py-bragerone==2026.4.4"
   ],
-  "version": "2026.4.3"
+  "version": "2026.4.4"
 }


### PR DESCRIPTION
## Summary
- update integration manifest `version` to `2026.4.4`
- update manifest requirement to `py-bragerone==2026.4.4`
- ensure release metadata matches already merged fixes before tagging

## Test plan
- [x] verify manifest diff contains only version/requirement bump
- [ ] run CI checks in PR