### PR TITLE
ci: add Copilot auto-review, issue/PR templates, and Codecov bot skip

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+# Default owner for the whole repository
+*       @marpi82
+
+# Critical paths
+/.github/                              @marpi82
+/custom_components/habragerone/        @marpi82
+/SECURITY.md                           @marpi82
+/pyproject.toml                        @marpi82
+/hacs.json                             @marpi82

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,105 @@
+name: Bug report
+description: Something is broken or behaves unexpectedly in the Home Assistant integration.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug.
+
+        **Security issues must not be filed here.** Use [private vulnerability reporting](https://github.com/marpi82/ha-bragerone/security/advisories/new) or email `marpi82.dev@google.com` (see [SECURITY.md](https://github.com/marpi82/ha-bragerone/blob/main/SECURITY.md)).
+
+        Protocol / cloud-API problems (REST, Socket.IO, ParamStore, catalog parsers) belong in [py-bragerone](https://github.com/marpi82/py-bragerone/issues/new/choose).
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: One or two sentences describing the problem.
+      placeholder: e.g. Number entity for CH setpoint rejects a value that the BragerOne web UI accepts.
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      description: What you expected to happen.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      description: What actually happened (include Home Assistant log excerpts if any). Redact passwords and tokens.
+    validations:
+      required: true
+
+  - type: textarea
+    id: reproduce
+    attributes:
+      label: Steps to reproduce
+      description: Minimal, numbered steps. Prefer a clean restart + one entity / service call.
+      placeholder: |
+        1. …
+        2. …
+        3. …
+      render: markdown
+    validations:
+      required: true
+
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Versions that help triage. Do not paste credentials or diagnostics dumps with secrets.
+      value: |
+        - ha-bragerone version:
+        - Home Assistant version:
+        - Installation (HACS / manual / other):
+        - py-bragerone version (from `manifest.json` / diagnostics):
+        - Controller / device type:
+        - Platform (bragerone / tisconnect):
+      render: markdown
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the integration is involved?
+      multiple: true
+      options:
+        - Config flow / options / reauth
+        - Bootstrap / entity descriptors
+        - Runtime / WebSocket / reconnect
+        - Sensor / binary_sensor
+        - Switch
+        - Number
+        - Select
+        - Button
+        - Writes (`command_write` / `runtime.async_write`)
+        - Diagnostics
+        - Translations / UI strings
+        - Docs
+        - CI / packaging / HACS
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues for duplicates.
+          required: true
+        - label: This is not a security vulnerability (those go through SECURITY.md).
+          required: true
+        - label: Logs and diagnostics in this report have passwords and tokens redacted.
+          required: true
+        - label: This looks like an integration (Home Assistant) issue, not a py-bragerone library/protocol bug.
+          required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/marpi82/ha-bragerone/security/advisories/new
+    about: Do not file a public issue. Use private vulnerability reporting (or email marpi82.dev@google.com). See SECURITY.md.
+  - name: py-bragerone (library / protocol)
+    url: https://github.com/marpi82/py-bragerone/issues/new/choose
+    about: REST, WebSocket, ParamStore, catalog parsers, and other library bugs belong in py-bragerone.
+  - name: Documentation
+    url: https://github.com/marpi82/ha-bragerone#readme
+    about: Integration README, contributing, and development notes.

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,43 @@
+name: Documentation
+description: Docs are wrong, missing, unclear, or out of date relative to the code.
+title: "docs: "
+labels: ["documentation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Docs live in `README.md`, `CONTRIBUTING.md`, `DEVELOPMENT.md`, and `docs/`, plus UI strings in `strings.json` / `translations/`. They must describe the integration as it is. Docs↔code drift in either direction is a defect.
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: What is wrong or missing?
+      description: Page / section, and what you expected to find.
+      placeholder: e.g. README still lists a climate platform after it was removed.
+    validations:
+      required: true
+
+  - type: textarea
+    id: suggestion
+    attributes:
+      label: Suggested fix
+      description: Proposed wording, structure, or examples (optional).
+    validations:
+      required: false
+
+  - type: input
+    id: link
+    attributes:
+      label: Link / path
+      description: URL or repo path to the affected page.
+      placeholder: README.md
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I checked the latest docs in this repo (`README.md`, `docs/`, translations).
+          required: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,82 @@
+name: Feature request
+description: Propose a new capability or improvement for the Home Assistant integration.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Describe the problem you want solved. Focus on the **Home Assistant user need**; implementation details can come later.
+
+        Protocol or catalog changes belong in [py-bragerone](https://github.com/marpi82/py-bragerone/issues/new/choose). Changing `unique_id` patterns or adding a `climate` platform is a breaking / architectural change — call that out explicitly.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What are you trying to do that is hard or impossible today?
+      placeholder: As a Home Assistant user, I need …
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: Sketch the entity, option, or UI behavior you have in mind.
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you evaluated, or why existing entities / options are insufficient.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: impact
+    attributes:
+      label: Compatibility impact
+      description: Would this change anything existing installations rely on?
+      options:
+        - No — additive / internal only
+        - Yes — new entities / options (non-breaking)
+        - Yes — breaking (`unique_id`, platforms, config flow, bootstrap cache)
+        - Unsure
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      multiple: true
+      options:
+        - Config flow / options / reauth
+        - Bootstrap / entity descriptors
+        - Runtime / WebSocket / reconnect
+        - Sensor / binary_sensor
+        - Switch
+        - Number
+        - Select
+        - Button
+        - Writes (`command_write` / `runtime.async_write`)
+        - Diagnostics
+        - Translations / UI strings
+        - Docs
+        - CI / packaging / HACS
+        - Other / unsure
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched existing issues / docs for similar requests.
+          required: true
+        - label: I am willing to help implement this (optional).
+          required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,37 @@
+name: Question
+description: Ask how something works, or whether observed behavior is intended.
+title: "question: "
+labels: ["question"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Prefer this when you are unsure whether something is a bug.
+
+        For setup help, see [CONTRIBUTING.md](https://github.com/marpi82/ha-bragerone/blob/main/CONTRIBUTING.md) and [DEVELOPMENT.md](https://github.com/marpi82/ha-bragerone/blob/main/DEVELOPMENT.md).
+        Library / protocol questions: [py-bragerone](https://github.com/marpi82/py-bragerone/issues/new/choose).
+
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What are you trying to understand or achieve?
+    validations:
+      required: true
+
+  - type: textarea
+    id: context
+    attributes:
+      label: Context
+      description: Relevant versions (HA, ha-bragerone, py-bragerone), entity ids, and logs (redact credentials).
+      render: markdown
+    validations:
+      required: false
+
+  - type: checkboxes
+    id: checklist
+    attributes:
+      label: Checklist
+      options:
+        - label: I searched issues and the docs before asking.
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,36 @@
+## Summary
+
+<!-- What does this PR change and why? Link related issues with "Fixes #N" / "Closes #N" when applicable. -->
+
+## Type of change
+
+<!-- Check all that apply. -->
+
+- [ ] Bug fix (non-breaking)
+- [ ] New feature / enhancement (non-breaking)
+- [ ] Breaking change (`unique_id`, platforms, config flow version, `BOOTSTRAP_VERSION` / descriptor cache) — call this out explicitly
+- [ ] Docs only
+- [ ] Tests / CI / tooling / chore
+
+## Checklist
+
+- [ ] English only in code, comments, and docs; Google-style docstrings
+- [ ] `uv run --group dev --group test poe validate` passes locally (fmt + lint + mypy --strict + security + tests)
+- [ ] Tests added / updated where practical (regression test for bug fixes; cover enum/numeric write safety when touching the write path). Tests pass offline
+- [ ] Docs / translations updated when user-facing behavior changes (`README.md`, `docs/`, `strings.json` + `translations/en.json`)
+- [ ] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency)
+- [ ] No secrets / credentials / real device dumps committed; diagnostics remain redacted
+
+## Test plan
+
+<!-- How did you verify this? Commands run, scenarios covered. -->
+
+```bash
+uv run poe lint
+uv run poe typecheck
+uv run poe test
+```
+
+## Notes for reviewers
+
+<!-- Trade-offs, follow-ups, unique_id impact, py-bragerone pin bumps, bootstrap cache invalidation, etc. -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,7 +15,7 @@
 ## Checklist
 
 - [ ] English only in code, comments, and docs; Google-style docstrings
-- [ ] `uv run --group dev --group test poe validate` passes locally (fmt + lint + mypy --strict + security + tests)
+- [ ] `uv run poe validate` passes locally (fmt + lint + mypy --strict + security + tests; sync `--group dev --group test` first)
 - [ ] Tests added / updated where practical (regression test for bug fixes; cover enum/numeric write safety when touching the write path). Tests pass offline
 - [ ] Docs / translations updated when user-facing behavior changes (`README.md`, `docs/`, `strings.json` + `translations/en.json`)
 - [ ] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency)

--- a/.github/branch-protection-checklist.md
+++ b/.github/branch-protection-checklist.md
@@ -10,7 +10,7 @@ Recommended rules for `main`:
 1. Require a pull request before merging
 2. Require approvals: at least **1**
 3. Dismiss stale pull request approvals when new commits are pushed
-4. Require review from Code Owners
+4. Require review from Code Owners (enabled)
 5. Require conversation resolution before merging
 6. Do **not** allow force pushes
 7. Do **not** allow deletions

--- a/.github/branch-protection-checklist.md
+++ b/.github/branch-protection-checklist.md
@@ -1,0 +1,17 @@
+# Branch protection checklist (`main`)
+
+Scorecard `BranchProtection` / `CodeReview` alerts need GitHub Settings changes
+(not only repository files). `CODEOWNERS` is already in `.github/CODEOWNERS`.
+
+Open: https://github.com/marpi82/ha-bragerone/settings/branches
+
+Recommended rules for `main`:
+
+1. Require a pull request before merging
+2. Require approvals: at least **1**
+3. Dismiss stale pull request approvals when new commits are pushed
+4. Require review from Code Owners
+5. Require conversation resolution before merging
+6. Do **not** allow force pushes
+7. Do **not** allow deletions
+8. Require status checks to pass — only the aggregate gates (`CI`, `HA Integration Tests`, `HACS Validation`) so renaming matrix legs never needs a ruleset change

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -62,6 +62,15 @@ Add/maintain tests for:
 - min/max rejection behavior,
 - command route selection behavior.
 
+## CI/CD & GitHub Workflows
+
+- **ci.yml**: lint, mypy, tests (pytest + Codecov upload), hassfest, security, wheel-compat, aggregate `CI` gate
+- **ha-integration-test.yml**: Docker matrix against HA `2026.3.0` / `latest` / `dev`
+- **hacs.yml**: HACS validation
+- **copilot-rerequest.yml**: re-request GitHub Copilot review on same-repo PRs (`COPILOT_REVIEW_TOKEN`)
+
+Issue forms live in `.github/ISSUE_TEMPLATE/`; the PR body template is `.github/PULL_REQUEST_TEMPLATE.md`.
+
 ## Change Discipline
 - Keep changes focused and minimal.
 - Do not modify unrelated files.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,23 @@ jobs:
         run: uv run --group test pytest -q --maxfail=1 --disable-warnings --cov=custom_components.habragerone --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage reports to Codecov
-        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
+        # Skip by PR author (not github.actor): a human re-run on a Dependabot/
+        # Renovate PR would otherwise expose CODECOV_TOKEN. Push events have no
+        # pull_request payload, so those still key off github.actor.
+        if: >-
+          (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false)
+          && (
+            (
+              github.event_name == 'pull_request'
+              && github.event.pull_request.user.login != 'dependabot[bot]'
+              && github.event.pull_request.user.login != 'renovate[bot]'
+            )
+            || (
+              github.event_name != 'pull_request'
+              && github.actor != 'dependabot[bot]'
+              && github.actor != 'renovate[bot]'
+            )
+          )
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./coverage.xml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -260,7 +260,7 @@ jobs:
         run: uv run --group test pytest -q --maxfail=1 --disable-warnings --cov=custom_components.habragerone --cov-report=xml --cov-report=term-missing
 
       - name: Upload coverage reports to Codecov
-        if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false }}
+        if: ${{ github.actor != 'dependabot[bot]' && github.actor != 'renovate[bot]' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork == false) }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
         with:
           files: ./coverage.xml

--- a/.github/workflows/copilot-rerequest.yml
+++ b/.github/workflows/copilot-rerequest.yml
@@ -1,0 +1,127 @@
+# Re-request GitHub Copilot code review after PR updates.
+#
+# Why a PAT: the default GITHUB_TOKEN (and the Cursor GitHub App) cannot request
+# the Copilot reviewer bot. This workflow uses secrets.COPILOT_REVIEW_TOKEN and
+# GraphQL `requestReviews(botIds: …)` — the reliable path for Copilot.
+#
+# Setup (one-time, as a repo admin with write access — typically @marpi82):
+#   1. GitHub → Settings → Developer settings → Personal access tokens
+#      → Fine-grained tokens → Generate new token
+#   2. Resource owner: your user/org that owns this repo
+#   3. Repository access: Only select repositories → ha-bragerone
+#   4. Permissions → Repository permissions:
+#        - Pull requests: Read and write
+#        - Metadata: Read-only (auto)
+#   5. Generate, copy the token once
+#   6. Repo → Settings → Secrets and variables → Actions
+#      → New repository secret → Name: COPILOT_REVIEW_TOKEN → paste token
+#
+# Classic PATs with the `repo` scope also work, but fine-grained is preferred.
+# Rotate before expiry; without the secret this job no-ops with a notice.
+
+name: Re-request Copilot review
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: copilot-rerequest-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  rerequest:
+    name: Re-request Copilot
+    runs-on: ubuntu-latest
+    # Same-repo PRs only (forks cannot use this secret). Skip bot dependency PRs
+    # by author (not github.actor — a human reopen/ready_for_review would otherwise
+    # bypass the skip and expose COPILOT_REVIEW_TOKEN on Dependabot/Renovate PRs).
+    if: >-
+      github.event.pull_request.head.repo.full_name == github.repository
+      && github.event.pull_request.user.login != 'dependabot[bot]'
+      && github.event.pull_request.user.login != 'renovate[bot]'
+    steps:
+      - name: Check COPILOT_REVIEW_TOKEN
+        id: token
+        env:
+          COPILOT_REVIEW_TOKEN: ${{ secrets.COPILOT_REVIEW_TOKEN }}
+        run: |
+          if [ -z "${COPILOT_REVIEW_TOKEN}" ]; then
+            echo "present=false" >> "${GITHUB_OUTPUT}"
+            echo "::notice::COPILOT_REVIEW_TOKEN is not set; skipping Copilot re-request. See the header comment in this workflow for setup."
+          else
+            echo "present=true" >> "${GITHUB_OUTPUT}"
+          fi
+
+      - name: Request Copilot via GraphQL botIds
+        if: steps.token.outputs.present == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_REVIEW_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+
+          PR_ID="$(
+            gh api graphql \
+              -f query='query($owner:String!,$repo:String!,$n:Int!) {
+                repository(owner:$owner, name:$repo) {
+                  pullRequest(number:$n) { id }
+                }
+              }' \
+              -F owner="${OWNER}" \
+              -F repo="${REPO}" \
+              -F n="${PR_NUMBER}" \
+              --jq '.data.repository.pullRequest.id'
+          )"
+
+          BOT_ID="$(
+            gh api "users/copilot-pull-request-reviewer%5Bbot%5D" --jq '.node_id'
+          )"
+
+          echo "Requesting Copilot review on PR #${PR_NUMBER} (bot=${BOT_ID})"
+
+          RESULT="$(
+            gh api graphql \
+              -f query='mutation($pr:ID!,$botIds:[ID!]!) {
+                requestReviews(input: {pullRequestId: $pr, botIds: $botIds, union: true}) {
+                  pullRequest {
+                    reviewRequests(first: 20) {
+                      nodes {
+                        requestedReviewer {
+                          __typename
+                          ... on Bot { login }
+                          ... on User { login }
+                        }
+                      }
+                    }
+                  }
+                }
+              }' \
+              -F pr="${PR_ID}" \
+              -f "botIds[]=${BOT_ID}"
+          )"
+
+          # Fail loudly if GraphQL returned errors (gh may still exit 0).
+          if echo "${RESULT}" | jq -e '(.errors // []) | length > 0' >/dev/null; then
+            echo "${RESULT}" | jq '.errors'
+            exit 1
+          fi
+
+          REQUESTS="$(
+            echo "${RESULT}" | jq -c '
+              .data.requestReviews.pullRequest.reviewRequests.nodes
+              | map(.requestedReviewer.login // .requestedReviewer.__typename)
+            '
+          )"
+          echo "reviewRequests after mutation: ${REQUESTS}"
+          # Copilot may consume the request almost immediately; an empty list is not
+          # always a failure. Treat GraphQL errors (above) as the hard signal.
+          if [ "${REQUESTS}" = "[]" ]; then
+            echo "::notice::reviewRequests is empty after requestReviews — Copilot may already be reviewing, or code review may be disabled for this repo."
+          fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,7 +21,7 @@ uv run poe cov                   # coverage report (the 70% threshold is enforce
 uv run poe validate              # fmt + lint + typecheck + security + test
 ```
 
-CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable. CI uploads `coverage.xml` to Codecov (`codecov-commenter` on PRs). Patch coverage target is 100%; project coverage is informational — the 70% floor stays on pre-push.
+CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable. CI uploads `coverage.xml` to Codecov (`codecov-commenter` on PRs; skip Dependabot/Renovate and forks). Patch coverage target is 100%; project coverage is informational — the 70% floor stays on pre-push. Same-repo PRs re-request GitHub Copilot review via `.github/workflows/copilot-rerequest.yml` (`COPILOT_REVIEW_TOKEN`).
 
 ## Architecture in one paragraph
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ Protocol / cloud-API work belongs in [py-bragerone](https://github.com/marpi82/p
 ## Requirements for acceptable contributions
 
 - **Tests**: major new functionality MUST come with tests; bug fixes should add a regression test where practical. All tests must pass offline.
-- **Style**: `ruff format` + `ruff check` clean, `mypy --strict` clean, English only in code and docs, Google-style docstrings. Run `uv run --group dev --group test poe validate` before pushing.
+- **Style**: `ruff format` + `ruff check` clean, `mypy --strict` clean, English only in code and docs, Google-style docstrings. Run `uv run poe validate` before pushing (after `uv sync --locked --group dev --group test`).
 - **Write safety**: changes to the write path must convert enum label→raw, apply the inverse numeric transform, validate min/max (`n`/`x`), and pick the correct route (`parameter_write` vs `raw_command`). Invalid input must error, never send silently.
 - **unique_id**: `{entry_id}_{devid}_{symbol}` plus platform suffix is contractual — changing it is a breaking change.
 - **Docs**: user-facing behavior changes update `README.md` / `docs/` / translations in the same PR.
@@ -28,7 +28,7 @@ See [DEVELOPMENT.md](DEVELOPMENT.md). Short version:
 ```bash
 uv sync --locked --group dev --group test
 uv run pre-commit install
