### PR TITLE
[SUPERSEDED — please close] ci: add Cloud Agent environment.json

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,5 @@
+{
+  "name": "py/ha-bragerone",
+  "user": "ubuntu",
+  "install": "export PATH=\"$HOME/.local/bin:$PATH\"\nif ! command -v uv >/dev/null 2>&1; then curl -LsSf https://astral.sh/uv/0.12.3/install.sh | sh; fi\nexport PATH=\"$HOME/.local/bin:$PATH\"\nuv sync --locked --group dev --group test --group docs --python 3.13 --directory /agent/repos/py-bragerone\nuv sync --locked --group dev --group test --directory /agent/repos/ha-bragerone"
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Superseded — do not merge

I initially added `.cursor/environment.json` to this repo, but the Cloud Agent environment's **primary repo is `py-bragerone`** (confirmed via `run-info`: `repoUrl = github.com/marpi82/py-bragerone`). The environment reads `.cursor/environment.json` from the primary repo only, so a copy here would be ignored (a draft build off this branch ran no user install).

The environment config now lives in the correct repo:

➡️ **[marpi82/py-bragerone#275](https://github.com/marpi82/py-bragerone/pull/275)**

Please **close this PR**. I left the branch/PR intact rather than closing it automatically. No changes here are needed.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7f3a6450-6e97-4bab-a03d-91a1fc8c08c4?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f3a6450-6e97-4bab-a03d-91a1fc8c08c4&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

