### PR TITLE
Use HA constants for sensor units and classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ HACS custom integration (`custom_components/habragerone`) connecting BragerOne h
 
 ## Project shape
 
-- **Platforms**: `sensor`, `binary_sensor`, `switch`, `number` (`NumberMode.BOX`), `select`, `button` (no `climate`).
+- **Platforms**: `sensor` (HA `device_class` / `state_class` / unit constants from bootstrap units), `binary_sensor`, `switch`, `number` (`NumberMode.BOX`), `select`, `button` (no `climate`).
 - **Python**: `>=3.14.2,<3.15`; **HA**: `homeassistant>=2026.3.0`; iot_class `cloud_push`.
 - **Dependencies**: **uv** (`uv.lock` committed). Runtime deps pinned exactly in `manifest.json`.
 - **Build/versioning**: hatchling + hatch-vcs, CalVer from git tags.

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -4,8 +4,19 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity, SensorStateClass
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
+    UnitOfEnergy,
+    UnitOfFrequency,
+    UnitOfPower,
+    UnitOfPressure,
+    UnitOfTemperature,
+    UnitOfVolumeFlowRate,
+)
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -68,6 +79,7 @@ class BragerSymbolSensor(SensorEntity):
         self._attr_suggested_object_id = descriptor_suggested_object_id(descriptor)
         self._attr_unique_id = f"{entry.entry_id}_{devid}_{symbol}".lower().replace(" ", "_")
         self._attr_native_unit_of_measurement = self._normalize_unit(descriptor.get("unit"))
+        self._attr_device_class, self._attr_state_class = self._infer_sensor_classes(self._attr_native_unit_of_measurement)
         self._attr_available = True
         self._raw_to_label = descriptor_raw_to_label(descriptor)
         mapping = descriptor.get("mapping")
@@ -119,6 +131,7 @@ class BragerSymbolSensor(SensorEntity):
             normalized_dynamic_unit = self._normalize_unit(resolved_unit)
             if normalized_dynamic_unit:
                 self._attr_native_unit_of_measurement = normalized_dynamic_unit
+                self._attr_device_class, self._attr_state_class = self._infer_sensor_classes(normalized_dynamic_unit)
             if resolved_value is not None:
                 self._attr_native_value = _normalize_text_state(resolved_value)
                 return
@@ -163,13 +176,44 @@ class BragerSymbolSensor(SensorEntity):
                 lowered = unit.casefold()
                 if lowered.startswith(("wn.", "units.", "app.")):
                     return None
-            return unit
+            return _UNIT_ALIASES.get(unit.casefold(), unit)
         if isinstance(value, dict):
             for key in ("en", "pl"):
                 val = value.get(key)
                 if isinstance(val, str) and val.strip():
-                    return val
+                    return _UNIT_ALIASES.get(val.strip().casefold(), val.strip())
         return None
+
+    @staticmethod
+    def _infer_sensor_classes(unit: str | None) -> tuple[SensorDeviceClass | None, SensorStateClass | None]:
+        if unit in {UnitOfTemperature.CELSIUS, UnitOfTemperature.FAHRENHEIT, UnitOfTemperature.KELVIN}:
+            return SensorDeviceClass.TEMPERATURE, SensorStateClass.MEASUREMENT
+        if unit in {UnitOfEnergy.WATT_HOUR, UnitOfEnergy.KILO_WATT_HOUR, UnitOfEnergy.MEGA_WATT_HOUR}:
+            # Cumulative energy counters — TOTAL_INCREASING keeps energy dashboard / LTS correct.
+            return SensorDeviceClass.ENERGY, SensorStateClass.TOTAL_INCREASING
+        if unit in {
+            UnitOfPower.WATT,
+            UnitOfPower.KILO_WATT,
+            UnitOfPower.BTU_PER_HOUR,
+        }:
+            return SensorDeviceClass.POWER, SensorStateClass.MEASUREMENT
+        if unit in {UnitOfPressure.PA, UnitOfPressure.HPA, UnitOfPressure.BAR}:
+            return SensorDeviceClass.PRESSURE, SensorStateClass.MEASUREMENT
+        if unit in {UnitOfElectricCurrent.AMPERE, UnitOfElectricCurrent.MILLIAMPERE}:
+            return SensorDeviceClass.CURRENT, SensorStateClass.MEASUREMENT
+        if unit in {
+            UnitOfElectricPotential.VOLT,
+            UnitOfElectricPotential.MILLIVOLT,
+            UnitOfElectricPotential.KILOVOLT,
+        }:
+            return SensorDeviceClass.VOLTAGE, SensorStateClass.MEASUREMENT
+        if unit in {UnitOfFrequency.HERTZ, UnitOfFrequency.KILOHERTZ, UnitOfFrequency.MEGAHERTZ, UnitOfFrequency.GIGAHERTZ}:
+            return SensorDeviceClass.FREQUENCY, SensorStateClass.MEASUREMENT
+        if unit == UnitOfVolumeFlowRate.LITERS_PER_MINUTE:
+            return SensorDeviceClass.VOLUME_FLOW_RATE, SensorStateClass.MEASUREMENT
+        if unit == PERCENTAGE:
+            return None, SensorStateClass.MEASUREMENT
+        return None, None
 
 
 def _normalize_text_state(value: Any) -> Any:
