### PR TITLE
test: add entity_common, switch, and number platform coverage (PR2)

Extend the offline test harness with hass.data registration helpers and
FakeStore.get_family(), then add unit tests for entity_common helpers and
switch/number platform entities (setup, listeners, state refresh, writes).

Coverage: entity_common 93%, switch 99%, number 98%; project total ~52%.

Co-authored-by: marpi82 <marpi82@gmail.com>

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@ htmlcov/
 .cache
 nosetests.xml
 coverage.xml
+coverage.json
 *.cover
 *.py,cover
 .hypothesis/

--- a/tests/helpers/descriptors.py
+++ b/tests/helpers/descriptors.py
@@ -45,8 +45,44 @@ def command_rule_descriptor(
     chan: str = "s",
     idx: int = 0,
     command_rules: list[dict[str, Any]],
+    platform: str = "switch",
+    label: str | None = None,
+    panel_path: str | None = None,
+    module_name: str | None = "boiler_module",
 ) -> dict[str, Any]:
     """Build a descriptor with command_rules (raw command route)."""
+    descriptor: dict[str, Any] = {
+        "symbol": symbol,
+        "devid": devid,
+        "pool": pool,
+        "chan": chan,
+        "idx": idx,
+        "platform": platform,
+        "mapping": {"command_rules": command_rules},
+    }
+    if label is not None:
+        descriptor["label"] = label
+    if panel_path is not None:
+        descriptor["panel_path"] = panel_path
+    if module_name is not None:
+        descriptor["module_name"] = module_name
+    return descriptor
+
+
+def switch_descriptor(
+    *,
+    symbol: str = "SWITCH_0",
+    devid: str = "DEV1",
+    pool: str = "P5",
+    chan: str = "s",
+    idx: int = 0,
+    mapping_inputs: list[dict[str, str]] | None = None,
+    command_rules: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a switch-platform descriptor."""
+    mapping: dict[str, Any] = {"command_rules": command_rules or []}
+    if mapping_inputs:
+        mapping["inputs"] = mapping_inputs
     return {
         "symbol": symbol,
         "devid": devid,
@@ -54,5 +90,7 @@ def command_rule_descriptor(
         "chan": chan,
         "idx": idx,
         "platform": "switch",
-        "mapping": {"command_rules": command_rules},
+        "label": "Test switch",
+        "module_name": "module_a",
+        "mapping": mapping,
     }

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -89,6 +89,24 @@ class FakeStore:
     def flatten(self) -> dict[str, object]:
         return dict(self._flat)
 
+    def get_family(self, pool: str, idx: int) -> dict[str, object] | None:
+        """Return channel map for one ParamStore family (``P<n>.<chan><idx>`` keys)."""
+        family: dict[str, object] = {}
+        for key, value in self._flat.items():
+            if not isinstance(key, str) or "." not in key:
+                continue
+            key_pool, rest = key.split(".", 1)
+            if key_pool != pool or len(rest) < 2:
+                continue
+            chan = rest[0]
+            try:
+                key_idx = int(rest[1:])
+            except ValueError:
+                continue
+            if key_idx == idx:
+                family[chan] = value
+        return family or None
+
     async def run_with_bus(self, _bus: object) -> None:
         self.run_started = True
         try:

--- a/tests/helpers/hass.py
+++ b/tests/helpers/hass.py
@@ -1,0 +1,48 @@
+"""Home Assistant test harness helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.habragerone.const import (
+    CONF_ENTITY_DESCRIPTORS,
+    CONF_OBJECT_ID,
+    DATA_ENTITY_STATS,
+    DATA_RUNTIME,
+    DOMAIN,
+)
+
+
+def register_config_entry(
+    hass: HomeAssistant,
+    *,
+    entry_id: str = "test-entry-id",
+    runtime: Any,
+    descriptors: list[dict[str, Any]],
+    entity_stats: dict[str, Any] | None = None,
+) -> MockConfigEntry:
+    """Register a config entry with runtime + cached descriptors in hass.data."""
+    entry = MockConfigEntry(
+        entry_id=entry_id,
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "secret",
+            CONF_OBJECT_ID: 1,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    entry_payload: dict[str, Any] = {
+        DATA_RUNTIME: runtime,
+        CONF_ENTITY_DESCRIPTORS: descriptors,
+    }
+    if entity_stats is not None:
+        entry_payload[DATA_ENTITY_STATS] = entity_stats
+
+    hass.data.setdefault(DOMAIN, {})[entry.entry_id] = entry_payload
+    return entry

--- a/tests/test_entity_common.py
+++ b/tests/test_entity_common.py
@@ -1,0 +1,169 @@
+"""Tests for shared entity_common helpers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.const import (  # noqa: E402
+    CONF_ENTITY_DESCRIPTORS,
+    DATA_ENTITY_STATS,
+    DATA_RUNTIME,
+    DOMAIN,
+)
+from custom_components.habragerone.entity_common import (  # noqa: E402
+    descriptor_current_raw_value,
+    descriptor_enum_map,
+    descriptor_options,
+    descriptor_raw_to_label,
+    descriptor_refresh_keys,
+    device_info_from_descriptor,
+    get_runtime_and_descriptors,
+    record_platform_entity_stats,
+    store_value_for_address,
+)
+from tests.helpers.descriptors import switch_descriptor, writable_parameter_descriptor  # noqa: E402
+from tests.helpers.fakes import FakeStore, make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+def test_descriptor_refresh_keys_direct_address() -> None:
+    descriptor = switch_descriptor(pool="P5", chan="s", idx=3)
+    assert descriptor_refresh_keys(descriptor) == {"P5.s3"}
+
+
+def test_descriptor_refresh_keys_mapping_inputs() -> None:
+    descriptor = {
+        "mapping": {
+            "inputs": [{"address": "P1.v2"}, {"address": " P6.s0 "}, {"address": ""}, "bad"],
+        },
+    }
+    assert descriptor_refresh_keys(descriptor) == {"P1.v2", "P6.s0"}
+
+
+def test_store_value_for_address_reads_family_channel() -> None:
+    store = FakeStore(flat_values={"P6.v0": 42, "P6.s0": 1})
+    assert store_value_for_address(store, "P6.v0") == 42
+    assert store_value_for_address(store, "P6.s9") is None
+
+
+def test_store_value_for_address_rejects_invalid_syntax() -> None:
+    store = FakeStore()
+    assert store_value_for_address(store, "invalid") is None
+    assert store_value_for_address(store, "P6.bad") is None
+
+
+def test_descriptor_current_raw_value_prefers_direct_mapping() -> None:
+    store = FakeStore(flat_values={"P5.s0": 0, "P1.v2": 99})
+    descriptor = switch_descriptor(
+        pool="P5",
+        chan="s",
+        idx=0,
+        mapping_inputs=[{"address": "P1.v2"}],
+    )
+    assert descriptor_current_raw_value(store, descriptor) == 0
+
+
+def test_descriptor_current_raw_value_falls_back_to_mapping_input() -> None:
+    store = FakeStore(flat_values={"P1.v2": 7})
+    descriptor = {
+        "pool": "P5",
+        "chan": "s",
+        "idx": 0,
+        "mapping": {"inputs": [{"address": "P1.v2"}]},
+    }
+    assert descriptor_current_raw_value(store, descriptor) == 7
+
+
+def test_descriptor_current_raw_value_returns_none_when_missing() -> None:
+    store = FakeStore()
+    assert descriptor_current_raw_value(store, switch_descriptor()) is None
+
+
+def test_descriptor_options_filters_invalid_entries() -> None:
+    descriptor: dict[str, Any] = {"options": [" Auto ", "", 3, None]}
+    assert descriptor_options(descriptor) == [" Auto ", "3", "None"]
+    assert descriptor_options({"options": "bad"}) == []
+
+
+def test_descriptor_enum_map_keeps_scalar_values_only() -> None:
+    descriptor: dict[str, Any] = {
+        "enum_map": {"On": 1, "Off": 0, "Bad": {"nested": True}, "Text": "x"},
+    }
+    assert descriptor_enum_map(descriptor) == {"On": 1, "Off": 0, "Text": "x"}
+    assert descriptor_enum_map({"enum_map": []}) == {}
+
+
+def test_descriptor_raw_to_label_normalizes_keys() -> None:
+    descriptor: dict[str, Any] = {"raw_to_label": {1: "On", 0: "Off"}}
+    assert descriptor_raw_to_label(descriptor) == {"1": "On", "0": "Off"}
+    assert descriptor_raw_to_label({"raw_to_label": "bad"}) == {}
+
+
+def test_device_info_from_descriptor_builds_registry_payload() -> None:
+    descriptor = writable_parameter_descriptor(
+        devid="DEV9",
+        symbol="TEMP",
+    )
+    descriptor.update(
+        {
+            "module_name": "boiler",
+            "module_title": "Boiler module",
+            "module_version": "1.2.3",
+        },
+    )
+    info = device_info_from_descriptor(descriptor, domain=DOMAIN)
+    assert info["identifiers"] == {(DOMAIN, "DEV9")}
+    assert info["manufacturer"] == "BragerOne"
+    assert info["name"] == "boiler"
+    assert info["model"] == "Boiler module"
+    assert info["sw_version"] == "1.2.3"
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_and_descriptors_filters_platform(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    switch = switch_descriptor()
+    number = writable_parameter_descriptor(symbol="NUM")
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[switch, number])
+
+    result = get_runtime_and_descriptors(hass, entry, platform="switch")
+    assert result is not None
+    resolved_runtime, descriptors = result
+    assert resolved_runtime is runtime
+    assert descriptors == [switch]
+
+
+@pytest.mark.asyncio
+async def test_get_runtime_and_descriptors_returns_none_for_invalid_payload(hass: HomeAssistant) -> None:
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[])
+    hass.data[DOMAIN][entry.entry_id][DATA_RUNTIME] = "not-a-runtime"
+
+    assert get_runtime_and_descriptors(hass, entry, platform="switch") is None
+
+    hass.data[DOMAIN][entry.entry_id][DATA_RUNTIME] = make_runtime()[0]
+    hass.data[DOMAIN][entry.entry_id][CONF_ENTITY_DESCRIPTORS] = "bad"
+    assert get_runtime_and_descriptors(hass, entry, platform="switch") is None
+
+
+@pytest.mark.asyncio
+async def test_record_platform_entity_stats_persists_counts(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+
+    record_platform_entity_stats(
+        hass,
+        entry,
+        platform="switch",
+        descriptor_count=3,
+        created_count=2,
+    )
+
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]
+    assert stats == {"switch": {"descriptor_count": 3, "created_count": 2}}

--- a/tests/test_platform_number.py
+++ b/tests/test_platform_number.py
@@ -1,0 +1,132 @@
+"""Tests for the number platform and BragerSymbolNumber entity."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.const import DATA_ENTITY_STATS, DOMAIN  # noqa: E402
+from custom_components.habragerone.number import BragerSymbolNumber, async_setup_entry  # noqa: E402
+from tests.helpers.descriptors import switch_descriptor, writable_parameter_descriptor  # noqa: E402
+from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_entities_and_stats(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P6.v0": 12.5})
+    descriptors = [
+        writable_parameter_descriptor(symbol="NUM1", raw_min=0, raw_max=100),
+        writable_parameter_descriptor(symbol="NUM2", idx=1),
+        switch_descriptor(),
+    ]
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
+    added: list[BragerSymbolNumber] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert len(added) == 2
+    assert {entity._symbol for entity in added} == {"NUM1", "NUM2"}
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["number"]
+    assert stats == {"descriptor_count": 2, "created_count": 2}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_noop_when_runtime_missing(hass: HomeAssistant) -> None:
+    entry = register_config_entry(
+        hass,
+        runtime=make_runtime()[0],
+        descriptors=[writable_parameter_descriptor()],
+    )
+    hass.data[DOMAIN][entry.entry_id].pop("runtime")
+    added: list[BragerSymbolNumber] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_number_entity_identity_min_max_and_device_info(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = writable_parameter_descriptor(symbol="SETPOINT", raw_min=5, raw_max=30)
+    descriptor.update(
+        {
+            "label": "Target temperature",
+            "panel_path": "Heating/Zone 1",
+            "module_name": "zone_module",
+        },
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolNumber(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._attr_name == "Heating/Zone 1 - Target temperature"
+    assert entity._attr_suggested_object_id == "zone_module_setpoint"
+    assert entity._attr_unique_id == f"{entry.entry_id}_dev1_setpoint_number"
+    assert entity._attr_native_min_value == 5.0
+    assert entity._attr_native_max_value == 30.0
+    assert entity.device_info["identifiers"] == {(DOMAIN, "DEV1")}
+
+
+@pytest.mark.asyncio
+async def test_number_listener_lifecycle_and_state_refresh(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P6.v0": 21})
+    descriptor = writable_parameter_descriptor()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolNumber(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "number.test_number"
+
+    await entity.async_added_to_hass()
+    assert callable(entity._unsubscribe_listener)
+
+    await entity.async_update()
+    assert entity.native_value == 21.0
+    assert entity.available is True
+
+    entity._runtime.store._flat.clear()
+    await entity.async_update()
+    assert entity.available is False
+
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_listener is None
+
+
+@pytest.mark.asyncio
+async def test_number_set_native_value_dispatches_write(hass: HomeAssistant) -> None:
+    runtime, api, _gateway, _store = make_runtime()
+    descriptor = writable_parameter_descriptor(raw_min=0, raw_max=100)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolNumber(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "number.test_number"
+    await entity.async_added_to_hass()
+
+    await entity.async_set_native_value(18.5)
+
+    assert len(api.calls) == 1
+    assert entity.native_value == 18.5
+
+
+@pytest.mark.asyncio
+async def test_number_runtime_update_schedules_refresh_for_matching_key(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = writable_parameter_descriptor(pool="P6", chan="v", idx=0)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolNumber(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "number.test_number"
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+    await entity.async_added_to_hass()
+    entity.async_schedule_update_ha_state.reset_mock()
+
+    entity._on_runtime_update(FakeParamUpdate(pool="P6", chan="v", idx=0))
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_runtime_update(FakeParamUpdate(pool="P1", chan="s", idx=9))
+    entity.async_schedule_update_ha_state.assert_not_called()

--- a/tests/test_platform_number.py
+++ b/tests/test_platform_number.py
@@ -11,7 +11,7 @@ from tests.conftest import install_pybragerone_stubs
 
 install_pybragerone_stubs()
 
-from custom_components.habragerone.const import DATA_ENTITY_STATS, DOMAIN  # noqa: E402
+from custom_components.habragerone.const import DATA_ENTITY_STATS, DATA_RUNTIME, DOMAIN  # noqa: E402
 from custom_components.habragerone.number import BragerSymbolNumber, async_setup_entry  # noqa: E402
 from tests.helpers.descriptors import switch_descriptor, writable_parameter_descriptor  # noqa: E402
 from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
@@ -43,7 +43,7 @@ async def test_async_setup_entry_noop_when_runtime_missing(hass: HomeAssistant) 
         runtime=make_runtime()[0],
         descriptors=[writable_parameter_descriptor()],
     )
-    hass.data[DOMAIN][entry.entry_id].pop("runtime")
+    hass.data[DOMAIN][entry.entry_id].pop(DATA_RUNTIME)
     added: list[BragerSymbolNumber] = []
     await async_setup_entry(hass, entry, added.extend)
 

--- a/tests/test_platform_switch.py
+++ b/tests/test_platform_switch.py
@@ -12,7 +12,7 @@ from tests.conftest import install_pybragerone_stubs
 
 install_pybragerone_stubs()
 
-from custom_components.habragerone.const import DATA_ENTITY_STATS, DOMAIN  # noqa: E402
+from custom_components.habragerone.const import DATA_ENTITY_STATS, DATA_RUNTIME, DOMAIN  # noqa: E402
 from custom_components.habragerone.switch import (  # noqa: E402
     BragerSymbolSwitch,
     _coerce_bool,
@@ -67,7 +67,7 @@ async def test_async_setup_entry_registers_entities_and_stats(hass: HomeAssistan
 @pytest.mark.asyncio
 async def test_async_setup_entry_noop_when_runtime_missing(hass: HomeAssistant) -> None:
     entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[switch_descriptor()])
-    hass.data[DOMAIN][entry.entry_id].pop("runtime")
+    hass.data[DOMAIN][entry.entry_id].pop(DATA_RUNTIME)
     added: list[BragerSymbolSwitch] = []
     await async_setup_entry(hass, entry, added.extend)
 

--- a/tests/test_platform_switch.py
+++ b/tests/test_platform_switch.py
@@ -1,0 +1,162 @@
+"""Tests for the switch platform and BragerSymbolSwitch entity."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.const import DATA_ENTITY_STATS, DOMAIN  # noqa: E402
+from custom_components.habragerone.switch import (  # noqa: E402
+    BragerSymbolSwitch,
+    _coerce_bool,
+    async_setup_entry,
+)
+from tests.helpers.descriptors import (  # noqa: E402
+    command_rule_descriptor,
+    switch_descriptor,
+    writable_parameter_descriptor,
+)
+from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (True, True),
+        (False, False),
+        (1, True),
+        (0, False),
+        ("on", True),
+        ("OFF", False),
+        ("yes", True),
+        ("disabled", False),
+        ("maybe", False),
+        (None, False),
+    ],
+)
+def test_coerce_bool(raw: Any, expected: bool) -> None:
+    assert _coerce_bool(raw) is expected
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_entities_and_stats(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s0": 1})
+    descriptors = [
+        switch_descriptor(symbol="SW1"),
+        switch_descriptor(symbol="SW2", idx=1),
+        writable_parameter_descriptor(symbol="NUM_ONLY"),
+    ]
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
+    added: list[BragerSymbolSwitch] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert len(added) == 2
+    assert {entity._symbol for entity in added} == {"SW1", "SW2"}
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["switch"]
+    assert stats == {"descriptor_count": 2, "created_count": 2}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_noop_when_runtime_missing(hass: HomeAssistant) -> None:
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[switch_descriptor()])
+    hass.data[DOMAIN][entry.entry_id].pop("runtime")
+    added: list[BragerSymbolSwitch] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_switch_entity_identity_and_device_info(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = command_rule_descriptor(
+        platform="switch",
+        label="Boiler run",
+        panel_path="Menu/Boiler",
+        module_name="boiler_module",
+        command_rules=[{"command": "BOILER_START", "value": "ON"}],
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSwitch(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._attr_name == "Menu/Boiler - Boiler run"
+    assert entity._attr_suggested_object_id == "boiler_module_uruchomienie_kotla"
+    assert entity._attr_unique_id == f"{entry.entry_id}_dev1_uruchomienie_kotla_switch"
+    assert entity.device_info["identifiers"] == {(DOMAIN, "DEV1")}
+
+
+@pytest.mark.asyncio
+async def test_switch_listener_lifecycle_and_state_refresh(hass: HomeAssistant) -> None:
+    runtime, _api, _gateway, _store = make_runtime(flat_values={"P5.s0": 1})
+    descriptor = switch_descriptor()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSwitch(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "switch.test_switch"
+
+    await entity.async_added_to_hass()
+    assert callable(entity._unsubscribe_listener)
+
+    await entity.async_update()
+    assert entity.is_on is True
+    assert entity.available is True
+
+    entity._attr_available = True
+    entity._attr_is_on = True
+    entity._runtime.store._flat.clear()
+    await entity.async_update()
+    assert entity.available is False
+
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_listener is None
+
+
+@pytest.mark.asyncio
+async def test_switch_turn_on_off_dispatch_writes(hass: HomeAssistant) -> None:
+    runtime, api, _gateway, _store = make_runtime()
+    descriptor = command_rule_descriptor(
+        platform="switch",
+        command_rules=[
+            {"logic": "on", "command": "BOILER_START", "value": "ON"},
+            {"logic": "off", "command": "BOILER_STOP", "value": "OFF"},
+        ],
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSwitch(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "switch.test_switch"
+    await entity.async_added_to_hass()
+
+    await entity.async_turn_on()
+    await entity.async_turn_off()
+
+    assert len(api.calls) == 2
+    assert entity.is_on is False
+
+
+@pytest.mark.asyncio
+async def test_switch_runtime_update_schedules_refresh_for_matching_key(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = switch_descriptor(pool="P5", chan="s", idx=0)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSwitch(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "switch.test_switch"
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+    await entity.async_added_to_hass()
+    entity.async_schedule_update_ha_state.reset_mock()
+
+    entity._on_runtime_update(FakeParamUpdate(pool="P5", chan="s", idx=0))
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_runtime_update(FakeParamUpdate(pool="P9", chan="v", idx=1))
+    entity.async_schedule_update_ha_state.assert_not_called()


### PR DESCRIPTION
## Summary

Second slice of the multi-PR coverage plan (follows merged #146). Adds offline unit tests for shared entity helpers and the `switch` / `number` platform entities — no production code changes.

**Harness extensions**
- `tests/helpers/hass.py` — `register_config_entry()` seeds `hass.data[DOMAIN]` with runtime + cached descriptors
- `tests/helpers/fakes.py` — `FakeStore.get_family()` for `P<n>.<chan><idx>` reads
- `tests/helpers/descriptors.py` — `switch_descriptor()`, richer `command_rule_descriptor()`

**New tests**
- `tests/test_entity_common.py` — refresh keys, store reads, platform filter, enum/options, device info, stats
- `tests/test_platform_switch.py` — setup, listener lifecycle, `_coerce_bool`, turn on/off, runtime updates
- `tests/test_platform_number.py` — setup, min/max, `async_set_native_value`, listener lifecycle

**Coverage impact (local `uv run poe cov`)**

| Module | Before | After |
|---|---|---|
| `entity_common.py` | ~31% | **93%** |
| `switch.py` | 0% | **99%** |
| `number.py` | 0% | **98%** |
| **Project total** | ~44% | **~52%** |

Also adds `coverage.json` to `.gitignore`.

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] `uv run poe validate` passes locally (fmt + lint + mypy --strict + security + tests)
- [x] Tests added / updated where practical. Tests pass offline
- [ ] Docs / translations updated when user-facing behavior changes — N/A (tests only)
- [ ] Version pins stay consistent — N/A (no pin changes)
- [x] No secrets / credentials / real device dumps committed

## Test plan

```bash
uv sync --locked --group dev --group test
uv run poe validate
uv run poe cov