-uv run --group dev --group test poe validate
+uv run poe validate
 ```
 
 ## Coding standards

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,9 +1,53 @@
-## Contributing
+# Contributing to ha-bragerone
 
-Contributions are welcome! Please:
+Thanks for helping improve the BragerOne Home Assistant integration.
 
-1. Fork the repository
-2. Create a feature branch
-3. Make your changes
-4. Run tests and linting
-5. Submit a pull request
+## How to contribute
+
+1. Open an issue describing the bug or enhancement (optional but appreciated) — use the [issue templates](https://github.com/marpi82/ha-bragerone/issues/new/choose).
+2. Fork the repository and create a feature branch from `main`.
+3. Make your changes with tests where practical.
+4. Open a pull request against `main` (the [PR template](.github/PULL_REQUEST_TEMPLATE.md) is applied automatically).
+
+The project uses GitHub Issues and Pull Requests for discussion and review. Do **not** file security issues publicly — see [SECURITY.md](SECURITY.md).
+
+Protocol / cloud-API work belongs in [py-bragerone](https://github.com/marpi82/py-bragerone), not this integration.
+
+## Requirements for acceptable contributions
+
+- **Tests**: major new functionality MUST come with tests; bug fixes should add a regression test where practical. All tests must pass offline.
+- **Style**: `ruff format` + `ruff check` clean, `mypy --strict` clean, English only in code and docs, Google-style docstrings. Run `uv run --group dev --group test poe validate` before pushing.
+- **Write safety**: changes to the write path must convert enum label→raw, apply the inverse numeric transform, validate min/max (`n`/`x`), and pick the correct route (`parameter_write` vs `raw_command`). Invalid input must error, never send silently.
+- **unique_id**: `{entry_id}_{devid}_{symbol}` plus platform suffix is contractual — changing it is a breaking change.
+- **Docs**: user-facing behavior changes update `README.md` / `docs/` / translations in the same PR.
+
+## Development setup
+
+See [DEVELOPMENT.md](DEVELOPMENT.md). Short version:
+
+```bash
+uv sync --locked --group dev --group test
+uv run pre-commit install
+uv run --group dev --group test poe validate
+```
+
+## Coding standards
+
+- Target Python 3.14.2+ and Home Assistant `>=2026.3.0`.
+- Format and lint with **Ruff**; type-check with **mypy** (strict).
+- Prefer small, focused PRs with clear commit messages.
+- Keep protocol logic in `pybragerone`; do not re-implement REST/WS/param handling here.
+- Keep `manifest.json` `py-bragerone==X` in sync with `pyproject.toml`, and `hacs.json` HA minimum in sync with the `homeassistant` dependency.
+
+## Security reports
+
+Do **not** open a public issue for vulnerabilities. Follow [SECURITY.md](SECURITY.md)
+and email `marpi82.dev@google.com`.
+
+## License
+
+By contributing, you agree that your contributions are licensed under the MIT License.
+
+## Branch protection
+
+See [.github/branch-protection-checklist.md](.github/branch-protection-checklist.md) for recommended `main` protection settings.

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,9 @@ uv run pytest
 uv run pytest --cov=custom_components.habragerone --cov-report=term-missing
 ```
 