@@ -187,3 +231,33 @@ def _normalize_text_state(value: Any) -> Any:
     if letters and all(ch.isupper() for ch in letters):
         return text
     return f"{head.lower()}{text[1:]}"
+
+
+_UNIT_ALIASES: dict[str, str] = {
+    "°c": UnitOfTemperature.CELSIUS,
+    "c": UnitOfTemperature.CELSIUS,
+    "℃": UnitOfTemperature.CELSIUS,
+    "°f": UnitOfTemperature.FAHRENHEIT,
+    "f": UnitOfTemperature.FAHRENHEIT,
+    "℉": UnitOfTemperature.FAHRENHEIT,
+    "k": UnitOfTemperature.KELVIN,
+    "w": UnitOfPower.WATT,
+    "kw": UnitOfPower.KILO_WATT,
+    "wh": UnitOfEnergy.WATT_HOUR,
+    "kwh": UnitOfEnergy.KILO_WATT_HOUR,
+    "mwh": UnitOfEnergy.MEGA_WATT_HOUR,
+    "hpa": UnitOfPressure.HPA,
+    "bar": UnitOfPressure.BAR,
+    "pa": UnitOfPressure.PA,
+    "hz": UnitOfFrequency.HERTZ,
+    "khz": UnitOfFrequency.KILOHERTZ,
+    "mhz": UnitOfFrequency.MEGAHERTZ,
+    "ghz": UnitOfFrequency.GIGAHERTZ,
+    "a": UnitOfElectricCurrent.AMPERE,
+    "ma": UnitOfElectricCurrent.MILLIAMPERE,
+    "v": UnitOfElectricPotential.VOLT,
+    "mv": UnitOfElectricPotential.MILLIVOLT,
+    "kv": UnitOfElectricPotential.KILOVOLT,
+    "l/min": UnitOfVolumeFlowRate.LITERS_PER_MINUTE,
+    "%": PERCENTAGE,
+}

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -6,6 +6,8 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import UnitOfTemperature
 from homeassistant.core import HomeAssistant
 
 from tests.conftest import install_pybragerone_stubs
@@ -56,7 +58,9 @@ async def test_sensor_entity_identity_and_device_info(hass: HomeAssistant) -> No
 
     assert entity._attr_name == "Boiler temperature"
     assert entity._attr_unique_id == f"{entry.entry_id}_dev1_temp_boiler"
-    assert entity._attr_native_unit_of_measurement == "°C"
+    assert entity._attr_native_unit_of_measurement == UnitOfTemperature.CELSIUS
+    assert entity._attr_device_class == SensorDeviceClass.TEMPERATURE
+    assert entity._attr_state_class == SensorStateClass.MEASUREMENT
     assert entity.device_info["identifiers"] == {(DOMAIN, "DEV1")}
 
 
@@ -150,7 +154,42 @@ async def test_sensor_update_uses_dynamic_unit_resolver(hass: HomeAssistant) -> 
 
     assert entity.native_value == 42.0
     assert entity.native_unit_of_measurement == "%"
+    assert entity._attr_device_class is None
+    assert entity._attr_state_class == SensorStateClass.MEASUREMENT
     resolve_with_unit.assert_awaited_once_with("PARAM16_2")
