### PR TITLE
test: config_flow coverage (PR4)

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,6 +34,7 @@ def install_pybragerone_stubs() -> None:
 
     class _Platform:
         BRAGERONE = types.SimpleNamespace(value="bragerone")
+        TISCONNECT = types.SimpleNamespace(value="tisconnect")
 
     def _server_for(_platform: str) -> object:
         return object()

--- a/tests/helpers/config_flow.py
+++ b/tests/helpers/config_flow.py
@@ -1,0 +1,88 @@
+"""Shared mocks for config flow integration tests."""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import AsyncMock, patch
+
+from pybragerone.api.client import ApiError
+
+
+def _module_model(*, devid: str = "DEV1", name: str = "Boiler module", version: str = "1.0") -> SimpleNamespace:
+    return SimpleNamespace(
+        model_dump=lambda mode="json": {
+            "devid": devid,
+            "name": name,
+            "moduleTitle": name,
+            "moduleVersion": version,
+        },
+    )
+
+
+def make_fake_api(
+    *,
+    auth_error: bool = False,
+    objects: list[SimpleNamespace] | None = None,
+    modules: list[SimpleNamespace] | None = None,
+) -> AsyncMock:
+    """Build a fake API client for config/options flow tests."""
+    api = AsyncMock()
+    api.ensure_auth = AsyncMock(side_effect=ApiError(401, {"message": "auth"}) if auth_error else None)
+    api.get_objects = AsyncMock(
+        return_value=[
+            SimpleNamespace(id=1, name="Site A"),
+            SimpleNamespace(id=2, name="Site B"),
+        ]
+        if objects is None
+        else objects,
+    )
+    api.get_modules = AsyncMock(return_value=modules if modules is not None else [_module_model()])
+    api.close = AsyncMock()
+    return api
+
+
+def make_language_config() -> SimpleNamespace:
+    """Build a minimal language config payload for LiveAssetsCatalog."""
+    return SimpleNamespace(
+        default_translation="en",
+        translations=[
+            {"id": "en", "name": "English", "flag": "🇬🇧"},
+            {"id": "pl", "name": "Polski", "flag": "🇵🇱"},
+        ],
+    )
+
+
+def make_bootstrap_payload() -> dict[str, Any]:
+    """Build a minimal bootstrap payload returned during module selection."""
+    return {
+        "entity_descriptors": [{"symbol": "PARAM_0", "devid": "DEV1", "platform": "sensor"}],
+        "modules_meta": {"DEV1": {"name": "Boiler module"}},
+        "module_filter_modes": {"DEV1": "ui"},
+    }
+
+
+@contextmanager
+def patch_config_flow_dependencies(
+    *,
+    api: AsyncMock | None = None,
+    bootstrap_payload: dict[str, Any] | None = None,
+    bootstrap_error: Exception | None = None,
+):
+    """Patch config-flow external collaborators for offline tests."""
+    fake_api = api or make_fake_api()
+    bootstrap_result = bootstrap_payload if bootstrap_payload is not None else make_bootstrap_payload()
+    bootstrap_mock = AsyncMock(side_effect=bootstrap_error) if bootstrap_error else AsyncMock(return_value=bootstrap_result)
+
+    catalog = AsyncMock()
+    catalog.list_language_config = AsyncMock(return_value=make_language_config())
+    catalog.get_i18n = AsyncMock(return_value={"lang": {"en": "English", "pl": "Polski"}})
+
+    with (
+        patch("custom_components.habragerone.config_flow.BragerOneApiClient", return_value=fake_api),
+        patch("custom_components.habragerone.config_flow.LiveAssetsCatalog", return_value=catalog),
+        patch("custom_components.habragerone.config_flow.async_build_bootstrap_payload", bootstrap_mock),
+        patch("custom_components.habragerone.config_flow.server_for", return_value=object()),
+    ):
+        yield fake_api, bootstrap_mock

--- a/tests/helpers/config_flow.py
+++ b/tests/helpers/config_flow.py
@@ -7,8 +7,6 @@ from types import SimpleNamespace
 from typing import Any
 from unittest.mock import AsyncMock, patch
 
