### PR TITLE
test: add write-path harness and expand runtime coverage (PR1)

### DIFF
--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -1,0 +1,1 @@
+"""Shared test helpers for ha-bragerone unit tests."""

--- a/tests/helpers/descriptors.py
+++ b/tests/helpers/descriptors.py
@@ -1,0 +1,58 @@
+"""Descriptor fixtures for platform and runtime write tests."""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+def writable_parameter_descriptor(
+    *,
+    symbol: str = "PARAM_0",
+    devid: str = "DEV1",
+    pool: str = "P6",
+    chan: str = "v",
+    idx: int = 0,
+    parameter_name: str | None = "parameters.PARAM_0",
+    raw_min: float | None = None,
+    raw_max: float | None = None,
+    command_rules: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a descriptor that routes writes through the parameter path."""
+    mapping: dict[str, Any] = {"command_rules": command_rules or []}
+    if parameter_name is not None:
+        mapping["raw"] = {"name": parameter_name}
+    descriptor: dict[str, Any] = {
+        "symbol": symbol,
+        "devid": devid,
+        "pool": pool,
+        "chan": chan,
+        "idx": idx,
+        "platform": "number",
+        "mapping": mapping,
+    }
+    if raw_min is not None:
+        descriptor["min"] = raw_min
+    if raw_max is not None:
+        descriptor["max"] = raw_max
+    return descriptor
+
+
+def command_rule_descriptor(
+    *,
+    symbol: str = "URUCHOMIENIE_KOTLA",
+    devid: str = "DEV1",
+    pool: str = "P5",
+    chan: str = "s",
+    idx: int = 0,
+    command_rules: list[dict[str, Any]],
+) -> dict[str, Any]:
+    """Build a descriptor with command_rules (raw command route)."""
+    return {
+        "symbol": symbol,
+        "devid": devid,
+        "pool": pool,
+        "chan": chan,
+        "idx": idx,
+        "platform": "switch",
+        "mapping": {"command_rules": command_rules},
+    }

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -1,0 +1,128 @@
+"""Fake py-bragerone / runtime collaborators for offline unit tests."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from typing import Any, ClassVar
+
+
+@dataclass
+class FakeParamUpdate:
+    """Minimal ParamUpdate stand-in for runtime dispatch tests."""
+
+    pool: str
+    chan: str
+    idx: int
+    devid: str = "DEV1"
+    value: Any = None
+    meta: dict[str, Any] = field(default_factory=dict)
+
+
+class FakeBus:
+    """Async bus that yields pushed updates until closed."""
+
+    def __init__(self) -> None:
+        self._queue: asyncio.Queue[FakeParamUpdate | None] = asyncio.Queue()
+
+    async def subscribe(self) -> AsyncIterator[FakeParamUpdate]:
+        while True:
+            update = await self._queue.get()
+            if update is None:
+                break
+            yield update
+
+    def push(self, update: FakeParamUpdate) -> None:
+        self._queue.put_nowait(update)
+
+    def close(self) -> None:
+        self._queue.put_nowait(None)
+
+
+class FakeApi:
+    """Records module_command_auto calls; configurable success flag."""
+
+    def __init__(self, *, succeed: bool = True) -> None:
+        self.calls: list[dict[str, object]] = []
+        self._succeed = succeed
+
+    async def module_command_auto(self, **kwargs: object) -> bool:
+        self.calls.append(kwargs)
+        return self._succeed
+
+    async def close(self) -> None:
+        return None
+
+
+class FakeGateway:
+    """Gateway with controllable start/stop and a fake event bus."""
+
+    modules: ClassVar[list[object]] = []
+
+    def __init__(self, *, start_error: Exception | None = None, start_delay: bool = False) -> None:
+        self.bus = FakeBus()
+        self._start_error = start_error
+        self._start_delay = start_delay
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        if self._start_delay:
+            await asyncio.sleep(0)
+        if self._start_error is not None:
+            raise self._start_error
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class FakeStore:
+    """ParamStore stand-in with flatten() and cancellable run_with_bus()."""
+
+    def __init__(self, *, flat_values: dict[str, object] | None = None) -> None:
+        self._flat = dict(flat_values or {})
+        self.run_started = False
+        self.run_cancelled = False
+
+    def flatten(self) -> dict[str, object]:
+        return dict(self._flat)
+
+    async def run_with_bus(self, _bus: object) -> None:
+        self.run_started = True
+        try:
+            await asyncio.Future()
+        except asyncio.CancelledError:
+            self.run_cancelled = True
+            raise
+
+
+def make_runtime(
+    *,
+    api: FakeApi | None = None,
+    gateway: FakeGateway | None = None,
+    store: FakeStore | None = None,
+    flat_values: dict[str, object] | None = None,
+    modules_meta: dict[str, dict[str, Any]] | None = None,
+    start_error: Exception | None = None,
+    start_delay: bool = False,
+) -> tuple[Any, FakeApi, FakeGateway, FakeStore]:
+    """Build a BragerRuntime wired to fake collaborators."""
+    from custom_components.habragerone.runtime import BragerRuntime
+
+    fake_api = api or FakeApi()
+    fake_gateway = gateway or FakeGateway(start_error=start_error, start_delay=start_delay)
+    fake_store = store or FakeStore(flat_values=flat_values)
+    runtime = BragerRuntime(
+        api=fake_api,  # type: ignore[arg-type]
+        gateway=fake_gateway,  # type: ignore[arg-type]
+        store=fake_store,  # type: ignore[arg-type]
+        modules_meta=modules_meta or {},
+    )
+    return runtime, fake_api, fake_gateway, fake_store
+
+
+def param_update(**kwargs: Any) -> FakeParamUpdate:
+    """Shorthand for FakeParamUpdate with SimpleNamespace-compatible fields."""
+    return FakeParamUpdate(**kwargs)

--- a/tests/test_command_write.py
+++ b/tests/test_command_write.py
@@ -69,3 +69,65 @@ def test_route_selection_behavior() -> None:
 
     with pytest.raises(WriteValidationError, match="No command route available"):
         select_command_route(has_parameter_address=False, has_command_rule=False)
+
+
+def test_enum_display_to_raw_accepts_already_mapped_raw_value() -> None:
+    mapping = {"Eco": 2, "Comfort": 3}
+    assert enum_display_to_raw(2, mapping) == 2
+
+
+def test_enum_raw_to_display_returns_label_or_raw() -> None:
+    mapping = {"Eco": 2, "Comfort": 3}
+    assert enum_raw_to_display(2, mapping) == "Eco"
+    assert enum_raw_to_display(99, mapping) == 99
+
+
+def test_prepare_write_rejects_below_minimum() -> None:
+    context = WriteContext(
+        symbol="P4.v1",
+        has_parameter_address=True,
+        has_command_rule=False,
+        raw_min=10,
+        raw_max=100,
+    )
+    with pytest.raises(WriteValidationError, match="below minimum"):
+        prepare_write(5, context=context)
+
+
+def test_prepare_write_rejects_zero_scale_transform() -> None:
+    context = WriteContext(
+        symbol="P4.v1",
+        has_parameter_address=True,
+        has_command_rule=False,
+        transform=NumericTransform(scale=0.0, offset=0.0),
+        raw_min=0,
+        raw_max=100,
+    )
+    with pytest.raises(WriteValidationError, match="scale cannot be 0"):
+        prepare_write(10, context=context)
+
+
+def test_prepare_write_keeps_fractional_raw_value() -> None:
+    context = WriteContext(
+        symbol="P4.v1",
+        has_parameter_address=True,
+        has_command_rule=False,
+        transform=NumericTransform(scale=3.0, offset=0.0),
+        raw_min=0,
+        raw_max=100,
+    )
+    prepared = prepare_write(10.0, context=context)
+    assert prepared.raw_value == pytest.approx(10.0 / 3.0)
+
+
+def test_prepare_write_applies_enum_mapping_before_bounds() -> None:
+    context = WriteContext(
+        symbol="P4.u1",
+        has_parameter_address=True,
+        has_command_rule=False,
+        enum_mapping={"Eco": 2, "Comfort": 3},
+        raw_min=0,
+        raw_max=10,
+    )
+    prepared = prepare_write("Eco", context=context)
+    assert prepared.raw_value == 2

--- a/tests/test_runtime_async_write.py
+++ b/tests/test_runtime_async_write.py
@@ -1,0 +1,152 @@
+"""Tests for BragerRuntime.async_write and command-rule helpers."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.runtime import (  # noqa: E402
+    _compare_condition,
+    _read_target_actual,
+    _rule_command_name,
+    _select_command_rule,
+    _select_intent_command_rule,
+)
+from tests.helpers.descriptors import command_rule_descriptor, writable_parameter_descriptor  # noqa: E402
+from tests.helpers.fakes import FakeApi, make_runtime  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_async_write_missing_devid_raises() -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    descriptor = writable_parameter_descriptor(devid="")
+    with pytest.raises(HomeAssistantError, match="Missing device id"):
+        await runtime.async_write(descriptor=descriptor, input_display_value=1)
+
+
+@pytest.mark.asyncio
+async def test_async_write_maps_write_validation_error_to_home_assistant_error() -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    descriptor = writable_parameter_descriptor(raw_min=0, raw_max=5)
+    with pytest.raises(HomeAssistantError, match="exceeds maximum"):
+        await runtime.async_write(descriptor=descriptor, input_display_value=99)
+
+
+@pytest.mark.asyncio
+async def test_async_write_parameter_route_failure_raises() -> None:
+    runtime, _api, _gateway, _store = make_runtime(api=FakeApi(succeed=False))
+    descriptor = writable_parameter_descriptor()
+    with pytest.raises(HomeAssistantError, match="parameter route"):
+        await runtime.async_write(descriptor=descriptor, input_display_value=42)
+
+
+@pytest.mark.asyncio
+async def test_async_write_raw_command_failure_raises() -> None:
+    runtime, _api, _gateway, _store = make_runtime(api=FakeApi(succeed=False))
+    descriptor = command_rule_descriptor(
+        command_rules=[{"command": "BOILER_START", "value": "ON"}],
+    )
+    with pytest.raises(HomeAssistantError, match="raw command route"):
+        await runtime.async_write(descriptor=descriptor, input_display_value=True)
+
+
+@pytest.mark.asyncio
+async def test_async_write_applies_enum_mapping() -> None:
+    runtime, api, _gateway, _store = make_runtime()
+    descriptor = writable_parameter_descriptor()
+    await runtime.async_write(
+        descriptor=descriptor,
+        input_display_value="Eco",
+        enum_mapping={"Eco": 2, "Comfort": 3},
+    )
+    assert api.calls[0]["value"] == 2
+
+
+@pytest.mark.asyncio
+async def test_async_write_uses_group_target_address() -> None:
+    runtime, api, _gateway, _store = make_runtime(flat_values={"P7.s3": 0})
+    descriptor = command_rule_descriptor(
+        command_rules=[
+            {
+                "conditions": [
+                    {
+                        "operation": "equalTo",
+                        "expected": 0,
+                        "targets": [{"group": "P7", "use": "s", "number": 3}],
+                    }
+                ],
+                "command": "RELAY_ON",
+                "value": "ON",
+            }
+        ],
+    )
+    await runtime.async_write(descriptor=descriptor, input_display_value=True)
+    assert api.calls[0]["command"] == "RELAY_ON"
+
+
+@pytest.mark.asyncio
+async def test_async_write_uses_connected_at_store_getter() -> None:
+    runtime, api, _gateway, _store = make_runtime(
+        flat_values={},
+        modules_meta={"DEV1": {"connectedAt": "2026-04-06T10:00:00Z"}},
+    )
+    descriptor = command_rule_descriptor(
+        command_rules=[
+            {
+                "conditions": [
+                    {
+                        "operation": "equalTo",
+                        "expected": "2026-04-06T10:00:00Z",
+                        "targets": [{"storeGetter": "modules.connectedAt"}],
+                    }
+                ],
+                "command": "SYNC_OK",
+                "value": "OK",
+            }
+        ],
+    )
+    await runtime.async_write(descriptor=descriptor, input_display_value=True)
+    assert api.calls[0]["command"] == "SYNC_OK"
+
+
+def test_rule_command_name_rejects_void() -> None:
+    assert _rule_command_name({"command": "void 0"}) is None
+    assert _rule_command_name({"command": " BOILER_START "}) == "BOILER_START"
+
+
+def test_select_command_rule_matches_bool_logic() -> None:
+    rules = [
+        {"logic": "on", "command": "START", "value": "ON"},
+        {"logic": "off", "command": "STOP", "value": "OFF"},
+    ]
+    assert _rule_command_name(_select_command_rule(command_rules=rules, desired_value=True)) == "START"
+    assert _rule_command_name(_select_command_rule(command_rules=rules, desired_value=False)) == "STOP"
+
+
+def test_select_intent_command_rule_prefers_logic_tags() -> None:
+    rules = [
+        {"logic": "on", "command": "BOILER_START", "value": "ON"},
+        {"logic": "off", "command": "BOILER_STOP", "value": "OFF"},
+    ]
+    picked = _select_intent_command_rule(command_rules=rules, desired_value=False)
+    assert _rule_command_name(picked) == "BOILER_STOP"
+
+
+def test_compare_condition_supports_not_equal() -> None:
+    assert _compare_condition(operation="notEqualTo", actual=1, expected=0) is True
+    assert _compare_condition(operation="equalTo", actual=1, expected=1) is True
+    assert _compare_condition(operation="unknown.op", actual=1, expected=1) is False
+
+
+def test_read_target_actual_extracts_bit_from_address() -> None:
+    actual = _read_target_actual(
+        {"address": "P5.s0", "bit": 1},
+        flat_values={"P5.s0": 0b10},
+        devid="DEV1",
+        modules_meta={},
+    )
+    assert actual == 1

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -12,6 +12,13 @@ install_pybragerone_stubs()
 
 from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
 
+_EXPECTED_RUNTIME_TASKS = frozenset({"habragerone-store-sync", "habragerone-update-dispatch"})
+
+
+def _runtime_task_names(runtime: object) -> set[str]:
+    tasks = getattr(runtime, "_tasks", [])
+    return {task.get_name() for task in tasks}
+
 
 @pytest.mark.asyncio
 async def test_runtime_start_and_stop_cancels_background_tasks() -> None:
@@ -20,7 +27,7 @@ async def test_runtime_start_and_stop_cancels_background_tasks() -> None:
     await asyncio.sleep(0)
     assert gateway.started
     assert store.run_started
-    assert len(runtime._tasks) == 2
+    assert _EXPECTED_RUNTIME_TASKS.issubset(_runtime_task_names(runtime))
 
     await runtime.stop()
     assert store.run_cancelled
@@ -61,13 +68,21 @@ async def test_runtime_dispatches_updates_to_listeners() -> None:
 async def test_runtime_listener_unsubscribe_stops_delivery() -> None:
     runtime, _api, gateway, _store = make_runtime()
     received: list[FakeParamUpdate] = []
+    callback_called = asyncio.Event()
 
-    remove = runtime.add_listener(received.append)
+    def _listener(update: FakeParamUpdate) -> None:
+        received.append(update)
+        callback_called.set()
+
+    remove = runtime.add_listener(_listener)
     remove()
 
     await runtime.start()
     gateway.bus.push(FakeParamUpdate(pool="P1", chan="v", idx=1))
-    await asyncio.sleep(0.05)
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if callback_called.is_set():
+            break
 
     assert received == []
     await runtime.stop()

--- a/tests/test_runtime_lifecycle.py
+++ b/tests/test_runtime_lifecycle.py
@@ -1,0 +1,97 @@
+"""Tests for BragerRuntime lifecycle, listeners, and update dispatch."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_runtime_start_and_stop_cancels_background_tasks() -> None:
+    runtime, _api, gateway, store = make_runtime()
+    await runtime.start()
+    await asyncio.sleep(0)
+    assert gateway.started
+    assert store.run_started
+    assert len(runtime._tasks) == 2
+
+    await runtime.stop()
+    assert store.run_cancelled
+    assert gateway.stopped
+
+
+@pytest.mark.asyncio
+async def test_runtime_start_failure_cancels_tasks_and_reraises() -> None:
+    runtime, _api, _gateway, store = make_runtime(start_error=RuntimeError("gateway failed"), start_delay=True)
+    with pytest.raises(RuntimeError, match="gateway failed"):
+        await runtime.start()
+    assert runtime._tasks == []
+    assert store.run_cancelled
+
+
+@pytest.mark.asyncio
+async def test_runtime_dispatches_updates_to_listeners() -> None:
+    runtime, _api, gateway, _store = make_runtime()
+    received: list[FakeParamUpdate] = []
+    received_event = asyncio.Event()
+
+    def _on_update(update: FakeParamUpdate) -> None:
+        received.append(update)
+        received_event.set()
+
+    runtime.add_listener(_on_update)
+    await runtime.start()
+
+    update = FakeParamUpdate(pool="P1", chan="v", idx=2, value=21.5)
+    gateway.bus.push(update)
+    await asyncio.wait_for(received_event.wait(), timeout=1.0)
+
+    assert received == [update]
+    await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_runtime_listener_unsubscribe_stops_delivery() -> None:
+    runtime, _api, gateway, _store = make_runtime()
+    received: list[FakeParamUpdate] = []
+
+    remove = runtime.add_listener(received.append)
+    remove()
+
+    await runtime.start()
+    gateway.bus.push(FakeParamUpdate(pool="P1", chan="v", idx=1))
+    await asyncio.sleep(0.05)
+
+    assert received == []
+    await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_runtime_listener_exception_does_not_stop_dispatcher() -> None:
+    runtime, _api, gateway, _store = make_runtime()
+    delivered: list[FakeParamUpdate] = []
+    delivered_event = asyncio.Event()
+
+    def _failing_listener(_update: FakeParamUpdate) -> None:
+        raise RuntimeError("listener boom")
+
+    def _healthy_listener(update: FakeParamUpdate) -> None:
+        delivered.append(update)
+        delivered_event.set()
+
+    runtime.add_listener(_failing_listener)
+    runtime.add_listener(_healthy_listener)
+    await runtime.start()
+
+    gateway.bus.push(FakeParamUpdate(pool="P2", chan="s", idx=0))
+    await asyncio.wait_for(delivered_event.wait(), timeout=1.0)
+    assert delivered
+
+    await runtime.stop()

--- a/tests/test_runtime_parameter_name.py
+++ b/tests/test_runtime_parameter_name.py
@@ -1,68 +1,23 @@
-import asyncio
-from typing import ClassVar
+"""Tests for parameter_write route metadata."""
+
+from __future__ import annotations
+
+import pytest
 
 from tests.conftest import install_pybragerone_stubs
 
 install_pybragerone_stubs()
 
-from custom_components.habragerone.runtime import BragerRuntime  # noqa: E402
+from tests.helpers.descriptors import writable_parameter_descriptor  # noqa: E402
+from tests.helpers.fakes import make_runtime  # noqa: E402
 
 
-class _FakeApi:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, object]] = []
+@pytest.mark.asyncio
+async def test_async_write_parameter_route_includes_parameter_name_from_mapping_raw() -> None:
+    runtime, api, _gateway, _store = make_runtime()
+    descriptor = writable_parameter_descriptor()
 
