### PR TITLE
Bump ha-bragerone to py-bragerone 2026.4.5

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -14,7 +14,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.4.4"
+    "py-bragerone==2026.4.5"
   ],
-  "version": "2026.4.4"
+  "version": "2026.4.5"
 }


### PR DESCRIPTION
## Summary
- update `custom_components/habragerone/manifest.json` requirement to `py-bragerone==2026.4.5`
- bump integration `version` to `2026.4.5`
- consume the py-bragerone menu-discovery fix for new `deviceMenu/<id>/<variant>.ts` routing format

## Test plan
- [x] verify manifest diff only includes version and requirement bump
- [ ] run CI checks in PR

Depends on py-bragerone release 2026.4.5.