-from pybragerone.api.client import ApiError
-
 
 def _module_model(*, devid: str = "DEV1", name: str = "Boiler module", version: str = "1.0") -> SimpleNamespace:
     return SimpleNamespace(
@@ -28,8 +26,13 @@ def make_fake_api(
     modules: list[SimpleNamespace] | None = None,
 ) -> AsyncMock:
     """Build a fake API client for config/options flow tests."""
+    from pybragerone.api.client import ApiError
+
     api = AsyncMock()
-    api.ensure_auth = AsyncMock(side_effect=ApiError(401, {"message": "auth"}) if auth_error else None)
+    if auth_error:
+        api.ensure_auth = AsyncMock(side_effect=ApiError(401, {"message": "auth"}))
+    else:
+        api.ensure_auth = AsyncMock(return_value=None)
     api.get_objects = AsyncMock(
         return_value=[
             SimpleNamespace(id=1, name="Site A"),

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -1,0 +1,117 @@
+"""Tests for config_flow helper functions not covered elsewhere."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import voluptuous as vol
+
+from custom_components.habragerone.config_flow import (
+    _build_modules_step_schema,
+    _entity_filter_mode_values,
+    _extract_language_label,
+    _extract_selected_module_filter_modes,
+    _language_label_from_row,
+    _looks_like_language_code_label,
+    _module_choices,
+    _ui_field_labels,
+)
+from custom_components.habragerone.const import CONF_ENTITY_FILTER_MODE, CONF_MODULES, FILTER_MODE_UI
+
+
+def test_module_choices_skips_empty_devid_and_formats_label() -> None:
+    modules = [
+        {"devid": "", "name": "Skip me"},
+        {"devid": "DEV1", "name": "Boiler", "moduleVersion": "2.1"},
+        {"devid": "DEV2", "moduleTitle": "Pump", "moduleVersion": "1.0"},
+    ]
+
+    assert _module_choices(modules) == [
+        ("DEV1", "Boiler (devid=DEV1, version=2.1)"),
+        ("DEV2", "Pump (devid=DEV2, version=1.0)"),
+    ]
+
+
+def test_ui_field_labels_supports_polish_and_english() -> None:
+    assert _ui_field_labels("pl-PL")["language"] == "Język"
+    assert _ui_field_labels("en")["language"] == "Language"
+
+
+def test_entity_filter_mode_values_supports_polish_and_english() -> None:
+    assert "Filtrowanie po menu UI" in _entity_filter_mode_values(ui_language="pl").values()
+    assert "UI menu filtering" in _entity_filter_mode_values(ui_language="en").values()
+
+
+def test_extract_selected_module_filter_modes_rejects_invalid_mode() -> None:
+    user_input: dict[str, Any] = {CONF_ENTITY_FILTER_MODE: "unknown-mode"}
+    assert (
+        _extract_selected_module_filter_modes(
+            user_input=user_input,
+            module_ids=["DEV1"],
+            default_mode=FILTER_MODE_UI,
+        )
+        is None
+    )
+
+
+def test_extract_selected_module_filter_modes_maps_all_modules() -> None:
+    user_input: dict[str, Any] = {CONF_ENTITY_FILTER_MODE: FILTER_MODE_UI}
+    assert _extract_selected_module_filter_modes(
+        user_input=user_input,
+        module_ids=["DEV1", "DEV2"],
+        default_mode=FILTER_MODE_UI,
+    ) == {"DEV1": FILTER_MODE_UI, "DEV2": FILTER_MODE_UI}
+
+
+def test_build_modules_step_schema_contains_modules_and_filter_mode() -> None:
+    schema = _build_modules_step_schema(
+        module_choices=[("DEV1", "Boiler")],
+        module_values={"DEV1": "Boiler"},
+        default_modules=["DEV1"],
+        module_filter_defaults={"DEV1": FILTER_MODE_UI},
+        filter_values=_entity_filter_mode_values(ui_language="en"),
+    )
+
+    parsed = schema(
+        {
+            CONF_MODULES: ["DEV1"],
+            CONF_ENTITY_FILTER_MODE: FILTER_MODE_UI,
+        },
+    )
+    assert parsed[CONF_MODULES] == ["DEV1"]
+
+
+def test_extract_language_label_handles_string_and_dict() -> None:
+    assert _extract_language_label(" English ", lang_id="en") == "English"
+    assert _extract_language_label({"en": "Polski", "de": "Deutsch"}, lang_id="en") == "Polski"
+    assert _extract_language_label({"de": "Deutsch"}, lang_id="en") == "Deutsch"
+    assert _extract_language_label(123, lang_id="en") is None
+
+
+def test_looks_like_language_code_label_detects_code_like_labels() -> None:
+    assert _looks_like_language_code_label("en", lang_id="en") is True
+    assert _looks_like_language_code_label("en US", lang_id="en") is True
+    assert _looks_like_language_code_label("English", lang_id="en") is False
+
+
+def test_language_label_from_row_prefers_native_name() -> None:
+    row = {"nativeName": "Polski", "name": "pl"}
+    assert _language_label_from_row(row, lang_id="pl") == "Polski"
+
+    fallback_row = {"name": "pl"}
+    assert _language_label_from_row(fallback_row, lang_id="pl") == "pl"
+
+
+def test_build_modules_step_schema_rejects_invalid_filter_mode() -> None:
+    schema = _build_modules_step_schema(
+        module_choices=[("DEV1", "Boiler")],
+        module_values={"DEV1": "Boiler"},
+        default_modules=["DEV1"],
+        module_filter_defaults={"DEV1": FILTER_MODE_UI},
+        filter_values=_entity_filter_mode_values(ui_language="en"),
+    )
+    try:
+        schema({CONF_MODULES: ["DEV1"], CONF_ENTITY_FILTER_MODE: "bad"})
+    except vol.Invalid:
+        return
+    raise AssertionError("Expected vol.Invalid for unknown filter mode")

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -6,7 +6,11 @@ from typing import Any
 
 import voluptuous as vol
 
-from custom_components.habragerone.config_flow import (
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.config_flow import (  # noqa: E402
     _build_modules_step_schema,
     _entity_filter_mode_values,
     _extract_language_label,
@@ -16,7 +20,7 @@ from custom_components.habragerone.config_flow import (
     _module_choices,
     _ui_field_labels,
 )
-from custom_components.habragerone.const import CONF_ENTITY_FILTER_MODE, CONF_MODULES, FILTER_MODE_UI
+from custom_components.habragerone.const import CONF_ENTITY_FILTER_MODE, CONF_MODULES, FILTER_MODE_UI  # noqa: E402
 
 
 def test_module_choices_skips_empty_devid_and_formats_label() -> None:

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -1,0 +1,290 @@
+"""Integration tests for Brager config/options/reauth flows."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant import config_entries
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.data_entry_flow import FlowResultType, InvalidData
+from pybragerone.api.client import ApiError
+from pytest_homeassistant_custom_component.common import MockConfigEntry, MockModule, mock_integration, mock_platform
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+import custom_components.habragerone.config_flow as config_flow_module  # noqa: E402
+from custom_components.habragerone.const import (  # noqa: E402
+    CONF_BACKEND_PLATFORM,
+    CONF_ENTITY_DESCRIPTORS,
+    CONF_ENTITY_FILTER_MODE,
+    CONF_LANGUAGE,
+    CONF_MODULES,
+    CONF_OBJECT_ID,
+    DOMAIN,
+    FILTER_MODE_UI,
+)
+from tests.helpers.config_flow import make_fake_api, patch_config_flow_dependencies  # noqa: E402
+
+_USER_INPUT = {
+    CONF_EMAIL: "user@example.com",
+    CONF_PASSWORD: "secret",
+    CONF_BACKEND_PLATFORM: "bragerone",
+    CONF_LANGUAGE: "en",
+}
+
+
+@pytest.fixture(autouse=True)
+def register_config_flow_platform(hass: HomeAssistant) -> None:
+    """Register the custom integration config flow handler with hass."""
+    mock_integration(hass, MockModule(DOMAIN), built_in=False)
+    mock_platform(hass, f"{DOMAIN}.config_flow", config_flow_module, built_in=False)
+
+
+from custom_components.habragerone.const import (  # noqa: E402
+    CONF_BACKEND_PLATFORM,
+    CONF_LANGUAGE,
+)
+
+_USER_INPUT = {
+    CONF_EMAIL: "user@example.com",
+    CONF_PASSWORD: "secret",
+    CONF_BACKEND_PLATFORM: "bragerone",
+    CONF_LANGUAGE: "en",
+}
+
+
+@pytest.mark.asyncio
+async def test_config_flow_user_step_shows_form(hass: HomeAssistant) -> None:
+    with patch_config_flow_dependencies():
+        result = await hass.config_entries.flow.async_init(DOMAIN, context={"source": config_entries.SOURCE_USER})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+
+
+@pytest.mark.asyncio
+async def test_config_flow_user_step_rejects_auth_error(hass: HomeAssistant) -> None:
+    api = make_fake_api(auth_error=True)
+    with patch_config_flow_dependencies(api=api):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=_USER_INPUT,
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "auth"}
+
+
+@pytest.mark.asyncio
+async def test_config_flow_user_step_rejects_invalid_language(hass: HomeAssistant) -> None:
+    with patch_config_flow_dependencies():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data={**_USER_INPUT, CONF_LANGUAGE: "xx"},
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "user"
+    assert result["errors"] == {"base": "invalid_response"}
+
+
+@pytest.mark.asyncio
+async def test_config_flow_happy_path_creates_entry(hass: HomeAssistant) -> None:
+    with patch_config_flow_dependencies() as (api, bootstrap_mock):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=_USER_INPUT,
+        )
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "select_site"
+
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_OBJECT_ID: 1})
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "select_modules"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MODULES: ["DEV1"], CONF_ENTITY_FILTER_MODE: FILTER_MODE_UI},
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["title"] == "user@example.com (bragerone, id=1)"
+    assert result["data"][CONF_EMAIL] == "user@example.com"
+    assert result["data"][CONF_OBJECT_ID] == 1
+    assert result["data"][CONF_MODULES] == ["DEV1"]
+    assert result["data"][CONF_ENTITY_DESCRIPTORS]
+    api.ensure_auth.assert_awaited()
+    bootstrap_mock.assert_awaited()
+
+
+@pytest.mark.asyncio
+async def test_config_flow_select_modules_rejects_invalid_filter_mode(hass: HomeAssistant) -> None:
+    with patch_config_flow_dependencies():
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=_USER_INPUT,
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_OBJECT_ID: 1})
+        with pytest.raises(InvalidData, match="Schema validation failed"):
+            await hass.config_entries.flow.async_configure(
+                result["flow_id"],
+                {CONF_MODULES: ["DEV1"], CONF_ENTITY_FILTER_MODE: "bad-mode"},
+            )
+
+
+@pytest.mark.asyncio
+async def test_config_flow_select_modules_handles_bootstrap_failure(hass: HomeAssistant) -> None:
+    with patch_config_flow_dependencies(bootstrap_error=RuntimeError("bootstrap failed")):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=_USER_INPUT,
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_OBJECT_ID: 1})
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_MODULES: ["DEV1"], CONF_ENTITY_FILTER_MODE: FILTER_MODE_UI},
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "select_modules"
+    assert result["errors"] == {"base": "invalid_response"}
+
+
+@pytest.mark.asyncio
+async def test_config_flow_reauth_updates_credentials(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "old-secret",
+            CONF_BACKEND_PLATFORM: "bragerone",
+            CONF_OBJECT_ID: 1,
+            CONF_MODULES: ["DEV1"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch_config_flow_dependencies():
+        result = await entry.start_reauth_flow(hass)
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "reauth_confirm"
+
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_EMAIL: "user@example.com", CONF_PASSWORD: "new-secret"},
+        )
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "reauth_successful"
+    assert entry.data[CONF_PASSWORD] == "new-secret"
+
+
+@pytest.mark.asyncio
+async def test_config_flow_reauth_shows_auth_error(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "old-secret",
+            CONF_BACKEND_PLATFORM: "bragerone",
+            CONF_OBJECT_ID: 1,
+            CONF_MODULES: ["DEV1"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    api = make_fake_api(auth_error=True)
+    with patch_config_flow_dependencies(api=api):
+        result = await entry.start_reauth_flow(hass)
+        result = await hass.config_entries.flow.async_configure(
+            result["flow_id"],
+            {CONF_EMAIL: "user@example.com", CONF_PASSWORD: "bad-secret"},
+        )
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "reauth_confirm"
+    assert result["errors"] == {"base": "auth"}
+
+
+@pytest.mark.asyncio
+async def test_options_flow_updates_module_scope(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "secret",
+            CONF_BACKEND_PLATFORM: "bragerone",
+            CONF_OBJECT_ID: 1,
+            CONF_MODULES: ["DEV1"],
+            CONF_ENTITY_FILTER_MODE: FILTER_MODE_UI,
+        },
+    )
+    entry.add_to_hass(hass)
+
+    with patch_config_flow_dependencies():
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "init"
+
+        result = await hass.config_entries.options.async_configure(result["flow_id"], {CONF_OBJECT_ID: 1})
+        assert result["type"] == FlowResultType.FORM
+        assert result["step_id"] == "modules"
+
+        result = await hass.config_entries.options.async_configure(
+            result["flow_id"],
+            {CONF_MODULES: ["DEV1"], CONF_ENTITY_FILTER_MODE: FILTER_MODE_UI},
+        )
+
+    assert result["type"] == FlowResultType.CREATE_ENTRY
+    assert result["data"][CONF_OBJECT_ID] == 1
+    assert result["data"][CONF_MODULES] == ["DEV1"]
+
+
+@pytest.mark.asyncio
+async def test_options_flow_aborts_when_no_objects(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "secret",
+            CONF_BACKEND_PLATFORM: "bragerone",
+            CONF_OBJECT_ID: 1,
+            CONF_MODULES: ["DEV1"],
+        },
+    )
+    entry.add_to_hass(hass)
+
+    api = make_fake_api(objects=[])
+    with patch_config_flow_dependencies(api=api):
+        result = await hass.config_entries.options.async_init(entry.entry_id)
+
+    assert result["type"] == FlowResultType.ABORT
+    assert result["reason"] == "invalid_response"
+
+
+@pytest.mark.asyncio
+async def test_config_flow_select_site_handles_module_api_error(hass: HomeAssistant) -> None:
+    api = make_fake_api()
+    api.get_modules = AsyncMock(side_effect=ApiError(503, {"message": "down"}))
+
+    with patch_config_flow_dependencies(api=api):
+        result = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={"source": config_entries.SOURCE_USER},
+            data=_USER_INPUT,
+        )
+        result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_OBJECT_ID: 1})
+
+    assert result["type"] == FlowResultType.FORM
+    assert result["step_id"] == "select_site"
+    assert result["errors"] == {"base": "cannot_connect"}

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -9,12 +9,13 @@ from homeassistant import config_entries
 from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
 from homeassistant.core import HomeAssistant
 from homeassistant.data_entry_flow import FlowResultType, InvalidData