+
+
+@pytest.mark.asyncio
+async def test_sensor_dynamic_unit_resolver_skips_unresolved_unit_token(hass: HomeAssistant) -> None:
+    store = FakeStore(flat_values={"P10.v2": 33})
+    resolve_with_unit = AsyncMock(return_value=(None, "wn.9998"))
+    runtime = SimpleNamespace(
+        store=store,
+        add_listener=lambda _cb: lambda: None,
+        module_online=lambda _devid: None,
+        async_resolve_symbol_with_unit=resolve_with_unit,
+        async_resolve_status_label=AsyncMock(return_value=None),
+    )
+    descriptor = sensor_descriptor(
+        symbol="PARAM16_2",
+        pool="P10",
+        chan="v",
+        idx=2,
+        unit=None,
+        mapping_channels={
+            "value": [{"address": "P10.v2"}],
+            "unit": [{"address": "P10.u2"}],
+        },
+    )
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)  # type: ignore[arg-type]
+    entity.hass = hass
+    entity.entity_id = "sensor.test_power"
+
+    await entity.async_update()
+
+    assert entity.native_unit_of_measurement is None
+    assert entity.native_value == 33
 
 
 @pytest.mark.asyncio

--- a/tests/test_sensor_dynamic_unit_resolution.py
+++ b/tests/test_sensor_dynamic_unit_resolution.py
@@ -5,6 +5,15 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
+from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
+from homeassistant.const import (
+    PERCENTAGE,
+    UnitOfEnergy,
+    UnitOfPower,
+    UnitOfTemperature,
+    UnitOfVolumeFlowRate,
+)
+
 from custom_components.habragerone.sensor import BragerSymbolSensor
 
 
@@ -34,3 +43,61 @@ def test_sensor_marks_dynamic_unit_channel_for_resolver_path() -> None:
     entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
 
     assert entity._requires_resolver_value is True
+
+
+def test_sensor_normalizes_common_units_to_ha_constants() -> None:
+    assert BragerSymbolSensor._normalize_unit("kWh") == UnitOfEnergy.KILO_WATT_HOUR
+    assert BragerSymbolSensor._normalize_unit("Wh") == UnitOfEnergy.WATT_HOUR
+    assert BragerSymbolSensor._normalize_unit("kW") == UnitOfPower.KILO_WATT
+    assert BragerSymbolSensor._normalize_unit("°C") == UnitOfTemperature.CELSIUS
+    assert BragerSymbolSensor._normalize_unit("%") == PERCENTAGE
+    assert BragerSymbolSensor._normalize_unit("l/min") == UnitOfVolumeFlowRate.LITERS_PER_MINUTE
+    assert BragerSymbolSensor._normalize_unit({"pl": "°C", "en": "C"}) == UnitOfTemperature.CELSIUS
+    assert BragerSymbolSensor._normalize_unit("wn.9998") is None
+
+
+def test_sensor_infers_energy_and_power_classes_from_unit() -> None:
+    energy_class, energy_state = BragerSymbolSensor._infer_sensor_classes(UnitOfEnergy.KILO_WATT_HOUR)
+    assert energy_class == SensorDeviceClass.ENERGY
+    assert energy_state == SensorStateClass.TOTAL_INCREASING
+
+    power_class, power_state = BragerSymbolSensor._infer_sensor_classes(UnitOfPower.KILO_WATT)
+    assert power_class == SensorDeviceClass.POWER
+    assert power_state == SensorStateClass.MEASUREMENT
+
+    temp_class, temp_state = BragerSymbolSensor._infer_sensor_classes(UnitOfTemperature.CELSIUS)
+    assert temp_class == SensorDeviceClass.TEMPERATURE
+    assert temp_state == SensorStateClass.MEASUREMENT
+
+    flow_class, flow_state = BragerSymbolSensor._infer_sensor_classes(UnitOfVolumeFlowRate.LITERS_PER_MINUTE)
+    assert flow_class == SensorDeviceClass.VOLUME_FLOW_RATE
+    assert flow_state == SensorStateClass.MEASUREMENT
+
+    pct_class, pct_state = BragerSymbolSensor._infer_sensor_classes(PERCENTAGE)
+    assert pct_class is None
+    assert pct_state == SensorStateClass.MEASUREMENT
+
+
+def test_sensor_entity_applies_classes_from_descriptor_unit() -> None:
+    runtime = SimpleNamespace(
+        store=SimpleNamespace(),
+        add_listener=lambda _cb: None,
+        add_connectivity_listener=lambda _cb: None,
+    )
+    entry = SimpleNamespace(entry_id="entry-1")
+    descriptor = {
+        "symbol": "TEMP1",
+        "devid": "MOD1",
+        "label": "Boiler temp",
+        "pool": "P1",
+        "chan": "v",
+        "idx": 0,
+        "unit": "°C",
+        "mapping": {},
+    }
+
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._attr_native_unit_of_measurement == UnitOfTemperature.CELSIUS
+    assert entity._attr_device_class == SensorDeviceClass.TEMPERATURE
+    assert entity._attr_state_class == SensorStateClass.MEASUREMENT

