### PR TITLE
Add Copilot code review customization

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,7 +21,7 @@
    - Treat WebSocket as delta stream only.
 
 ## Implementation Guidelines
-- Python 3.13+, strict typing (`mypy --strict`) and Ruff compliance.
+- Python 3.14+, strict typing (`mypy --strict`) and Ruff compliance (line-length 130, Google docstrings).
 - Keep code and comments in English.
 - Favor small, testable utilities for:
   - enum conversion,
@@ -29,6 +29,19 @@
   - bounds validation,
   - command payload construction.
 - Reuse existing architecture patterns in this repository; do not introduce parallel abstractions unless needed.
+- Home Assistant patterns: entities are push-based (`_attr_should_poll = False`) driven by `BragerRuntime` — do not introduce `DataUpdateCoordinator` or polling; descriptor-driven entity creation via cached `entry.data` descriptors; `_attr_has_entity_name = True`.
+
+## Library Boundary (py-bragerone)
+- All BragerOne protocol logic lives in the `pybragerone` package (pinned in `manifest.json`). Integration code must not re-implement REST/WS/param logic — extend the library instead.
+- `manifest.json` pins exact versions (`py-bragerone==...`); bump deliberately and keep `pyproject.toml` dependency bounds in sync.
+
+## Code Review Priorities
+When reviewing pull requests, prioritize (details in `.github/skills/code-review/SKILL.md`):
+1. **Write path safety**: enum label→raw conversion, inverse numeric transform, min/max (`n`/`x`) validation, correct route (`parameter_write` vs `raw_command`).
+2. **Entity lifecycle**: entities subscribe/unsubscribe to `runtime.add_listener()` correctly; no polling; unique_id patterns preserved (`{entry_id}_{devid}_{symbol}` + platform suffix).
+3. **Bootstrap cache**: `BOOTSTRAP_VERSION` bump when descriptor shape changes; cache invalidation correctness.
+4. **HA quality scale**: config flow errors with proper abort reasons, reauth, translations for new strings (`strings.json` + `translations/`), diagnostics redact credentials.
+5. **Version consistency**: `hacs.json`, `manifest.json`, `pyproject.toml` HA/Python/library versions must not drift.
 
 ## Logging & Diagnostics
 - Add debug logs for command write pipeline:

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -29,7 +29,7 @@
   - bounds validation,
   - command payload construction.
 - Reuse existing architecture patterns in this repository; do not introduce parallel abstractions unless needed.
-- Home Assistant patterns: entities are push-based (`_attr_should_poll = False`) driven by `BragerRuntime` — do not introduce `DataUpdateCoordinator` or polling; descriptor-driven entity creation via cached `entry.data` descriptors; `_attr_has_entity_name = True`.
+- Home Assistant patterns: state-bearing entities are push-based (`_attr_should_poll = False`) driven by `BragerRuntime` — do not introduce `DataUpdateCoordinator` or polling (command-only buttons have no state subscription by design); descriptor-driven entity creation via cached `entry.data` descriptors; `_attr_has_entity_name = True`.
 
 ## Library Boundary (py-bragerone)
 - All BragerOne protocol logic lives in the `pybragerone` package (pinned in `manifest.json`). Integration code must not re-implement REST/WS/param logic — extend the library instead.
