### PR TITLE
chore(copilot): flag code↔docs drift in reviews

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -42,6 +42,7 @@ When reviewing pull requests, prioritize (details in `.github/skills/code-review
 3. **Bootstrap cache**: `BOOTSTRAP_VERSION` bump when descriptor shape changes; cache invalidation correctness.
 4. **HA quality scale**: config flow errors with proper abort reasons, reauth, translations for new strings (`strings.json` + `translations/`), diagnostics redact credentials.
 5. **Version consistency**: `hacs.json` HA minimum ↔ `pyproject.toml` `homeassistant` dependency, and `manifest.json` `py-bragerone==X` pin ↔ `pyproject.toml` library bound must not drift (`manifest.json` carries no HA/Python version).
+6. **Docs consistency (code↔docs)**: changes to config flow options, entity naming, supported platforms, or setup steps must be reflected in `README.md`, `docs/`, and translations; docs-only changes must match the actual code — flag drift in either direction.
 
 ## Logging & Diagnostics
 - Add debug logs for command write pipeline:

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,0 +1,10 @@
+---
+applyTo: "README.md,docs/**,custom_components/habragerone/strings.json,custom_components/habragerone/translations/**"
+---
+
+# Documentation rules
+
+1. **Docs describe the integration as it is, not as it should be**: before editing documented behavior (setup steps, options, entity naming, supported platforms), verify it against `custom_components/habragerone/`. Code changes that alter documented behavior must update the docs in the same PR — drift in either direction is a defect.
+2. **UI strings are docs too**: new config/options/error strings go into `strings.json` and English `translations/en.json`; the other locales follow. Entity naming in docs must match `descriptor_display_name` / unique_id patterns in code.
+3. **Version references** (minimum HA version, `py-bragerone` pin, Python version) must match `hacs.json`, `manifest.json`, and `pyproject.toml`.
+4. **Examples must be runnable**: setup instructions and YAML/service examples must work copy-paste against the current integration.

--- a/.github/instructions/docs.instructions.md
+++ b/.github/instructions/docs.instructions.md
@@ -1,10 +1,10 @@
 ---
-applyTo: "README.md,docs/**,custom_components/habragerone/strings.json,custom_components/habragerone/translations/**"
+applyTo: "README.md, docs/**, custom_components/habragerone/strings.json, custom_components/habragerone/translations/**"
 ---
 
 # Documentation rules
 
 1. **Docs describe the integration as it is, not as it should be**: before editing documented behavior (setup steps, options, entity naming, supported platforms), verify it against `custom_components/habragerone/`. Code changes that alter documented behavior must update the docs in the same PR — drift in either direction is a defect.
 2. **UI strings are docs too**: new config/options/error strings go into `strings.json` and English `translations/en.json`; the other locales follow. Entity naming in docs must match `descriptor_display_name` / unique_id patterns in code.
-3. **Version references** (minimum HA version, `py-bragerone` pin, Python version) must match `hacs.json`, `manifest.json`, and `pyproject.toml`.
+3. **Version references** (minimum HA version, `py-bragerone` pin, Python version) must match `hacs.json`, `manifest.json`, and `pyproject.toml`. Where those sources currently disagree (known drift: `hacs.json` HA minimum vs the `pyproject.toml` `homeassistant` dependency), do not paper over it in docs — flag the drift in the PR so it gets fixed at the source.
 4. **Examples must be runnable**: setup instructions and YAML/service examples must work copy-paste against the current integration.

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -52,6 +52,11 @@ Review procedure for pull requests to this Home Assistant integration. Work thro
 - [ ] No credentials/tokens in code, fixtures, logs, or diagnostics output.
 - [ ] User input reaching `async_write` validated before hitting the library.
 
+## 8. Docs & metadata
+
+- [ ] **Code↔docs drift (both directions)**: changes to config flow options, entity naming/unique_id patterns, supported platforms, or setup steps must be reflected in `README.md`, `docs/`, and `strings.json`/`translations/`; docs-only changes must match the actual code — flag drift.
+- [ ] Version references in docs/examples match `manifest.json`, `hacs.json`, and `pyproject.toml`.
+
 ## Stack awareness
 
 - Before flagging stale references or inconsistencies, check whether the PR belongs to a stack: look for "Stacked on #NNN" links or cross-referenced PRs in the PR body and timeline, and fetch those PRs via the GitHub MCP server. If the PR is part of a stack, review the layer in the context of the whole stack — the fix may already exist in a linked layer.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,7 @@ All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The 
 5. **English only** in code/comments/docstrings; mypy `--strict`; ruff (line-length 130, Google docstrings).
 6. **Credentials**: diagnostics and logs must redact password/tokens.
 7. **Library boundary**: don't re-implement protocol logic in the integration — that belongs to `py-bragerone`. Keep `manifest.json` pins and `pyproject.toml` bounds in sync.
+8. **Docs parity**: `README.md`, `docs/`, and translations must describe the integration as it is; code changes that alter documented behavior update docs in the same PR, and docs-only changes must match the code — drift in either direction is a defect.
 
 ## Testing
 


### PR DESCRIPTION
## Summary
- Adds a bidirectional documentation-consistency rule to all Copilot review surfaces: code changes altering documented behavior (setup steps, options, entity naming, platforms) must update `README.md`, `docs/`, `strings.json`/`translations/` in the same PR; docs-only changes must be verified against the actual code.
- New `.github/instructions/docs.instructions.md` scoped to `README.md`, `docs/**`, `strings.json`, `translations/**`.
- `AGENTS.md` gains convention #8 (docs parity).

## Test plan
- [ ] Copilot review on this PR surfaces no issues with the new rules