-    async def module_command_auto(self, **kwargs: object) -> bool:
-        self.calls.append(kwargs)
-        return True
-
-    async def close(self) -> None:
-        return None
-
-
-class _FakeGateway:
-    modules: ClassVar[list[object]] = []
-
-    class _FakeBus:
-        async def subscribe(self):  # pragma: no cover - not used in this test
-            if False:
-                yield None
-
-    bus = _FakeBus()
-
-    async def start(self) -> None:
-        return None
-
-    async def stop(self) -> None:
-        return None
-
-
-class _FakeStore:
-    def flatten(self) -> dict[str, object]:
-        return {}
-
-    async def run_with_bus(self, _bus: object) -> None:  # pragma: no cover - not used in this test
-        return None
-
-
-def test_async_write_parameter_route_includes_parameter_name_from_mapping_raw() -> None:
-    api = _FakeApi()
-    runtime = BragerRuntime(
-        api=api,
-        gateway=_FakeGateway(),
-        store=_FakeStore(),
-        modules_meta={},
-    )
-    descriptor = {
-        "symbol": "PARAM_0",
-        "devid": "DEV1",
-        "pool": "P6",
-        "chan": "v",
-        "idx": 0,
-        "mapping": {"raw": {"name": "parameters.PARAM_0"}, "command_rules": []},
-    }
-
-    asyncio.run(runtime.async_write(descriptor=descriptor, input_display_value=77.0))
+    await runtime.async_write(descriptor=descriptor, input_display_value=77.0)
 
     assert len(api.calls) == 1
     assert api.calls[0]["pool"] == "P6"

