### PR TITLE
ci: add Codecov PR comments and fix coverage upload

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -13,4 +13,4 @@ applyTo: "tests/**/*.py"
    - command route selection (`parameter_write` vs `raw_command`).
 4. **Bootstrap**: classification/filtering changes need descriptor fixtures covering each platform type.
 5. **Naming tests**: entity naming/unique_id patterns are contractual — keep regression tests for them.
-6. **Style**: same ruff/mypy rules as the integration; coverage gate is `--cov-fail-under=70` (pre-push).
+6. **Style**: same ruff/mypy rules as the integration; coverage gate is `--cov-fail-under=70` (pre-push). CI uploads to Codecov (patch target 100%, project informational).

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,7 +263,7 @@ jobs:
         if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
-          file: ./coverage.xml
+          files: ./coverage.xml
           flags: unittests
           name: ha-bragerone
           fail_ci_if_error: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ uv run poe cov                   # coverage report (the 70% threshold is enforce
 uv run poe validate              # fmt + lint + typecheck + security + test
 ```
 
-CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable.
+CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable. CI uploads `coverage.xml` to Codecov (`codecov-commenter` on PRs). Patch coverage target is 100%; project coverage is informational — the 70% floor stays on pre-push.
 
 ## Architecture in one paragraph
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,7 +13,7 @@ This project uses:
 # Install dependencies
 uv sync --group dev --group test
 
-# Install pre-commit hooks  
+# Install pre-commit hooks
 uv run pre-commit install
 
 # Start development environment
@@ -29,6 +29,8 @@ uv run pytest
 # Run with coverage
 uv run pytest --cov=custom_components.habragerone --cov-report=term-missing
 ```
+
+CI uploads `coverage.xml` to Codecov. Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational (the 70% floor is the pre-push hook).
 
 ### Publishing Releases
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,17 @@
+coverage:
+  status:
+    patch:
+      default:
+        target: 100%
+        threshold: 0%
+    project:
+      default:
+        informational: true
+
+ignore:
+  - "tests/**/*"
+  - "scripts/**/*"
+
+comment:
+  layout: "reach, diff, flags, files"
+  require_changes: true


### PR DESCRIPTION
This pull request introduces Codecov integration for code coverage reporting in CI, sets stricter patch coverage requirements, and clarifies documentation around coverage enforcement and reporting. The main changes are the addition of a `codecov.yml` configuration, updates to CI workflow, and improved documentation for contributors.

**Codecov integration and coverage enforcement:**

* Added `codecov.yml` to configure Codecov: sets patch coverage target to 100%, makes project coverage informational, and customizes comment layout; also ignores `tests` and `scripts` directories in coverage reports.
* Updated CI workflow in `.github/workflows/ci.yml` to upload `coverage.xml` to Codecov using the correct input parameter (`files` instead of `file`).

**Documentation updates:**

* Updated `AGENTS.md`, `DEVELOPMENT.md`, and `.github/instructions/tests.instructions.md` to document Codecov integration, clarify that patch coverage must be 100%, and explain that project coverage is informational while the 70% threshold remains enforced pre-push. [[1]](diffhunk://#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9L24-R24) [[2]](diffhunk://#diff-fc2a310fcfedfefb0046def697f932def80cbb1e78c689bc0af3c8eab3e33eceR33-R34) [[3]](diffhunk://#diff-0ba29cf4ba476c41b8748f8855c232e3967bae551b3bea644d3462f14deb808eL16-R16)Configure patch/project status like ESPHome and pass coverage.xml via files= so the v7 uploader actually sends the report.