-from pybragerone.api.client import ApiError
 from pytest_homeassistant_custom_component.common import MockConfigEntry, MockModule, mock_integration, mock_platform
 
 from tests.conftest import install_pybragerone_stubs
 
 install_pybragerone_stubs()
+
+from pybragerone.api.client import ApiError  # noqa: E402
 
 import custom_components.habragerone.config_flow as config_flow_module  # noqa: E402
 from custom_components.habragerone.const import (  # noqa: E402
@@ -121,7 +122,7 @@ async def test_config_flow_select_modules_rejects_invalid_filter_mode(hass: Home
             data=_USER_INPUT,
         )
         result = await hass.config_entries.flow.async_configure(result["flow_id"], {CONF_OBJECT_ID: 1})
-        with pytest.raises(InvalidData, match="Schema validation failed"):
+        with pytest.raises(InvalidData):
             await hass.config_entries.flow.async_configure(
                 result["flow_id"],
                 {CONF_MODULES: ["DEV1"], CONF_ENTITY_FILTER_MODE: "bad-mode"},

--- a/tests/test_config_flow_integration.py
+++ b/tests/test_config_flow_integration.py
@@ -44,19 +44,6 @@ def register_config_flow_platform(hass: HomeAssistant) -> None:
     mock_platform(hass, f"{DOMAIN}.config_flow", config_flow_module, built_in=False)
 
 
-from custom_components.habragerone.const import (  # noqa: E402
-    CONF_BACKEND_PLATFORM,
-    CONF_LANGUAGE,
-)
-
-_USER_INPUT = {
-    CONF_EMAIL: "user@example.com",
-    CONF_PASSWORD: "secret",
-    CONF_BACKEND_PLATFORM: "bragerone",
-    CONF_LANGUAGE: "en",
-}
-
-
 @pytest.mark.asyncio
 async def test_config_flow_user_step_shows_form(hass: HomeAssistant) -> None:
     with patch_config_flow_dependencies():


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds offline unit and integration tests for `config_flow.py` (user/options/reauth flows), stacked on PR #148.

## Changes

- `tests/test_config_flow_helpers.py` — helper function and schema validation tests
- `tests/test_config_flow_integration.py` — full flow integration tests with mocked API/catalog
- `tests/helpers/config_flow.py` — shared mocks and patch helpers
- `tests/conftest.py` — `Platform.TISCONNECT` stub

## Coverage

| Module | Coverage |
|--------|----------|
| config_flow | ~83% |
| **project** | **~71%** |

## Stack

```
main
 └── #148 PR3  cursor/test-coverage-platforms-pr3-b7ce
      └── #149 PR4  cursor/test-coverage-config-flow-b7ce
           └── #151 PR5  cursor/test-coverage-init-diagnostics-b7ce
```

## Review follow-ups (addressed)

- `make_fake_api()`: `ensure_auth` now returns `None` explicitly on the happy path
- Config flow test modules install `pybragerone` stubs before importing integration code
- Dropped brittle `InvalidData` message matching in integration tests
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