-CI uploads `coverage.xml` to Codecov. Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational (the 70% floor is the pre-push hook).
+CI uploads `coverage.xml` to Codecov (skipped for Dependabot/Renovate and fork PRs). Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational (the 70% floor is the pre-push hook).
+
+Same-repo PRs also re-request GitHub Copilot code review (`.github/workflows/copilot-rerequest.yml`, secret `COPILOT_REVIEW_TOKEN`). Issue and PR templates live under `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`.
 
 ### Publishing Releases
 

--- a/README.md
+++ b/README.md
@@ -39,14 +39,16 @@ The integration can be configured through the Home Assistant UI. You will need:
 
 ## Contributions are welcome!
 
-If you want to contribute to this, please read the [Contributing guidelines](CONTRIBUTING.md) and [Development guidelines](DEVELOPMENT.md).
+If you want to contribute to this, please read the [Contributing guidelines](CONTRIBUTING.md) and [Development guidelines](DEVELOPMENT.md). Use the [issue forms](https://github.com/marpi82/ha-bragerone/issues/new/choose) and the pull request template.
 
 ## Support
 
 For issues and questions:
 
-- GitHub Issues: https://github.com/marpi82/ha-bragerone/issues
+- GitHub Issues (templated): https://github.com/marpi82/ha-bragerone/issues/new/choose
 - Home Assistant Community: https://community.home-assistant.io/
+
+Do **not** file security issues publicly — see [SECURITY.md](SECURITY.md).
 
 ## License
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,44 @@
+# Security Policy
+
+## Reporting Security Vulnerabilities
+
+If you discover a security vulnerability in ha-bragerone, please report it privately:
+
+- **Preferred**: [GitHub private vulnerability reporting](https://github.com/marpi82/ha-bragerone/security/advisories/new)
+- **Alternative**: email marpi82.dev@google.com
+
+Please do not create a public GitHub issue for security vulnerabilities.
+
+Vulnerabilities in the `pybragerone` library itself should be reported to [py-bragerone](https://github.com/marpi82/py-bragerone/security/advisories/new).
+
+## Coordinated Vulnerability Disclosure
+
+- **Acknowledgement**: within 3 business days.
+- **Initial assessment and severity triage**: within 14 days.
+- **Fix or mitigation**: targeted within 90 days of confirmation, depending on severity and complexity.
+- **Disclosure**: coordinated with the reporter; a GitHub Security Advisory is published once a fix is released (or when we mutually agree). Reporters are credited in the advisory unless they prefer otherwise.
+
+## Supported Versions
+
+Only the **latest release** receives security fixes; there are no backports to older versions. When a release line stops receiving security updates, it is simply superseded by the newest release — upgrade to stay supported.
+
+## Security tooling
+
+This project uses several tools for code and dependency security scanning:
+
+- **bandit**: Security linting for Python code (pre-commit + `poe security`)
+- **ruff** (`S` / flake8-bandit): Fast security lint rules in the same pass as style checks
+- **pip-audit**: Dependency vulnerability scanning
+- **gitleaks**: Secret scanning in CI
+
+## Security Best Practices
+
+When using ha-bragerone:
+
+1. **Keep the integration updated** via HACS or by tracking GitHub releases.
+2. **Secure credentials**: never commit BragerOne passwords or tokens. Diagnostics and logs must redact them.
+3. **Home Assistant**: follow Home Assistant's security guidelines for custom components.
+
+## Contact
+
+For security concerns, use [GitHub private vulnerability reporting](https://github.com/marpi82/ha-bragerone/security/advisories/new) or contact: marpi82.dev@google.com

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,7 @@ coverage:
 ignore:
   - "tests/**/*"
   - "scripts/**/*"
+  - "docs/**/*"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ Documentation = "https://github.com/marpi82/ha-bragerone"
 Repository = "https://github.com/marpi82/ha-bragerone"
 Issues = "https://github.com/marpi82/ha-bragerone/issues"
 Changelog = "https://github.com/marpi82/ha-bragerone/blob/main/CHANGELOG.md"
+Security = "https://github.com/marpi82/ha-bragerone/security/advisories"
 
 [project.scripts]
 hass-dev = "homeassistant.__main__:main"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Mirrors the GitHub hygiene already in `py-bragerone`: automatic Copilot review on same-repo PRs, structured issue/PR templates, `CODEOWNERS`, and a small Codecov alignment. Tokens (`CODECOV_TOKEN`, `COPILOT_REVIEW_TOKEN`) are already configured.

Codecov upload + `codecov.yml` (patch 100%, project informational, PR comments) landed in #143; this PR skips bot/fork uploads (by **PR author**, not `github.actor`) and ignores `docs/` in coverage.

**Code Owners review is already enabled** on `main`.

## Type of change

- [x] Tests / CI / tooling / chore
- [x] Docs only (CONTRIBUTING / README / SECURITY / AGENTS)

## What was added

**Copilot auto-review** (`.github/workflows/copilot-rerequest.yml`):
- Re-requests the Copilot reviewer bot on `opened` / `synchronize` / `reopened` / `ready_for_review`
- GraphQL `requestReviews(botIds: …)` via `COPILOT_REVIEW_TOKEN`
- Skips forks and Dependabot/Renovate **by PR author** (not event actor)

**Issue forms** (`.github/ISSUE_TEMPLATE/`):

| Template | Purpose |
| --- | --- |
| `bug_report.yml` | Repro steps, HA/integration environment, area (config flow / platforms / writes / …) |
| `feature_request.yml` | Motivation, proposal, unique_id / platform impact |
| `documentation.yml` | Docs↔code drift reports |
| `question.yml` | “Is this intended?” questions |
| `config.yml` | Disables blank issues; contact links for **Security**, py-bragerone library bugs, and README |

**Also:**
- PR template (`.github/PULL_REQUEST_TEMPLATE.md`) aligned with integration conventions (write safety, unique_id, version pins, translations)
- `CODEOWNERS` (`@marpi82`) and branch-protection checklist (Code Owners review noted as enabled)
- `SECURITY.md` (private advisory path; required by the issue chooser)
- Codecov: skip Dependabot/Renovate/fork uploads by PR author; ignore `docs/**`

## Copilot review follow-ups

- Inline: Codecov skip now uses PR author on `pull_request` events (thread resolved).
- Suppressed (3): `CONTRIBUTING.md` / PR template now use `uv run poe validate` after `uv sync --locked --group dev --group test`, matching `AGENTS.md`.

## Checklist

- [x] English only in code, comments, and docs
- [x] No secrets / credentials committed
- [x] YAML issue forms parse cleanly
- [x] Version pins unchanged

## Test plan

- Parsed all `.yml` templates and workflows with PyYAML.
- Copilot re-request on this PR: green, `reviewRequests` included `copilot-pull-request-reviewer`.
- After merge: open https://github.com/marpi82/ha-bragerone/issues/new/choose and confirm the chooser + forms render.

## Notes for reviewers

Issue chooser templates apply from `main` after merge. Merge still needs a Code Owner approval (`@marpi82`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

