### PR TITLE
chore: lower declared HA minimum to 2026.3.0 (verified by CI)

### DIFF
--- a/.github/instructions/integration-core.instructions.md
+++ b/.github/instructions/integration-core.instructions.md
@@ -13,7 +13,7 @@ applyTo: "custom_components/habragerone/**/*.py"
    - route selection (`parameter_write` vs `raw_command`) must stay consistent with existing rules.
 4. **unique_id / naming**: keep `{entry_id}_{devid}_{symbol}` + platform suffix patterns and `descriptor_display_name` ("{panel_path} - {label}") stable; `_attr_has_entity_name = True`; DeviceInfo identifiers `(domain, devid)`.
 5. **Descriptors**: entity creation is descriptor-driven from `entry.data[CONF_ENTITY_DESCRIPTORS]`. Platform classification/filtering changes belong in `bootstrap.py` and require a `BOOTSTRAP_VERSION` bump.
-6. **HA APIs**: use modern HA patterns (config entries, no `hass.data` globals beyond the runtime slot, `ConfigEntry` runtime_data pattern where applicable). Target HA `>=2026.8.1`.
+6. **HA APIs**: use modern HA patterns (config entries, no `hass.data` globals beyond the runtime slot, `ConfigEntry` runtime_data pattern where applicable). Target HA `>=2026.3.0` (the declared minimum; must stay consistent with `hacs.json`/`pyproject.toml`).
 7. **Async**: never block the event loop; library calls are awaited; no threads.
 8. **Typing/style**: mypy strict, ruff (130 cols, Google docstrings), English only.
 9. **Secrets**: never log or expose password/tokens; diagnostics redact them.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,7 +110,7 @@ jobs:
         continue-on-error: true
 
       - name: Run Semgrep
-        # exclude-newer would block homeassistant>=2026.8.1 until the cooldown elapses
+        # exclude-newer would block a freshly released homeassistant until the cooldown elapses
         run: >
           uv run --group dev semgrep --config p/ci --error
           --exclude-rule package_managers.uv.uv-missing-dependency-cooldown.uv-missing-dependency-cooldown

--- a/.github/workflows/ha-integration-test.yml
+++ b/.github/workflows/ha-integration-test.yml
@@ -18,7 +18,7 @@ jobs:
         strategy:
             matrix:
                 home-assistant-version:
-                    - "2026.8.1"
+                    - "2026.3.0"
                     - "latest"
                     - "dev" # Latest development version
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
             ## Requirements
             - Python >= 3.14.2
-            - Home Assistant >= 2026.8.1
+            - Home Assistant >= 2026.3.0
           draft: false
           prerelease: ${{ steps.meta.outputs.prerelease == 'true' }}
           files: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ HACS custom integration (`custom_components/habragerone`) connecting BragerOne h
 ## Project shape
 
 - **Platforms**: `sensor`, `binary_sensor`, `switch`, `number`, `select`, `button` (no `climate`).
-- **Python**: `>=3.14.2,<3.15`; **HA**: `homeassistant>=2026.8.1`; iot_class `cloud_push`.
+- **Python**: `>=3.14.2,<3.15`; **HA**: `homeassistant>=2026.3.0`; iot_class `cloud_push`.
 - **Dependencies**: **uv** (`uv.lock` committed). Runtime deps pinned exactly in `manifest.json`.
 - **Build/versioning**: hatchling + hatch-vcs, CalVer from git tags.
 
@@ -21,7 +21,7 @@ uv run poe cov                   # coverage report (the 70% threshold is enforce
 uv run poe validate              # fmt + lint + typecheck + security + test
 ```
 
-CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.8.1` / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable.
+CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable.
 
 ## Architecture in one paragraph
 

--- a/hacs.json
+++ b/hacs.json
@@ -12,6 +12,6 @@
         "SI",
         "RO"
     ],
-    "homeassistant": "2026.8.1",
+    "homeassistant": "2026.3.0",
     "render_readme": true
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ keywords = [
   "custom-component",
 ]
 dependencies = [
-    "homeassistant>=2026.8.1",
+    "homeassistant>=2026.3.0",
     "py-bragerone>=2026.8.1",
 ]
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -1217,7 +1217,7 @@ test = [
 
 [package.metadata]
 requires-dist = [
-    { name = "homeassistant", specifier = ">=2026.8.1" },
+    { name = "homeassistant", specifier = ">=2026.3.0" },
     { name = "py-bragerone", specifier = ">=2026.8.1" },
 ]
 


### PR DESCRIPTION
## Summary
- `2026.8.1` was never a technical requirement — the hard floor is Python ≥ 3.14.2, which HA first ships in **2026.3**. All HA APIs used by the integration predate 2026.3.
- Lowers the declared minimum consistently: `hacs.json`, `pyproject.toml` (`homeassistant>=2026.3.0`), release notes template, AGENTS.md, integration instructions.
- The Docker matrix pinned leg is now `2026.3.0` — this PR is the empirical verification: **if the 2026.3.0 leg goes green, the floor is real; if red, we revert**.
- `uv.lock` regenerated.

## Test plan
- [x] `HA Integration Test (2026.3.0)` passes in Docker
- [x] `HA Integration Test (latest)` and `(dev)` still pass
- [x] hassfest accepts the lowered `hacs.json` minimum