--- a/tests/test_runtime_write_routing.py
+++ b/tests/test_runtime_write_routing.py
@@ -1,85 +1,37 @@
-import asyncio
-from typing import ClassVar
+"""Runtime write routing tests (raw command vs parameter path)."""
+
+from __future__ import annotations
+
+import pytest
 
 from tests.conftest import install_pybragerone_stubs
 
 install_pybragerone_stubs()
 
-from custom_components.habragerone.runtime import BragerRuntime  # noqa: E402
+from tests.helpers.descriptors import command_rule_descriptor  # noqa: E402
+from tests.helpers.fakes import make_runtime  # noqa: E402
 
 
-class _FakeApi:
-    def __init__(self) -> None:
-        self.calls: list[dict[str, object]] = []
-
-    async def module_command_auto(self, **kwargs: object) -> bool:
-        self.calls.append(kwargs)
-        return True
-
-    async def close(self) -> None:
-        return None
-
-
-class _FakeGateway:
-    modules: ClassVar[list[object]] = []
-
-    class _FakeBus:
-        async def subscribe(self):  # pragma: no cover - not used in these tests
-            if False:
-                yield None
-
-    bus = _FakeBus()
-
-    async def start(self) -> None:
-        return None
-
-    async def stop(self) -> None:
-        return None
-
-
-class _FakeStore:
-    def __init__(self, *, flat_values: dict[str, object]) -> None:
-        self._flat = dict(flat_values)
-
-    def flatten(self) -> dict[str, object]:
-        return dict(self._flat)
-
-    async def run_with_bus(self, _bus: object) -> None:  # pragma: no cover - not used in these tests
-        return None
-
-
-def test_async_write_prefers_raw_command_rule_over_parameter_address() -> None:
-    api = _FakeApi()
-    runtime = BragerRuntime(
-        api=api,
-        gateway=_FakeGateway(),
-        store=_FakeStore(flat_values={"P5.s0": 0}),
-        modules_meta={"DEV1": {"connectedAt": "2026-04-06T10:00:00Z"}},
+@pytest.mark.asyncio
+async def test_async_write_prefers_raw_command_rule_over_parameter_address() -> None:
+    runtime, api, _gateway, _store = make_runtime(flat_values={"P5.s0": 0})
+    descriptor = command_rule_descriptor(
+        command_rules=[
+            {
+                "operation": "ignored",
+                "conditions": [{"operation": "equalTo", "expected": 0, "targets": [{"address": "P5.s0", "bit": 0}]}],
+                "command": "BOILER_START",
+                "value": "OFF",
+            },
+            {
+                "conditions": [{"operation": "equalTo", "expected": 1, "targets": [{"address": "P5.s0", "bit": 0}]}],
+                "command": "BOILER_STOP",
+                "value": "ON",
+            },
+        ],
     )
-    descriptor = {
-        "symbol": "URUCHOMIENIE_KOTLA",
-        "devid": "DEV1",
-        "pool": "P5",
-        "chan": "s",
-        "idx": 0,
-        "mapping": {
-            "command_rules": [
-                {
-                    "operation": "ignored",
-                    "conditions": [{"operation": "equalTo", "expected": 0, "targets": [{"address": "P5.s0", "bit": 0}]}],
-                    "command": "BOILER_START",
-                    "value": "OFF",
-                },
-                {
-                    "conditions": [{"operation": "equalTo", "expected": 1, "targets": [{"address": "P5.s0", "bit": 0}]}],
-                    "command": "BOILER_STOP",
-                    "value": "ON",
-                },
-            ]
-        },
-    }
 
-    asyncio.run(runtime.async_write(descriptor=descriptor, input_display_value=True))
+    await runtime.async_write(descriptor=descriptor, input_display_value=True)
 
     assert len(api.calls) == 1
     assert api.calls[0]["command"] == "BOILER_START"
@@ -88,59 +40,35 @@ def test_async_write_prefers_raw_command_rule_over_parameter_address() -> None:
     assert "parameter" not in api.calls[0]
 
 
-def test_async_write_uses_descriptor_address_when_rule_conditions_have_no_targets() -> None:
-    api = _FakeApi()
-    runtime = BragerRuntime(
-        api=api,
-        gateway=_FakeGateway(),
-        store=_FakeStore(flat_values={"P5.s0": 1}),
-        modules_meta={"DEV1": {}},
+@pytest.mark.asyncio
+async def test_async_write_uses_descriptor_address_when_rule_conditions_have_no_targets() -> None:
+    runtime, api, _gateway, _store = make_runtime(flat_values={"P5.s0": 1})
+    descriptor = command_rule_descriptor(
+        command_rules=[
+            {"conditions": [{"operation": "equalTo", "expected": 0}], "command": "BOILER_START", "value": "OFF"},
+            {"conditions": [{"operation": "equalTo", "expected": 1}], "command": "BOILER_STOP", "value": "ON"},
+            {"conditions": [], "command": "void 0"},
+        ],
     )
-    descriptor = {
-        "symbol": "URUCHOMIENIE_KOTLA",
-        "devid": "DEV1",
-        "pool": "P5",
-        "chan": "s",
-        "idx": 0,
-        "mapping": {
-            "command_rules": [
-                {"conditions": [{"operation": "equalTo", "expected": 0}], "command": "BOILER_START", "value": "OFF"},
-                {"conditions": [{"operation": "equalTo", "expected": 1}], "command": "BOILER_STOP", "value": "ON"},
-                {"conditions": [], "command": "void 0"},
-            ]
-        },
-    }
 
-    asyncio.run(runtime.async_write(descriptor=descriptor, input_display_value=False))
+    await runtime.async_write(descriptor=descriptor, input_display_value=False)
 
     assert len(api.calls) == 1
     assert api.calls[0]["command"] == "BOILER_STOP"
     assert api.calls[0]["value"] == "ON"
 
 
-def test_async_write_prefers_intent_rule_for_start_stop_commands() -> None:
-    api = _FakeApi()
-    runtime = BragerRuntime(
-        api=api,
-        gateway=_FakeGateway(),
-        store=_FakeStore(flat_values={"P5.s0": 0}),
-        modules_meta={"DEV1": {}},
+@pytest.mark.asyncio
+async def test_async_write_prefers_intent_rule_for_start_stop_commands() -> None:
+    runtime, api, _gateway, _store = make_runtime(flat_values={"P5.s0": 0})
+    descriptor = command_rule_descriptor(
+        command_rules=[
+            {"conditions": [{"operation": "equalTo", "expected": 0}], "command": "BOILER_START", "value": "OFF"},
+            {"conditions": [{"operation": "equalTo", "expected": 1}], "command": "BOILER_STOP", "value": "ON"},
+        ],
     )
-    descriptor = {
-        "symbol": "URUCHOMIENIE_KOTLA",
-        "devid": "DEV1",
-        "pool": "P5",
-        "chan": "s",
-        "idx": 0,
-        "mapping": {
-            "command_rules": [
-                {"conditions": [{"operation": "equalTo", "expected": 0}], "command": "BOILER_START", "value": "OFF"},
-                {"conditions": [{"operation": "equalTo", "expected": 1}], "command": "BOILER_STOP", "value": "ON"},
-            ]
-        },
-    }
 
-    asyncio.run(runtime.async_write(descriptor=descriptor, input_display_value=False))
+    await runtime.async_write(descriptor=descriptor, input_display_value=False)
 
     assert len(api.calls) == 1
     assert api.calls[0]["command"] == "BOILER_STOP"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

PR 1 of the ha-bragerone coverage plan: shared test harness + critical **write path** coverage.

## Type of change

- [x] Tests / CI / tooling / chore

## What changed

**New `tests/helpers/`:**
- `descriptors.py` — factories for parameter / command-rule descriptors
- `fakes.py` — `FakeApi`, `FakeGateway`, `FakeBus`, `FakeStore`, `make_runtime()`

**New tests:**
- `test_runtime_lifecycle.py` — `start()`/`stop()`, gateway failure cleanup, listener dispatch + unsubscribe, listener exception isolation
- `test_runtime_async_write.py` — validation errors, route failures, enum mapping, group/storeGetter targets, rule helpers

**Expanded:**
- `test_command_write.py` — **100%** coverage (raw enum passthrough, min bound, zero scale, fractional raw, enum in `prepare_write`)

**Refactored** (same behaviour, shared helpers + `pytest.mark.asyncio`):
- `test_runtime_write_routing.py`
- `test_runtime_parameter_name.py`

## Coverage impact (local full suite)

| Module | Before | After |
| --- | ---: | ---: |
| **Project total** | ~41% | **~44%** |
| `command_write.py` | 87% | **100%** |
| `runtime.py` | 48% | **~75%** |

## Test plan

```bash
uv run pytest -q
uv run poe lint
uv run poe typecheck
uv run poe cov
```

## Notes for reviewers

No production code changes. Harness from this PR is intended for PR2 (platform entities) and PR4 (config flow).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