@@ -41,7 +41,7 @@ When reviewing pull requests, prioritize (details in `.github/skills/code-review
 2. **Entity lifecycle**: entities subscribe/unsubscribe to `runtime.add_listener()` correctly; no polling; unique_id patterns preserved (`{entry_id}_{devid}_{symbol}` + platform suffix).
 3. **Bootstrap cache**: `BOOTSTRAP_VERSION` bump when descriptor shape changes; cache invalidation correctness.
 4. **HA quality scale**: config flow errors with proper abort reasons, reauth, translations for new strings (`strings.json` + `translations/`), diagnostics redact credentials.
-5. **Version consistency**: `hacs.json`, `manifest.json`, `pyproject.toml` HA/Python/library versions must not drift.
+5. **Version consistency**: `hacs.json` HA minimum ↔ `pyproject.toml` `homeassistant` dependency, and `manifest.json` `py-bragerone==X` pin ↔ `pyproject.toml` library bound must not drift (`manifest.json` carries no HA/Python version).
 
 ## Logging & Diagnostics
 - Add debug logs for command write pipeline:

--- a/.github/instructions/config-flow.instructions.md
+++ b/.github/instructions/config-flow.instructions.md
@@ -1,0 +1,13 @@
+---
+applyTo: "custom_components/habragerone/config_flow.py, custom_components/habragerone/strings.json, custom_components/habragerone/translations/**, custom_components/habragerone/diagnostics.py, custom_components/habragerone/manifest.json"
+---
+
+# Config flow, translations & metadata rules
+
+1. **Config flow** (`VERSION = 2`): changes to stored data keys require a migration (see v2 legacy-key migration) or a version bump. Unique ID stays `{platform}:{email}:{object_id}`.
+2. **Abort reasons & errors**: use typed abort reasons and per-field errors; never raw exceptions to the UI. Reauth flow must keep working when login handling changes.
+3. **Options flow**: changing object/modules/filter mode triggers reload — keep that contract.
+4. **Strings**: every new config/options step, error, or abort reason needs `strings.json` + `translations/en.json` entries in the same PR; other locales may follow separately.
+5. **manifest.json**: `py-bragerone==X` and `tree-sitter==Y` pins are deliberate (CI checks wheel compatibility for musl/manylinux, x86_64 + aarch64). Bumping pins → check wheel availability. Keep `pyproject.toml` bounds in sync.
+6. **Diagnostics**: `async_get_config_entry_diagnostics` must redact credentials; new sensitive fields must be added to the redaction list.
+7. **hacs.json**: HA minimum version here, in `manifest.json`, and in `pyproject.toml` must not drift.

--- a/.github/instructions/config-flow.instructions.md
+++ b/.github/instructions/config-flow.instructions.md
@@ -1,13 +1,13 @@
 ---
-applyTo: "custom_components/habragerone/config_flow.py, custom_components/habragerone/strings.json, custom_components/habragerone/translations/**, custom_components/habragerone/diagnostics.py, custom_components/habragerone/manifest.json, hacs.json, pyproject.toml"
+applyTo: "custom_components/habragerone/config_flow.py, custom_components/habragerone/const.py, custom_components/habragerone/__init__.py, custom_components/habragerone/strings.json, custom_components/habragerone/translations/**, custom_components/habragerone/diagnostics.py, custom_components/habragerone/manifest.json, hacs.json, pyproject.toml"
 ---
 
 # Config flow, translations & metadata rules
 
-1. **Config flow** (`VERSION = 2`): changes to stored data keys require a migration (see v2 legacy-key migration) or a version bump. Unique ID stays `{platform}:{email}:{object_id}`.
+1. **Config flow** (`VERSION = 2`): breaking changes to stored data keys require both a version bump and migration logic in `async_migrate_entry` (see v2 legacy-key migration) — the bump alone leaves old entries on the old schema, and migration alone never runs for entries already at the current version. Unique ID stays `{platform}:{email}:{object_id}`.
 2. **Abort reasons & errors**: use typed abort reasons and per-field errors; never raw exceptions to the UI. Reauth flow must keep working when login handling changes.
 3. **Options flow**: changing object/modules/filter mode triggers reload — keep that contract.
 4. **Strings**: every new config/options step, error, or abort reason needs `strings.json` + `translations/en.json` entries in the same PR; other locales may follow separately.
-5. **manifest.json**: `py-bragerone==X` and `tree-sitter==Y` pins are deliberate (CI checks wheel compatibility for musl/manylinux, x86_64 + aarch64). Bumping pins → check wheel availability. Keep `pyproject.toml` bounds in sync.
+5. **manifest.json**: `py-bragerone==X` and `tree-sitter==Y` pins are deliberate (CI checks wheel compatibility for musl/manylinux, x86_64 + aarch64). Bumping pins → check wheel availability. Keep the `py-bragerone` bound in `pyproject.toml` in sync (`tree-sitter` is manifest-only, no `pyproject.toml` bound exists).
 6. **Diagnostics**: `async_get_config_entry_diagnostics` must redact credentials; new sensitive fields must be added to the redaction list.
 7. **hacs.json**: HA minimum version here and the `homeassistant` dependency in `pyproject.toml` must not drift (`manifest.json` has no HA version field).

--- a/.github/instructions/config-flow.instructions.md
+++ b/.github/instructions/config-flow.instructions.md
@@ -1,5 +1,5 @@
 ---
-applyTo: "custom_components/habragerone/config_flow.py, custom_components/habragerone/strings.json, custom_components/habragerone/translations/**, custom_components/habragerone/diagnostics.py, custom_components/habragerone/manifest.json"
+applyTo: "custom_components/habragerone/config_flow.py, custom_components/habragerone/strings.json, custom_components/habragerone/translations/**, custom_components/habragerone/diagnostics.py, custom_components/habragerone/manifest.json, hacs.json, pyproject.toml"
 ---
 
 # Config flow, translations & metadata rules

--- a/.github/instructions/config-flow.instructions.md
+++ b/.github/instructions/config-flow.instructions.md
@@ -10,4 +10,4 @@ applyTo: "custom_components/habragerone/config_flow.py, custom_components/habrag
 4. **Strings**: every new config/options step, error, or abort reason needs `strings.json` + `translations/en.json` entries in the same PR; other locales may follow separately.
 5. **manifest.json**: `py-bragerone==X` and `tree-sitter==Y` pins are deliberate (CI checks wheel compatibility for musl/manylinux, x86_64 + aarch64). Bumping pins → check wheel availability. Keep `pyproject.toml` bounds in sync.
 6. **Diagnostics**: `async_get_config_entry_diagnostics` must redact credentials; new sensitive fields must be added to the redaction list.
-7. **hacs.json**: HA minimum version here, in `manifest.json`, and in `pyproject.toml` must not drift.
+7. **hacs.json**: HA minimum version here and the `homeassistant` dependency in `pyproject.toml` must not drift (`manifest.json` has no HA version field).

--- a/.github/instructions/integration-core.instructions.md
+++ b/.github/instructions/integration-core.instructions.md
@@ -1,0 +1,19 @@
+---
+applyTo: "custom_components/habragerone/**/*.py"
+---
+
+# Integration core rules (apply to all of custom_components/habragerone)
+
+1. **Push architecture**: entities are push-based (`_attr_should_poll = False`) via `BragerRuntime.add_listener()`. Flag any introduction of polling, `DataUpdateCoordinator`, or `async_update` refresh loops.
+2. **Listener lifecycle**: entities must unsubscribe in `async_will_remove_from_hass` (or via the `async_on_remove` pattern used in the codebase). Leaked listeners cause duplicate state writes.
+3. **Write path** (`command_write.py` / `runtime.async_write`):
+   - enum label→raw before send; raw→label on read when a mapping exists;
+   - inverse numeric transform applied when UI and protocol scales differ;
+   - min/max (`n`/`x`) validated before send — out-of-range must raise, not clamp silently;
+   - route selection (`parameter_write` vs `raw_command`) must stay consistent with existing rules.
+4. **unique_id / naming**: keep `{entry_id}_{devid}_{symbol}` + platform suffix patterns and `descriptor_display_name` ("{panel_path} - {label}") stable; `_attr_has_entity_name = True`; DeviceInfo identifiers `(domain, devid)`.
+5. **Descriptors**: entity creation is descriptor-driven from `entry.data[CONF_ENTITY_DESCRIPTORS]`. Platform classification/filtering changes belong in `bootstrap.py` and require a `BOOTSTRAP_VERSION` bump.
+6. **HA APIs**: use modern HA patterns (config entries, no `hass.data` globals beyond the runtime slot, `ConfigEntry` runtime_data pattern where applicable). Target HA `>=2026.8.1`.
+7. **Async**: never block the event loop; library calls are awaited; no threads.
+8. **Typing/style**: mypy strict, ruff (130 cols, Google docstrings), English only.
+9. **Secrets**: never log or expose password/tokens; diagnostics redact them.

--- a/.github/instructions/integration-core.instructions.md
+++ b/.github/instructions/integration-core.instructions.md
@@ -4,8 +4,8 @@ applyTo: "custom_components/habragerone/**/*.py"
 
 # Integration core rules (apply to all of custom_components/habragerone)
 
-1. **Push architecture**: entities are push-based (`_attr_should_poll = False`) via `BragerRuntime.add_listener()`. Flag any introduction of polling, `DataUpdateCoordinator`, or `async_update` refresh loops.
-2. **Listener lifecycle**: entities must unsubscribe in `async_will_remove_from_hass` (or via the `async_on_remove` pattern used in the codebase). Leaked listeners cause duplicate state writes.
+1. **Push architecture**: state-bearing entities are push-based (`_attr_should_poll = False`) via `BragerRuntime.add_listener()`. Flag any introduction of polling, `DataUpdateCoordinator`, or `async_update` refresh loops. Command-only entities (buttons) have no state and no listener by design — do not flag that.
+2. **Listener lifecycle**: state-bearing entities must unsubscribe in `async_will_remove_from_hass` (or via the `async_on_remove` pattern used in the codebase). Leaked listeners cause duplicate state writes.
 3. **Write path** (`command_write.py` / `runtime.async_write`):
    - enum label→raw before send; raw→label on read when a mapping exists;
    - inverse numeric transform applied when UI and protocol scales differ;

--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -1,0 +1,16 @@
+---
+applyTo: "tests/**/*.py"
+---
+
+# Test suite rules
+
+1. **Framework**: pytest + pytest-asyncio + `pytest-homeassistant-custom-component`; most tests are pure unit tests with `install_pybragerone_stubs()` — prefer that over booting a full HA instance unless testing real HA wiring.
+2. **Offline**: tests must pass without network or real BragerOne credentials.
+3. **Mandatory coverage areas** when touching the write path:
+   - enum label→raw and raw→label conversion, invalid enum input,
+   - inverse numeric transform on write,
+   - min/max rejection,
+   - command route selection (`parameter_write` vs `raw_command`).
+4. **Bootstrap**: classification/filtering changes need descriptor fixtures covering each platform type.
+5. **Naming tests**: entity naming/unique_id patterns are contractual — keep regression tests for them.
+6. **Style**: same ruff/mypy rules as the integration; coverage gate is `--cov-fail-under=70` (pre-push).

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,0 +1,54 @@
+# Code Review — ha-bragerone
+
+Review procedure for pull requests to this Home Assistant integration. Work through every section; comment only on real issues, with file/line references and a concrete suggested fix.
+
+## 1. Write-path safety (highest priority — these commands reach physical heating hardware)
+
+- [ ] Enum writes convert display label → raw backend value; invalid labels produce a clear validation error, not a silent send.
+- [ ] Reads convert raw → display label where a mapping exists.
+- [ ] Numeric writes apply the inverse transform and are validated against `n`/`x` min/max; out-of-range is rejected explicitly.
+- [ ] Route selection (`parameter_write` vs `raw_command`) follows existing rules in `command_write.py`.
+- [ ] Debug logging covers symbol/entity, display value, raw value, route, validation failures — without logging secrets.
+
+## 2. Architecture invariants
+
+- [ ] Push model preserved: no polling, no `DataUpdateCoordinator`; entities use `runtime.add_listener()` and unsubscribe on removal.
+- [ ] Protocol logic stays in `pybragerone`; the integration doesn't re-implement REST/WS/param handling.
+- [ ] Descriptor-driven entity creation via `entry.data[CONF_ENTITY_DESCRIPTORS]`; descriptor shape changes bump `BOOTSTRAP_VERSION`.
+- [ ] unique_id patterns unchanged (`{entry_id}_{devid}_{symbol}` + platform suffix) — flag any change as breaking.
+
+## 3. Home Assistant conventions
+
+- [ ] Modern config-entry patterns; config flow uses typed abort reasons / per-field errors; reauth intact.
+- [ ] New user-facing strings added to `strings.json` + `translations/en.json`.
+- [ ] `_attr_has_entity_name = True`, DeviceInfo identifiers `(domain, devid)`, manufacturer `"BragerOne"`.
+- [ ] Diagnostics redact credentials and tokens.
+- [ ] No new platforms beyond sensor/binary_sensor/switch/number/select/button without discussion.
+
+## 4. Typing & style gates (CI runs these — flag what it can't catch)
+
+- [ ] mypy `--strict` clean; new `Any`/`type: ignore` justified in a comment.
+- [ ] Ruff: line length 130, Google docstrings, English-only code/comments.
+- [ ] No blocking calls in the event loop.
+
+## 5. Version consistency
+
+- [ ] `hacs.json` HA minimum ↔ `manifest.json` ↔ `pyproject.toml` stay in sync.
+- [ ] `manifest.json` `py-bragerone==X` pin ↔ `pyproject.toml` `py-bragerone>=X` bound in sync; wheel compat (musl/manylinux) considered for pin bumps.
+
+## 6. Tests
+
+- [ ] Write-path changes include the mandatory conversion/bounds/route tests (see `.github/instructions/tests.instructions.md`).
+- [ ] Bootstrap classification changes have per-platform descriptor fixtures.
+- [ ] Suite passes offline; coverage gate (70%) not weakened.
+
+## 7. Security
+
+- [ ] No credentials/tokens in code, fixtures, logs, or diagnostics output.
+- [ ] User input reaching `async_write` validated before hitting the library.
+
+## How to report
+
+- One comment per issue, severity-tagged: **blocker** (wrong value could be written to the heater, breaking change without migration, leaked secret), **major** (CI gate, architecture invariant, missing tests), **minor** (style, naming, translations).
+- Prefer the smallest change consistent with existing patterns.
+- If the PR references an issue, use the GitHub MCP server to read it and confirm the change resolves it; check linked py-bragerone PRs when the library pin changes.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -54,6 +54,6 @@ Review procedure for pull requests to this Home Assistant integration. Work thro
 
 ## How to report
 
-- One comment per issue, severity-tagged: **blocker** (wrong value could be written to the heater, breaking change without migration, leaked secret), **major** (CI gate, architecture invariant, missing tests), **minor** (style, naming, translations).
+- One comment per issue; start the comment with the severity in plain text — blocker (wrong value could be written to the heater, breaking change without migration, leaked secret), major (CI gate, architecture invariant, missing tests), or minor (style, naming, translations) — so impact is clear even though review comment formatting cannot be customized.
 - Prefer the smallest change consistent with existing patterns.
 - If the PR references an issue, use the GitHub MCP server to read it and confirm the change resolves it; check linked py-bragerone PRs when the library pin changes.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -54,6 +54,6 @@ Review procedure for pull requests to this Home Assistant integration. Work thro
 
 ## How to report
 
-- One comment per issue; start the comment with the severity in plain text — blocker (wrong value could be written to the heater, breaking change without migration, leaked secret), major (CI gate, architecture invariant, missing tests), or minor (style, naming, translations) — so impact is clear even though review comment formatting cannot be customized.
+- One comment per issue. Use severity to triage what you report — blocker (wrong value could be written to the heater, breaking change without migration, leaked secret), major (CI gate, architecture invariant, missing tests), minor (style, naming, translations) — and report blockers/majors first. Treat this as prioritization guidance, not a required comment format.
 - Prefer the smallest change consistent with existing patterns.
 - If the PR references an issue, use the GitHub MCP server to read it and confirm the change resolves it; check linked py-bragerone PRs when the library pin changes.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -1,3 +1,8 @@
+---
+name: code-review
+description: Review checklist for ha-bragerone pull requests. Use when reviewing PRs to verify write-path safety (enum/numeric conversion, bounds, routes), push architecture invariants, Home Assistant conventions, version consistency, tests, and security.
+---
+
 # Code Review — ha-bragerone
 
 Review procedure for pull requests to this Home Assistant integration. Work through every section; comment only on real issues, with file/line references and a concrete suggested fix.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -54,7 +54,7 @@ Review procedure for pull requests to this Home Assistant integration. Work thro
 
 ## Stack awareness
 
-- Before flagging stale references or inconsistencies, check whether the PR belongs to a stack (read the PR's `stack` object via the GitHub MCP server). If it does, fetch the stack's PR list and review the layer in the context of the whole stack — the fix may already exist in an upper layer.
+- Before flagging stale references or inconsistencies, check whether the PR belongs to a stack: look for "Stacked on #NNN" links or cross-referenced PRs in the PR body and timeline, and fetch those PRs via the GitHub MCP server. If the PR is part of a stack, review the layer in the context of the whole stack — the fix may already exist in a linked layer.
 
 ## How to report
 

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -52,6 +52,10 @@ Review procedure for pull requests to this Home Assistant integration. Work thro
 - [ ] No credentials/tokens in code, fixtures, logs, or diagnostics output.
 - [ ] User input reaching `async_write` validated before hitting the library.
 
+## Stack awareness
+
+- Before flagging stale references or inconsistencies, check whether the PR belongs to a stack (read the PR's `stack` object via the GitHub MCP server). If it does, fetch the stack's PR list and review the layer in the context of the whole stack — the fix may already exist in an upper layer.
+
 ## How to report
 
 - One comment per issue. Use severity to triage what you report — blocker (wrong value could be written to the heater, breaking change without migration, leaked secret), major (CI gate, architecture invariant, missing tests), minor (style, naming, translations) — and report blockers/majors first. Treat this as prioritization guidance, not a required comment format.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -17,7 +17,7 @@ Review procedure for pull requests to this Home Assistant integration. Work thro
 
 ## 2. Architecture invariants
 
-- [ ] Push model preserved: no polling, no `DataUpdateCoordinator`; entities use `runtime.add_listener()` and unsubscribe on removal.
+- [ ] Push model preserved: no polling, no `DataUpdateCoordinator`; state-bearing entities use `runtime.add_listener()` and unsubscribe on removal (command-only buttons have no listener by design).
 - [ ] Protocol logic stays in `pybragerone`; the integration doesn't re-implement REST/WS/param handling.
 - [ ] Descriptor-driven entity creation via `entry.data[CONF_ENTITY_DESCRIPTORS]`; descriptor shape changes bump `BOOTSTRAP_VERSION`.
 - [ ] unique_id patterns unchanged (`{entry_id}_{devid}_{symbol}` + platform suffix) — flag any change as breaking.
@@ -38,7 +38,7 @@ Review procedure for pull requests to this Home Assistant integration. Work thro
 
 ## 5. Version consistency
 
-- [ ] `hacs.json` HA minimum ↔ `manifest.json` ↔ `pyproject.toml` stay in sync.
+- [ ] `hacs.json` HA minimum ↔ `pyproject.toml` `homeassistant` dependency stay in sync (`manifest.json` has no HA version field).
 - [ ] `manifest.json` `py-bragerone==X` pin ↔ `pyproject.toml` `py-bragerone>=X` bound in sync; wheel compat (musl/manylinux) considered for pin bumps.
 
 ## 6. Tests

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wh
 
 ## Architecture in one paragraph
 
-All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 4`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go through `command_write.py` (enum label→raw, inverse numeric transform, min/max check, route selection) into `runtime.async_write`.
+All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 4`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go the other way: platform entities call `runtime.async_write`, which uses `command_write.prepare_write` (enum label→raw, inverse numeric transform, min/max check, route selection) before dispatching to the gateway.
 
 ## Non-negotiable conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,54 @@
+# AGENTS.md — ha-bragerone
+
+HACS custom integration (`custom_components/habragerone`) connecting BragerOne heating controllers to Home Assistant via the `py-bragerone` library (`pybragerone` package).
+
+## Project shape
+
+- **Platforms**: `sensor`, `binary_sensor`, `switch`, `number`, `select`, `button` (no `climate`).
+- **Python**: `>=3.14.2,<3.15`; **HA**: `homeassistant>=2026.8.1`; iot_class `cloud_push`.
+- **Dependencies**: **uv** (`uv.lock` committed). Runtime deps pinned exactly in `manifest.json`.
+- **Build/versioning**: hatchling + hatch-vcs, CalVer from git tags.
+
+## Common commands
+
+```bash
+uv sync --locked                 # environment
+uv run poe fmt                   # ruff format
+uv run poe lint                  # ruff check --fix
+uv run poe typecheck             # mypy --strict (python_version 3.14, pydantic plugin)
+uv run poe test                  # pytest (pytest-homeassistant-custom-component)
+uv run poe cov                   # coverage (pre-push gate: --cov-fail-under=70)
+uv run poe validate              # fmt + lint + typecheck + security + test
+```
+
+CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2025.5.1` / `latest` / `dev`.
+
+## Architecture in one paragraph
+
+All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 4`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go through `command_write.py` (enum label→raw, inverse numeric transform, min/max check, route selection) into `runtime.async_write`.
+
+## Non-negotiable conventions
+
+1. **Push, not poll**: entities set `_attr_should_poll = False` and update via `runtime.add_listener()`. Never add polling or a coordinator.
+2. **Write safety**: every write converts enum label→raw, applies inverse numeric transform, validates against `n`/`x` min/max, and picks the right route (`parameter_write` vs `raw_command`). Invalid input → explicit validation error, never a silent send.
+3. **unique_id stability**: `{entry_id}_{devid}_{symbol}` with platform suffix (`_binary`, `_switch`, `_number`, `_select`, `_button`). Changing these breaks user setups — treat as breaking change.
+4. **Naming**: display name `"{panel_path} - {label}"` via `descriptor_display_name`; suggested object id `slugify(f"{module_name}_{symbol}")`; `_attr_has_entity_name = True`; DeviceInfo identifiers `(domain, devid)`, manufacturer `"BragerOne"`.
+5. **English only** in code/comments/docstrings; mypy `--strict`; ruff (line-length 130, Google docstrings).
+6. **Credentials**: diagnostics and logs must redact password/tokens.
+7. **Library boundary**: don't re-implement protocol logic in the integration — that belongs to `py-bragerone`. Keep `manifest.json` pins and `pyproject.toml` bounds in sync.
+
+## Testing
+
+- pytest + pytest-asyncio + `pytest-homeassistant-custom-component`; most tests are pure unit tests using `install_pybragerone_stubs()`.
+- Cover at minimum: enum conversions (both directions + invalid input), inverse numeric transform, min/max rejection, route selection, bootstrap classification/filtering, entity naming.
+- Tests must pass offline.
+
+## Translations & UI strings
+
+New config/options/errors strings go into `strings.json` and English `translations/en.json`; the other 18 locales follow. hassfest validates these in CI.
+
+## Version consistency checklist (watch in reviews)
+
+- `hacs.json` homeassistant minimum vs `manifest.json` / `pyproject.toml` (known drift: `hacs.json` says 2025.5.1 vs code 2026.8.1).
+- `manifest.json` `py-bragerone==X` pin vs `pyproject.toml` `py-bragerone>=X`.
+- ruff `target-version` vs actual runtime Python.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ HACS custom integration (`custom_components/habragerone`) connecting BragerOne h
 ## Common commands
 
 ```bash
-uv sync --locked                 # environment
+uv sync --locked --group dev --group test   # environment (test group holds pytest; required by poe test/cov/validate)
 uv run poe fmt                   # ruff format
 uv run poe lint                  # ruff check --fix
 uv run poe typecheck             # mypy --strict (python_version 3.14, pydantic plugin)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,7 +17,7 @@ uv run poe fmt                   # ruff format
 uv run poe lint                  # ruff check --fix
 uv run poe typecheck             # mypy --strict (python_version 3.14, pydantic plugin)
 uv run poe test                  # pytest (pytest-homeassistant-custom-component)
-uv run poe cov                   # coverage (pre-push gate: --cov-fail-under=70)
+uv run poe cov                   # coverage report (the 70% threshold is enforced only by the pre-push hook)
 uv run poe validate              # fmt + lint + typecheck + security + test
 ```
 
@@ -29,7 +29,7 @@ All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The 
 
 ## Non-negotiable conventions
 
-1. **Push, not poll**: entities set `_attr_should_poll = False` and update via `runtime.add_listener()`. Never add polling or a coordinator.
+1. **Push, not poll**: state-bearing entities set `_attr_should_poll = False` and update via `runtime.add_listener()`. Never add polling or a coordinator. Exception: command-only entities (`button.py`) have no state and intentionally no listener.
 2. **Write safety**: every write converts enum label→raw, applies inverse numeric transform, validates against `n`/`x` min/max, and picks the right route (`parameter_write` vs `raw_command`). Invalid input → explicit validation error, never a silent send.
 3. **unique_id stability**: `{entry_id}_{devid}_{symbol}` with platform suffix (`_binary`, `_switch`, `_number`, `_select`, `_button`). Changing these breaks user setups — treat as breaking change.
 4. **Naming**: display name `"{panel_path} - {label}"` via `descriptor_display_name`; suggested object id `slugify(f"{module_name}_{symbol}")`; `_attr_has_entity_name = True`; DeviceInfo identifiers `(domain, devid)`, manufacturer `"BragerOne"`.
@@ -49,6 +49,6 @@ New config/options/errors strings go into `strings.json` and English `translatio
 
 ## Version consistency checklist (watch in reviews)
 
-- `hacs.json` homeassistant minimum vs `manifest.json` / `pyproject.toml` (known drift: `hacs.json` says 2025.5.1 vs code 2026.8.1).
+- `hacs.json` homeassistant minimum vs the `homeassistant` dependency in `pyproject.toml` (known drift: `hacs.json` says 2025.5.1 vs code 2026.8.1). Note: `manifest.json` has no HA version field.
 - `manifest.json` `py-bragerone==X` pin vs `pyproject.toml` `py-bragerone>=X`.
 - ruff `target-version` vs actual runtime Python.


### PR DESCRIPTION
## Summary
- Update `.github/copilot-instructions.md`: Python 3.14, library boundary rules, HA entity patterns, Code Review Priorities section
- Add `AGENTS.md` describing project shape, uv/poe commands, push architecture (no DataUpdateCoordinator), unique_id/naming contracts, version consistency checklist
- Add path-specific instructions in `.github/instructions/` (integration core, config flow/translations/manifest, tests)
- Add review-focused agent skill `.github/skills/code-review/SKILL.md` with a severity-tagged checklist (write-path safety for physical heating hardware, push architecture, HA conventions, version consistency)

## Test plan
- [ ] Open a test PR and request Copilot code review; verify comments reference the `code-review` skill / instructions (attributions under comments)
- [ ] Verify no CI regressions (markdown-only change)