### PR TITLE
test: select, binary_sensor, button, and sensor platform coverage (PR3)

### DIFF
--- a/tests/helpers/descriptors.py
+++ b/tests/helpers/descriptors.py
@@ -18,7 +18,7 @@ def writable_parameter_descriptor(
     command_rules: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build a descriptor that routes writes through the parameter path."""
-    mapping: dict[str, Any] = {"command_rules": command_rules or []}
+    mapping: dict[str, Any] = {"command_rules": command_rules if command_rules is not None else []}
     if parameter_name is not None:
         mapping["raw"] = {"name": parameter_name}
     descriptor: dict[str, Any] = {
@@ -80,7 +80,7 @@ def switch_descriptor(
     command_rules: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build a switch-platform descriptor."""
-    mapping: dict[str, Any] = {"command_rules": command_rules or []}
+    mapping: dict[str, Any] = {"command_rules": command_rules if command_rules is not None else []}
     if mapping_inputs:
         mapping["inputs"] = mapping_inputs
     return {
@@ -117,9 +117,9 @@ def select_descriptor(
         "platform": "select",
         "label": "Operating mode",
         "module_name": "module_a",
-        "options": options or ["Eco", "Comfort"],
-        "enum_map": enum_map or {"Eco": 2, "Comfort": 3},
-        "raw_to_label": raw_to_label or {"2": "Eco", "3": "Comfort"},
+        "options": ["Eco", "Comfort"] if options is None else options,
+        "enum_map": {"Eco": 2, "Comfort": 3} if enum_map is None else enum_map,
+        "raw_to_label": {"2": "Eco", "3": "Comfort"} if raw_to_label is None else raw_to_label,
         "mapping": {"command_rules": []},
     }
 
@@ -143,7 +143,7 @@ def binary_sensor_descriptor(
         "platform": "binary_sensor",
         "label": "Pump active",
         "module_name": "module_a",
-        "mapping": {"command_rules": command_rules or []},
+        "mapping": {"command_rules": command_rules if command_rules is not None else []},
     }
 
 
@@ -163,7 +163,11 @@ def button_descriptor(
         "platform": "button",
         "label": "Reset alarm",
         "module_name": "module_a",
-        "mapping": {"command_rules": command_rules or [{"command": "RESET_ALARM", "value": True}]},
+        "mapping": {
+            "command_rules": command_rules
+            if command_rules is not None
+            else [{"command": "RESET_ALARM", "value": True}],
+        },
     }
 
 
@@ -180,7 +184,7 @@ def sensor_descriptor(
     mapping_channels: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build a sensor-platform descriptor."""
-    mapping: dict[str, Any] = {"command_rules": command_rules or []}
+    mapping: dict[str, Any] = {"command_rules": command_rules if command_rules is not None else []}
     if mapping_channels is not None:
         mapping["channels"] = mapping_channels
     descriptor: dict[str, Any] = {

--- a/tests/helpers/descriptors.py
+++ b/tests/helpers/descriptors.py
@@ -94,3 +94,108 @@ def switch_descriptor(
         "module_name": "module_a",
         "mapping": mapping,
     }
+
+
+def select_descriptor(
+    *,
+    symbol: str = "MODE_SELECT",
+    devid: str = "DEV1",
+    pool: str = "P6",
+    chan: str = "v",
+    idx: int = 0,
+    options: list[str] | None = None,
+    enum_map: dict[str, str | int] | None = None,
+    raw_to_label: dict[str, str] | None = None,
+) -> dict[str, Any]:
+    """Build a select-platform descriptor with enum options."""
+    return {
+        "symbol": symbol,
+        "devid": devid,
+        "pool": pool,
+        "chan": chan,
+        "idx": idx,
+        "platform": "select",
+        "label": "Operating mode",
+        "module_name": "module_a",
+        "options": options or ["Eco", "Comfort"],
+        "enum_map": enum_map or {"Eco": 2, "Comfort": 3},
+        "raw_to_label": raw_to_label or {"2": "Eco", "3": "Comfort"},
+        "mapping": {"command_rules": []},
+    }
+
+
+def binary_sensor_descriptor(
+    *,
+    symbol: str = "FLAG_0",
+    devid: str = "DEV1",
+    pool: str = "P5",
+    chan: str = "s",
+    idx: int = 0,
+    command_rules: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a binary_sensor-platform descriptor."""
+    return {
+        "symbol": symbol,
+        "devid": devid,
+        "pool": pool,
+        "chan": chan,
+        "idx": idx,
+        "platform": "binary_sensor",
+        "label": "Pump active",
+        "module_name": "module_a",
+        "mapping": {"command_rules": command_rules or []},
+    }
+
+
+def button_descriptor(
+    *,
+    symbol: str = "ACTION_BTN",
+    devid: str = "DEV1",
+    command_rules: list[dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Build a button-platform descriptor."""
+    return {
+        "symbol": symbol,
+        "devid": devid,
+        "pool": "P5",
+        "chan": "s",
+        "idx": 0,
+        "platform": "button",
+        "label": "Reset alarm",
+        "module_name": "module_a",
+        "mapping": {"command_rules": command_rules or [{"command": "RESET_ALARM", "value": True}]},
+    }
+
+
+def sensor_descriptor(
+    *,
+    symbol: str = "TEMP_1",
+    devid: str = "DEV1",
+    pool: str = "P6",
+    chan: str = "v",
+    idx: int = 0,
+    unit: str | None = "°C",
+    raw_to_label: dict[str, str] | None = None,
+    command_rules: list[dict[str, Any]] | None = None,
+    mapping_channels: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Build a sensor-platform descriptor."""
+    mapping: dict[str, Any] = {"command_rules": command_rules or []}
+    if mapping_channels is not None:
+        mapping["channels"] = mapping_channels
+    descriptor: dict[str, Any] = {
+        "symbol": symbol,
+        "devid": devid,
+        "pool": pool,
+        "chan": chan,
+        "idx": idx,
+        "platform": "sensor",
+        "label": "Boiler temperature",
+        "module_name": "module_a",
+        "mapping": mapping,
+    }
+    if unit is not None:
+        descriptor["unit"] = unit
+    if raw_to_label is not None:
+        descriptor["raw_to_label"] = raw_to_label
+    return descriptor

--- a/tests/helpers/descriptors.py
+++ b/tests/helpers/descriptors.py
@@ -164,9 +164,7 @@ def button_descriptor(
         "label": "Reset alarm",
         "module_name": "module_a",
         "mapping": {
-            "command_rules": command_rules
-            if command_rules is not None
-            else [{"command": "RESET_ALARM", "value": True}],
+            "command_rules": command_rules if command_rules is not None else [{"command": "RESET_ALARM", "value": True}],
         },
     }
 

--- a/tests/test_platform_binary_sensor.py
+++ b/tests/test_platform_binary_sensor.py
@@ -1,0 +1,150 @@
+"""Tests for the binary_sensor platform and BragerStatusBinarySensor entity."""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.binary_sensor import (  # noqa: E402
+    BragerStatusBinarySensor,
+    _to_bool,
+    async_setup_entry,
+)
+from custom_components.habragerone.const import DATA_ENTITY_STATS, DATA_RUNTIME, DOMAIN  # noqa: E402
+from tests.helpers.descriptors import binary_sensor_descriptor, select_descriptor  # noqa: E402
+from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        (True, True),
+        (False, False),
+        (1, True),
+        (0, False),
+        ("on", True),
+        ("OFF", False),
+        ("yes", True),
+        ("disabled", False),
+        ("maybe", False),
+        (None, False),
+    ],
+)
+def test_to_bool(raw: Any, expected: bool) -> None:
+    assert _to_bool(raw) is expected
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_entities_and_stats(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s0": 1})
+    descriptors = [
+        binary_sensor_descriptor(symbol="BIN1"),
+        binary_sensor_descriptor(symbol="BIN2", idx=1),
+        select_descriptor(),
+    ]
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
+    added: list[BragerStatusBinarySensor] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert len(added) == 2
+    assert {entity._symbol for entity in added} == {"BIN1", "BIN2"}
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["binary_sensor"]
+    assert stats == {"descriptor_count": 2, "created_count": 2}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_noop_when_runtime_missing(hass: HomeAssistant) -> None:
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[binary_sensor_descriptor()])
+    hass.data[DOMAIN][entry.entry_id].pop(DATA_RUNTIME)
+    added: list[BragerStatusBinarySensor] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_entity_identity_and_device_info(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = binary_sensor_descriptor(symbol="PUMP_ON")
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._attr_name == "Pump active"
+    assert entity._attr_unique_id == f"{entry.entry_id}_dev1_pump_on_binary"
+    assert entity.device_info["identifiers"] == {(DOMAIN, "DEV1")}
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_listener_lifecycle_and_raw_bool_state(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s0": 1})
+    descriptor = binary_sensor_descriptor()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "binary_sensor.test_flag"
+
+    await entity.async_added_to_hass()
+    assert callable(entity._unsubscribe_listener)
+
+    await entity.async_update()
+    assert entity.is_on is True
+    assert entity.available is True
+
+    entity._runtime.store._flat.clear()
+    await entity.async_update()
+    assert entity.available is False
+
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_listener is None
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_uses_rule_mapping_when_configured(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s5": 768})
+    descriptor = binary_sensor_descriptor(
+        pool="P5",
+        chan="s",
+        idx=5,
+        command_rules=[
+            {
+                "value": "On",
+                "conditions": [{"operation": "equalTo", "expected": 768, "targets": [{"address": "P5.s5"}]}],
+            }
+        ],
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "binary_sensor.test_flag"
+
+    await entity.async_update()
+
+    assert entity.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_runtime_update_schedules_refresh_for_matching_key(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = binary_sensor_descriptor(pool="P5", chan="s", idx=0)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "binary_sensor.test_flag"
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+    await entity.async_added_to_hass()
+    entity.async_schedule_update_ha_state.reset_mock()
+
+    entity._on_runtime_update(FakeParamUpdate(pool="P5", chan="s", idx=0))
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_runtime_update(FakeParamUpdate(pool="P9", chan="v", idx=1))
+    entity.async_schedule_update_ha_state.assert_not_called()

--- a/tests/test_platform_button.py
+++ b/tests/test_platform_button.py
@@ -1,0 +1,88 @@
+"""Tests for the button platform and BragerActionButton entity."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.button import BragerActionButton, async_setup_entry  # noqa: E402
+from custom_components.habragerone.const import DATA_ENTITY_STATS, DATA_RUNTIME, DOMAIN  # noqa: E402
+from tests.helpers.descriptors import button_descriptor, sensor_descriptor  # noqa: E402
+from tests.helpers.fakes import make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_entities_and_stats(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptors = [
+        button_descriptor(symbol="BTN1"),
+        button_descriptor(symbol="BTN2"),
+        sensor_descriptor(),
+    ]
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
+    added: list[BragerActionButton] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert len(added) == 2
+    assert {entity._symbol for entity in added} == {"BTN1", "BTN2"}
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["button"]
+    assert stats == {"descriptor_count": 2, "created_count": 2}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_noop_when_runtime_missing(hass: HomeAssistant) -> None:
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[button_descriptor()])
+    hass.data[DOMAIN][entry.entry_id].pop(DATA_RUNTIME)
+    added: list[BragerActionButton] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_button_entity_identity_and_device_info(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = button_descriptor(symbol="RESET_ALARM")
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerActionButton(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._attr_name == "Reset alarm"
+    assert entity._attr_unique_id == f"{entry.entry_id}_dev1_reset_alarm_button"
+    assert entity.device_info["identifiers"] == {(DOMAIN, "DEV1")}
+
+
+@pytest.mark.asyncio
+async def test_button_press_dispatches_first_rule_value(hass: HomeAssistant) -> None:
+    runtime, api, _gateway, _store = make_runtime()
+    descriptor = button_descriptor(
+        command_rules=[{"command": "RESET_ALARM", "value": True}],
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerActionButton(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "button.test_reset"
+
+    await entity.async_press()
+
+    assert len(api.calls) == 1
+    assert api.calls[0]["command"] == "RESET_ALARM"
+
+
+@pytest.mark.asyncio
+async def test_button_press_defaults_value_when_rule_missing(hass: HomeAssistant) -> None:
+    runtime, api, _gateway, _store = make_runtime()
+    descriptor = button_descriptor(command_rules=[{"command": "PING"}])
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerActionButton(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "button.test_ping"
+
+    await entity.async_press()
+
+    assert len(api.calls) == 1
+    assert api.calls[0]["command"] == "PING"

--- a/tests/test_platform_select.py
+++ b/tests/test_platform_select.py
@@ -1,0 +1,117 @@
+"""Tests for the select platform and BragerSymbolSelect entity."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.const import DATA_ENTITY_STATS, DATA_RUNTIME, DOMAIN  # noqa: E402
+from custom_components.habragerone.select import BragerSymbolSelect, async_setup_entry  # noqa: E402
+from tests.helpers.descriptors import select_descriptor, switch_descriptor  # noqa: E402
+from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_entities_and_stats(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P6.v0": 2})
+    descriptors = [select_descriptor(symbol="SEL1"), select_descriptor(symbol="SEL2", idx=1), switch_descriptor()]
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
+    added: list[BragerSymbolSelect] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert len(added) == 2
+    assert {entity._symbol for entity in added} == {"SEL1", "SEL2"}
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["select"]
+    assert stats == {"descriptor_count": 2, "created_count": 2}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_noop_when_runtime_missing(hass: HomeAssistant) -> None:
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[select_descriptor()])
+    hass.data[DOMAIN][entry.entry_id].pop(DATA_RUNTIME)
+    added: list[BragerSymbolSelect] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_select_entity_identity_and_device_info(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = select_descriptor(symbol="MODE")
+    descriptor["panel_path"] = "Settings/Mode"
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSelect(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._attr_name == "Settings/Mode - Operating mode"
+    assert entity._attr_unique_id == f"{entry.entry_id}_dev1_mode_select"
+    assert entity._attr_options == ["Eco", "Comfort"]
+    assert entity.device_info["identifiers"] == {(DOMAIN, "DEV1")}
+
+
+@pytest.mark.asyncio
+async def test_select_listener_lifecycle_and_state_refresh(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P6.v0": 3})
+    descriptor = select_descriptor()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSelect(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "select.test_mode"
+
+    await entity.async_added_to_hass()
+    assert callable(entity._unsubscribe_listener)
+
+    await entity.async_update()
+    assert entity.current_option == "Comfort"
+    assert entity.available is True
+
+    entity._runtime.store._flat.clear()
+    await entity.async_update()
+    assert entity.available is False
+
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_listener is None
+
+
+@pytest.mark.asyncio
+async def test_select_option_dispatches_enum_mapped_write(hass: HomeAssistant) -> None:
+    runtime, api, _gateway, _store = make_runtime()
+    descriptor = select_descriptor()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSelect(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "select.test_mode"
+    await entity.async_added_to_hass()
+
+    await entity.async_select_option("Eco")
+
+    assert entity.current_option == "Eco"
+    assert len(api.calls) == 1
+    assert api.calls[0]["value"] == 2
+
+
+@pytest.mark.asyncio
+async def test_select_runtime_update_schedules_refresh_for_matching_key(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = select_descriptor(pool="P6", chan="v", idx=0)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSelect(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "select.test_mode"
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+    await entity.async_added_to_hass()
+    entity.async_schedule_update_ha_state.reset_mock()
+
+    entity._on_runtime_update(FakeParamUpdate(pool="P6", chan="v", idx=0))
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_runtime_update(FakeParamUpdate(pool="P1", chan="s", idx=9))
+    entity.async_schedule_update_ha_state.assert_not_called()

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -1,0 +1,196 @@
+"""Tests for the sensor platform entity lifecycle and update paths."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.const import DATA_ENTITY_STATS, DATA_RUNTIME, DOMAIN  # noqa: E402
+from custom_components.habragerone.sensor import BragerSymbolSensor, async_setup_entry  # noqa: E402
+from tests.helpers.descriptors import button_descriptor, sensor_descriptor  # noqa: E402
+from tests.helpers.fakes import FakeParamUpdate, FakeStore, make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_registers_entities_and_stats(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P6.v0": 21.5})
+    descriptors = [
+        sensor_descriptor(symbol="TEMP1"),
+        sensor_descriptor(symbol="TEMP2", idx=1),
+        button_descriptor(),
+    ]
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
+    added: list[BragerSymbolSensor] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert len(added) == 2
+    assert {entity._symbol for entity in added} == {"TEMP1", "TEMP2"}
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["sensor"]
+    assert stats == {"descriptor_count": 2, "created_count": 2}
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_noop_when_runtime_missing(hass: HomeAssistant) -> None:
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[sensor_descriptor()])
+    hass.data[DOMAIN][entry.entry_id].pop(DATA_RUNTIME)
+    added: list[BragerSymbolSensor] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    assert added == []
+
+
+@pytest.mark.asyncio
+async def test_sensor_entity_identity_and_device_info(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = sensor_descriptor(symbol="TEMP_BOILER", unit="°C")
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._attr_name == "Boiler temperature"
+    assert entity._attr_unique_id == f"{entry.entry_id}_dev1_temp_boiler"
+    assert entity._attr_native_unit_of_measurement == "°C"
+    assert entity.device_info["identifiers"] == {(DOMAIN, "DEV1")}
+
+
+@pytest.mark.asyncio
+async def test_sensor_listener_lifecycle_and_numeric_state(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P6.v0": 55.2})
+    descriptor = sensor_descriptor(unit=None)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_temp"
+
+    await entity.async_added_to_hass()
+    assert callable(entity._unsubscribe_listener)
+
+    await entity.async_update()
+    assert entity.native_value == 55.2
+    assert entity.available is True
+
+    entity._runtime.store._flat.clear()
+    await entity.async_update()
+    assert entity.available is False
+
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_listener is None
+
+
+@pytest.mark.asyncio
+async def test_sensor_update_uses_raw_to_label_mapping(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P6.v0": 1})
+    descriptor = sensor_descriptor(raw_to_label={"1": "Open", "0": "Closed"})
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_valve"
+
+    await entity.async_update()
+
+    assert entity.native_value == "open"
+
+
+@pytest.mark.asyncio
+async def test_sensor_update_uses_status_resolver_for_status_symbols(hass: HomeAssistant) -> None:
+    store = FakeStore(flat_values={"P5.s5": 768})
+    resolve_status = AsyncMock(return_value="Work")
+    runtime = SimpleNamespace(
+        store=store,
+        add_listener=lambda _cb: lambda: None,
+        async_resolve_status_label=resolve_status,
+    )
+    descriptor = sensor_descriptor(symbol="STATUS_BOILER", pool="P5", chan="s", idx=5, unit=None)
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)  # type: ignore[arg-type]
+    entity.hass = hass
+    entity.entity_id = "sensor.test_status"
+
+    await entity.async_update()
+
+    assert entity.native_value == "work"
+    resolve_status.assert_awaited_once_with("STATUS_BOILER")
+
+
+@pytest.mark.asyncio
+async def test_sensor_update_uses_dynamic_unit_resolver(hass: HomeAssistant) -> None:
+    store = FakeStore(flat_values={"P10.v2": 33})
+    resolve_with_unit = AsyncMock(return_value=(42.0, "%"))
+    runtime = SimpleNamespace(
+        store=store,
+        add_listener=lambda _cb: lambda: None,
+        async_resolve_symbol_with_unit=resolve_with_unit,
+    )
+    descriptor = sensor_descriptor(
+        symbol="PARAM16_2",
+        pool="P10",
+        chan="v",
+        idx=2,
+        unit=None,
+        mapping_channels={
+            "value": [{"address": "P10.v2"}],
+            "unit": [{"address": "P10.u2"}],
+        },
+    )
+    entry = register_config_entry(hass, runtime=make_runtime()[0], descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)  # type: ignore[arg-type]
+    entity.hass = hass
+    entity.entity_id = "sensor.test_power"
+
+    await entity.async_update()
+
+    assert entity.native_value == 42.0
+    assert entity.native_unit_of_measurement == "%"
+    resolve_with_unit.assert_awaited_once_with("PARAM16_2")
+
+
+@pytest.mark.asyncio
+async def test_sensor_update_uses_command_rule_display_value(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s5": 768})
+    descriptor = sensor_descriptor(
+        pool="P5",
+        chan="s",
+        idx=5,
+        unit=None,
+        command_rules=[
+            {
+                "value": "WORK",
+                "conditions": [{"operation": "equalTo", "expected": 768, "targets": [{"address": "P5.s5"}]}],
+            }
+        ],
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_rule"
+
+    await entity.async_update()
+
+    assert entity.native_value == "work"
+
+
+@pytest.mark.asyncio
+async def test_sensor_runtime_update_schedules_refresh_for_matching_key(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    descriptor = sensor_descriptor(pool="P6", chan="v", idx=0)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_temp"
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+    await entity.async_added_to_hass()
+    entity.async_schedule_update_ha_state.reset_mock()
+
+    entity._on_runtime_update(FakeParamUpdate(pool="P6", chan="v", idx=0))
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_runtime_update(FakeParamUpdate(pool="P9", chan="v", idx=1))
+    entity.async_schedule_update_ha_state.assert_not_called()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds offline unit tests for the remaining HA platforms (`select`, `binary_sensor`, `button`, `sensor`) to improve regression coverage of entity setup, listener lifecycle, state refresh, and write/dispatch behavior.

## Changes

- New platform test modules: `test_platform_select.py`, `test_platform_binary_sensor.py`, `test_platform_button.py`, `test_platform_sensor.py`
- Extended `tests/helpers/descriptors.py` with builders for select/binary_sensor/button/sensor descriptors
- Fixed descriptor helper defaults to use `is None` checks (Copilot feedback)

## Coverage

| Module | Coverage |
|--------|----------|
| binary_sensor | ~99% |
| button | ~96% |
| select | ~95% |
| sensor | ~89% |
| **project** | **~61%** |

173 tests total (stacked PR4 adds config_flow tests on top).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