--- a/tests/test_sensor_dynamic_unit_resolution.py
+++ b/tests/test_sensor_dynamic_unit_resolution.py
@@ -8,8 +8,12 @@ from unittest.mock import AsyncMock
 from homeassistant.components.sensor import SensorDeviceClass, SensorStateClass
 from homeassistant.const import (
     PERCENTAGE,
+    UnitOfElectricCurrent,
+    UnitOfElectricPotential,
     UnitOfEnergy,
+    UnitOfFrequency,
     UnitOfPower,
+    UnitOfPressure,
     UnitOfTemperature,
     UnitOfVolumeFlowRate,
 )
@@ -53,7 +57,14 @@ def test_sensor_normalizes_common_units_to_ha_constants() -> None:
     assert BragerSymbolSensor._normalize_unit("%") == PERCENTAGE
     assert BragerSymbolSensor._normalize_unit("l/min") == UnitOfVolumeFlowRate.LITERS_PER_MINUTE
     assert BragerSymbolSensor._normalize_unit({"pl": "°C", "en": "C"}) == UnitOfTemperature.CELSIUS
+    assert BragerSymbolSensor._normalize_unit({"pl": "bar"}) == UnitOfPressure.BAR
     assert BragerSymbolSensor._normalize_unit("wn.9998") is None
+    assert BragerSymbolSensor._normalize_unit("units.foo") is None
+    assert BragerSymbolSensor._normalize_unit("app.bar") is None
+    assert BragerSymbolSensor._normalize_unit("   ") is None
+    assert BragerSymbolSensor._normalize_unit({"en": "  "}) is None
+    assert BragerSymbolSensor._normalize_unit(None) is None
+    assert BragerSymbolSensor._normalize_unit("weird.token") == "weird.token"
 
 
 def test_sensor_infers_energy_and_power_classes_from_unit() -> None:
@@ -73,9 +84,28 @@ def test_sensor_infers_energy_and_power_classes_from_unit() -> None:
     assert flow_class == SensorDeviceClass.VOLUME_FLOW_RATE
     assert flow_state == SensorStateClass.MEASUREMENT
 
+    pressure_class, pressure_state = BragerSymbolSensor._infer_sensor_classes(UnitOfPressure.BAR)
+    assert pressure_class == SensorDeviceClass.PRESSURE
+    assert pressure_state == SensorStateClass.MEASUREMENT
+
+    current_class, current_state = BragerSymbolSensor._infer_sensor_classes(UnitOfElectricCurrent.AMPERE)
+    assert current_class == SensorDeviceClass.CURRENT
+    assert current_state == SensorStateClass.MEASUREMENT
+
+    voltage_class, voltage_state = BragerSymbolSensor._infer_sensor_classes(UnitOfElectricPotential.VOLT)
+    assert voltage_class == SensorDeviceClass.VOLTAGE
+    assert voltage_state == SensorStateClass.MEASUREMENT
+
+    freq_class, freq_state = BragerSymbolSensor._infer_sensor_classes(UnitOfFrequency.HERTZ)
+    assert freq_class == SensorDeviceClass.FREQUENCY
+    assert freq_state == SensorStateClass.MEASUREMENT
+
     pct_class, pct_state = BragerSymbolSensor._infer_sensor_classes(PERCENTAGE)
     assert pct_class is None
     assert pct_state == SensorStateClass.MEASUREMENT
+
+    assert BragerSymbolSensor._infer_sensor_classes(None) == (None, None)
+    assert BragerSymbolSensor._infer_sensor_classes("unknown") == (None, None)
 
 
 def test_sensor_entity_applies_classes_from_descriptor_unit() -> None:


### PR DESCRIPTION
## Summary
- normalize common UI unit labels (`°C`, `kW`, `%`, etc.) to Home Assistant unit constants
- infer sensor classes from normalized units (temperature/power + `measurement` state class)
- keep unresolved symbolic unit tokens filtered out as before

## Test plan
- [x] `uv run poe lint`
- [x] `uv run poe typecheck`
- [ ] validate sensor metadata in local HA container

Closes #46