### PR TITLE
Fix Python version in prompt template

### DIFF
--- a/.github/prompt-template.md
+++ b/.github/prompt-template.md
@@ -17,7 +17,7 @@ Current priorities:
 4. Add/adjust tests for enum conversion and write validation behavior.
 
 Constraints:
-- Python 3.13+, strict typing, ruff + mypy clean.
+- Python 3.14+, strict typing, ruff + mypy clean.
 - Minimal, focused changes only.
 - Keep code/comments/docstrings in English.
 


### PR DESCRIPTION
## Summary
- `.github/prompt-template.md` said Python 3.13+, but the repo targets Python 3.14 (`requires-python >=3.14.2`, mypy `python_version = "3.14"`)

Stacked on #129 (found while addressing its Copilot review).

## Test plan
- [ ] No CI impact (markdown-only change)