### PR TITLE
ci: aggregate gate jobs as stable required checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -321,9 +321,14 @@ jobs:
         env:
           NEEDS: ${{ toJSON(needs) }}
         run: |
+          # Only dependency-review may legitimately skip (push events); any other
+          # non-success fails the gate so a misconfigured `if:` can't slip through.
           echo "$NEEDS" | jq -e '
             to_entries
-            | map(select(.value.result != "success" and .value.result != "skipped"))
+            | map(select(
+                if .key == "dependency-review"
+                then (.value.result != "success" and .value.result != "skipped")
+                else .value.result != "success" end))
             | if length == 0 then true
               else error("Failed jobs: " + (map(.key) | join(", "))) end' > /dev/null
           echo "All required jobs passed."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -310,3 +310,20 @@ jobs:
           name: dist-${{ github.sha }}
           path: dist/*
           retention-days: 7
+
+  ci-gate:
+    name: CI
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [secrets, dependency-review, quality, security, hassfest, validate-ha, dependency-wheel-compat, tests, build]
+    steps:
+      - name: Verify all required jobs succeeded
+        env:
+          NEEDS: ${{ toJSON(needs) }}
+        run: |
+          echo "$NEEDS" | jq -e '
+            to_entries
+            | map(select(.value.result != "success" and .value.result != "skipped"))
+            | if length == 0 then true
+              else error("Failed jobs: " + (map(.key) | join(", "))) end' > /dev/null
+          echo "All required jobs passed."

--- a/.github/workflows/ha-integration-test.yml
+++ b/.github/workflows/ha-integration-test.yml
@@ -124,3 +124,16 @@ jobs:
               if: always()
               run: |
                   docker rm -f ha-under-test >/dev/null 2>&1 || true
+
+    integration-gate:
+        name: HA Integration Tests
+        runs-on: ubuntu-latest
+        if: always()
+        needs: [integration-test]
+        steps:
+            - name: Verify all matrix legs succeeded
+              env:
+                  NEEDS: ${{ toJSON(needs) }}
+              run: |
+                  echo "$NEEDS" | jq -e '.["integration-test"].result == "success"' > /dev/null
+                  echo "All HA versions passed."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
             ## Requirements
             - Python >= 3.14.2
-            - Home Assistant > 2025.5.0
+            - Home Assistant >= 2026.8.1
           draft: false
           prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
           files: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ uv run poe cov                   # coverage report (the 70% threshold is enforce
 uv run poe validate              # fmt + lint + typecheck + security + test
 ```
 
-CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.8.1` / `latest` / `dev`.
+CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.8.1` / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable.
 
 ## Architecture in one paragraph
 


### PR DESCRIPTION
## Summary
- Adds aggregate **gate jobs** with stable names: `CI` (ci.yml, needs all 9 jobs) and `HA Integration Tests` (ha-integration-test.yml, needs the full matrix). `HACS Validation` is already a single stable check.
- Gates run with `if: always()` and accept `skipped` (dependency-review legitimately skips on push).
- After merge, the `protect-main` ruleset will require only the 3 gates — renaming jobs or matrix versions (like the recent 2025.5.1 → 2026.8.1 bump) will never require ruleset changes again.
- `AGENTS.md` documents the pattern.

## Test plan
- [ ] All existing checks still pass (ruleset unchanged until this lands)
- [ ] New `CI` and `HA Integration Tests` checks appear and go green
- [ ] After merge: switch ruleset to the 3 gates (via API)