### PR TITLE
test: __init__, diagnostics, and token_store coverage (PR5)

### DIFF
--- a/custom_components/habragerone/__init__.py
+++ b/custom_components/habragerone/__init__.py
@@ -221,26 +221,23 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
     await hass.config_entries.async_reload(entry.entry_id)
 
 
-async def async_migrate_entry(_hass: HomeAssistant, entry: ConfigEntry) -> bool:
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Migrate legacy entries to the current schema."""
+    if entry.version >= 2:
+        return True
+
     data: dict[str, Any] = dict(entry.data)
-    changed = False
+    legacy_renames = (
+        ("email", CONF_EMAIL),
+        ("password", CONF_PASSWORD),
+        ("object_id", CONF_OBJECT_ID),
+        ("modules", CONF_MODULES),
+    )
+    for legacy_key, conf_key in legacy_renames:
+        if legacy_key != conf_key and legacy_key in data and conf_key not in data:
+            data[conf_key] = data.pop(legacy_key)
 
-    if "email" in data and CONF_EMAIL not in data:
-        data[CONF_EMAIL] = data.pop("email")
-        changed = True
-    if "password" in data and CONF_PASSWORD not in data:
-        data[CONF_PASSWORD] = data.pop("password")
-        changed = True
-    if "object_id" in data and CONF_OBJECT_ID not in data:
-        data[CONF_OBJECT_ID] = data.pop("object_id")
-        changed = True
-    if "modules" in data and CONF_MODULES not in data:
-        data[CONF_MODULES] = data.pop("modules")
-        changed = True
-
-    if changed:
-        _hass.config_entries.async_update_entry(entry, data=data, version=2)
-        LOGGER.info("Migrated BragerOne config entry %s to version 2", entry.entry_id)
+    hass.config_entries.async_update_entry(entry, data=data, version=2)
+    LOGGER.info("Migrated BragerOne config entry %s to version 2", entry.entry_id)
 
     return True

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,10 +1,23 @@
 import asyncio
 import sys
 import types
+from datetime import datetime
+from typing import Any
 
 import pytest
+from pydantic import BaseModel, Field
 
 pytest.register_assert_rewrite("tests.test_sensor")
+
+
+class _TokenStub(BaseModel):
+    """Minimal Token stand-in for offline token_store tests."""
+
+    access_token: str | None = None
+    refresh_token: str | None = None
+    token_type: str = "bearer"
+    expires_at: datetime | None = None
+    objects: list[dict[str, Any]] = Field(default_factory=list)
 
 
 @pytest.fixture(autouse=True)
@@ -24,7 +37,7 @@ def install_pybragerone_stubs() -> None:
     pybragerone_stub.BragerOneApiClient = object
     pybragerone_stub.BragerOneGateway = object
     pybragerone_stub.__path__ = []
-    sys.modules.setdefault("pybragerone", pybragerone_stub)
+    sys.modules["pybragerone"] = pybragerone_stub
 
     pybragerone_api_stub = types.ModuleType("pybragerone.api")
     pybragerone_api_stub.__path__ = []
@@ -70,3 +83,7 @@ def install_pybragerone_stubs() -> None:
     pybragerone_models_catalog_stub = types.ModuleType("pybragerone.models.catalog")
     pybragerone_models_catalog_stub.LiveAssetsCatalog = object
     sys.modules.setdefault("pybragerone.models.catalog", pybragerone_models_catalog_stub)
+
+    pybragerone_models_token_stub = types.ModuleType("pybragerone.models.token")
+    pybragerone_models_token_stub.Token = _TokenStub
+    sys.modules.setdefault("pybragerone.models.token", pybragerone_models_token_stub)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -86,4 +86,4 @@ def install_pybragerone_stubs() -> None:
 
     pybragerone_models_token_stub = types.ModuleType("pybragerone.models.token")
     pybragerone_models_token_stub.Token = _TokenStub
-    sys.modules.setdefault("pybragerone.models.token", pybragerone_models_token_stub)
+    sys.modules["pybragerone.models.token"] = pybragerone_models_token_stub

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -33,6 +33,13 @@ def enable_event_loop_debug() -> None:
 
 def install_pybragerone_stubs() -> None:
     """Install stub modules for optional `pybragerone` imports used by unit tests."""
+    if getattr(install_pybragerone_stubs, "_installed", False):
+        return
+
+    for module_name in list(sys.modules):
+        if module_name == "pybragerone" or module_name.startswith("pybragerone."):
+            del sys.modules[module_name]
+
     pybragerone_stub = types.ModuleType("pybragerone")
     pybragerone_stub.BragerOneApiClient = object
     pybragerone_stub.BragerOneGateway = object
@@ -41,7 +48,7 @@ def install_pybragerone_stubs() -> None:
 
     pybragerone_api_stub = types.ModuleType("pybragerone.api")
     pybragerone_api_stub.__path__ = []
-    sys.modules.setdefault("pybragerone.api", pybragerone_api_stub)
+    sys.modules["pybragerone.api"] = pybragerone_api_stub
 
     pybragerone_api_server_stub = types.ModuleType("pybragerone.api.server")
 
@@ -54,7 +61,7 @@ def install_pybragerone_stubs() -> None:
 
     pybragerone_api_server_stub.Platform = _Platform
     pybragerone_api_server_stub.server_for = _server_for
-    sys.modules.setdefault("pybragerone.api.server", pybragerone_api_server_stub)
+    sys.modules["pybragerone.api.server"] = pybragerone_api_server_stub
 
     pybragerone_api_client_stub = types.ModuleType("pybragerone.api.client")
 
@@ -62,28 +69,30 @@ def install_pybragerone_stubs() -> None:
         pass
 
     pybragerone_api_client_stub.ApiError = _ApiError
-    sys.modules.setdefault("pybragerone.api.client", pybragerone_api_client_stub)
+    sys.modules["pybragerone.api.client"] = pybragerone_api_client_stub
 
     pybragerone_models_stub = types.ModuleType("pybragerone.models")
     pybragerone_models_stub.__path__ = []
-    sys.modules.setdefault("pybragerone.models", pybragerone_models_stub)
+    sys.modules["pybragerone.models"] = pybragerone_models_stub
 
     pybragerone_models_param_stub = types.ModuleType("pybragerone.models.param")
     pybragerone_models_param_stub.ParamStore = object
-    sys.modules.setdefault("pybragerone.models.param", pybragerone_models_param_stub)
+    sys.modules["pybragerone.models.param"] = pybragerone_models_param_stub
 
     pybragerone_models_param_resolver_stub = types.ModuleType("pybragerone.models.param_resolver")
     pybragerone_models_param_resolver_stub.ParamResolver = object
-    sys.modules.setdefault("pybragerone.models.param_resolver", pybragerone_models_param_resolver_stub)
+    sys.modules["pybragerone.models.param_resolver"] = pybragerone_models_param_resolver_stub
 
     pybragerone_models_events_stub = types.ModuleType("pybragerone.models.events")
     pybragerone_models_events_stub.ParamUpdate = object
-    sys.modules.setdefault("pybragerone.models.events", pybragerone_models_events_stub)
+    sys.modules["pybragerone.models.events"] = pybragerone_models_events_stub
 
     pybragerone_models_catalog_stub = types.ModuleType("pybragerone.models.catalog")
     pybragerone_models_catalog_stub.LiveAssetsCatalog = object
-    sys.modules.setdefault("pybragerone.models.catalog", pybragerone_models_catalog_stub)
+    sys.modules["pybragerone.models.catalog"] = pybragerone_models_catalog_stub
 
     pybragerone_models_token_stub = types.ModuleType("pybragerone.models.token")
     pybragerone_models_token_stub.Token = _TokenStub
     sys.modules["pybragerone.models.token"] = pybragerone_models_token_stub
+
+    install_pybragerone_stubs._installed = True  # type: ignore[attr-defined]

--- a/tests/helpers/init_setup.py
+++ b/tests/helpers/init_setup.py
@@ -1,0 +1,94 @@
+"""Shared mocks for integration setup/unload tests."""
+
+from __future__ import annotations
+
+import ssl
+from contextlib import contextmanager
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.habragerone.const import (
+    BOOTSTRAP_VERSION,
+    CONF_BACKEND_PLATFORM,
+    CONF_BOOTSTRAP_VERSION,
+    CONF_ENTITY_DESCRIPTORS,
+    CONF_MODULES,
+    CONF_MODULES_META,
+    CONF_OBJECT_ID,
+    DOMAIN,
+)
+from tests.helpers.config_flow import make_bootstrap_payload
+
+
+def _fake_ssl_context() -> ssl.SSLContext:
+    return ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+
+
+def make_config_entry(
+    *,
+    entry_id: str = "test-entry-id",
+    data: dict[str, Any] | None = None,
+    options: dict[str, Any] | None = None,
+) -> MockConfigEntry:
+    """Build a config entry with a complete cached bootstrap payload."""
+    bootstrap = make_bootstrap_payload()
+    entry_data: dict[str, Any] = {
+        CONF_EMAIL: "user@example.com",
+        CONF_PASSWORD: "secret",
+        CONF_BACKEND_PLATFORM: "bragerone",
+        CONF_OBJECT_ID: 1,
+        CONF_MODULES: ["DEV1"],
+        CONF_BOOTSTRAP_VERSION: BOOTSTRAP_VERSION,
+        CONF_MODULES_META: bootstrap[CONF_MODULES_META],
+        CONF_ENTITY_DESCRIPTORS: bootstrap[CONF_ENTITY_DESCRIPTORS],
+    }
+    if data:
+        entry_data.update(data)
+    return MockConfigEntry(entry_id=entry_id, domain=DOMAIN, data=entry_data, options=options or {})
+
+
+@contextmanager
+def patch_setup_dependencies(
+    *,
+    api: AsyncMock | None = None,
+    bootstrap_payload: dict[str, Any] | None = None,
+    runtime: Any | None = None,
+):
+    """Patch collaborators used by async_setup_entry."""
+    if api is None:
+        fake_api = MagicMock()
+        fake_api.ensure_auth = AsyncMock(return_value=None)
+    else:
+        fake_api = api
+    fake_api.close = AsyncMock()
+
+    fake_gateway = MagicMock()
+    fake_store = MagicMock()
+    fake_runtime = runtime or MagicMock()
+    fake_runtime.start = AsyncMock()
+    fake_runtime.stop = AsyncMock()
+
+    bootstrap_result = bootstrap_payload if bootstrap_payload is not None else make_bootstrap_payload()
+    bootstrap_mock = AsyncMock(return_value=bootstrap_result)
+
+    def _api_factory(**_kwargs: object) -> MagicMock:
+        return fake_api
+
+    with (
+        patch("custom_components.habragerone.BragerOneApiClient", side_effect=_api_factory),
+        patch("custom_components.habragerone.BragerOneGateway", return_value=fake_gateway),
+        patch("custom_components.habragerone.ParamStore", return_value=fake_store),
+        patch("custom_components.habragerone.BragerRuntime", return_value=fake_runtime),
+        patch("custom_components.habragerone.async_build_bootstrap_payload", bootstrap_mock),
+        patch("custom_components.habragerone._build_ssl_context", _fake_ssl_context),
+    ):
+        yield {
+            "api": fake_api,
+            "gateway": fake_gateway,
+            "store": fake_store,
+            "runtime": fake_runtime,
+            "bootstrap": bootstrap_mock,
+        }

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -1,0 +1,111 @@
+"""Tests for diagnostics payload generation."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.const import CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.const import (  # noqa: E402
+    CONF_ENTITY_DESCRIPTORS,
+    DATA_DIAGNOSTIC_TREND,
+    DATA_ENTITY_STATS,
+    DOMAIN,
+)
+from custom_components.habragerone.diagnostics import async_get_config_entry_diagnostics  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_redacts_password_and_reports_aligned_health(hass: HomeAssistant) -> None:
+    runtime = object()
+    descriptors = [
+        {"platform": "sensor", "symbol": "TEMP", "writable": False},
+        {"platform": "switch", "symbol": "SW1", "writable": True},
+        {
+            "platform": "select",
+            "symbol": "MODE",
+            "writable": True,
+            "enum_map": {"0": "Eco", "1": "Comfort"},
+        },
+    ]
+    stats = {
+        "sensor": {"descriptor_count": 1, "created_count": 1},
+        "switch": {"descriptor_count": 1, "created_count": 1},
+        "select": {"descriptor_count": 1, "created_count": 1},
+    }
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors, entity_stats=stats)
+
+    payload = await async_get_config_entry_diagnostics(hass, entry)
+
+    assert payload["entry"][CONF_PASSWORD] == "**REDACTED**"
+    summary = payload["descriptor_summary"]
+    assert summary["total"] == 3
+    assert summary["writable"] == 2
+    assert summary["enum_mapped"] == 1
+    assert summary["health_status"] == "ok"
+    assert summary["severity_level"] == "none"
+    assert summary["health_hints"] == ["Descriptor classification and created entity counts are aligned."]
+    assert "sensor" in summary["sample_symbols_by_platform"]
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_reports_warning_when_entity_counts_mismatch(hass: HomeAssistant) -> None:
+    runtime = object()
+    descriptors = [
+        {"platform": "sensor", "symbol": "TEMP"},
+        {"platform": "switch", "symbol": "SW1"},
+    ]
+    stats = {
+        "sensor": {"descriptor_count": 2, "created_count": 1},
+        "switch": {"descriptor_count": 1, "created_count": 0},
+    }
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors, entity_stats=stats)
+
+    payload = await async_get_config_entry_diagnostics(hass, entry)
+    summary = payload["descriptor_summary"]
+
+    assert summary["health_status"] == "warning"
+    assert summary["descriptor_vs_created_mismatch"] is True
+    assert "switch" in summary["mismatched_platforms"]
+    assert summary["severity_level"] in {"minor", "major"}
+    assert any("Reload config entry" in hint for hint in summary["health_hints"])
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_tracks_trend_and_detects_regression(hass: HomeAssistant) -> None:
+    runtime = object()
+    descriptors = [{"platform": "sensor", "symbol": "TEMP"}]
+    stats = {"sensor": {"descriptor_count": 1, "created_count": 1}}
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors, entity_stats=stats)
+
+    first = await async_get_config_entry_diagnostics(hass, entry)
+    assert first["descriptor_summary"]["trend"]["diff_summary"]["trend_direction"] == "unknown"
+
+    runtime_data = hass.data[DOMAIN][entry.entry_id]
+    runtime_data[DATA_ENTITY_STATS] = {"sensor": {"descriptor_count": 1, "created_count": 0}}
+    runtime_data[CONF_ENTITY_DESCRIPTORS] = descriptors
+
+    second = await async_get_config_entry_diagnostics(hass, entry)
+    trend = second["descriptor_summary"]["trend"]
+    assert trend["changed_since_previous"] is True
+    assert trend["diff_summary"]["health_status_changed"] is True
+    assert trend["diff_summary"]["trend_direction"] == "regressed"
+    assert DATA_DIAGNOSTIC_TREND in runtime_data
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_reports_unknown_platforms(hass: HomeAssistant) -> None:
+    runtime = object()
+    descriptors = [{"platform": "climate", "symbol": "HVAC"}]
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
+
+    payload = await async_get_config_entry_diagnostics(hass, entry)
+    summary = payload["descriptor_summary"]
+
+    assert summary["unknown_platforms"] == {"climate": 1}
+    assert "climate" not in summary["platform_breakdown"]

--- a/tests/test_init_helpers.py
+++ b/tests/test_init_helpers.py
@@ -1,0 +1,42 @@
+"""Tests for integration setup helper functions."""
+
+from __future__ import annotations
+
+import ssl
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.__init__ import (  # noqa: E402
+    _build_ssl_context,
+    _descriptors_require_refresh,
+)
+
+
+def test_descriptors_require_refresh_rejects_non_list() -> None:
+    assert _descriptors_require_refresh(None) is True
+    assert _descriptors_require_refresh({"symbol": "X"}) is True
+
+
+def test_descriptors_require_refresh_select_without_options() -> None:
+    descriptors = [{"platform": "select", "symbol": "MODE"}]
+    assert _descriptors_require_refresh(descriptors) is True
+
+
+def test_descriptors_require_refresh_select_with_empty_options() -> None:
+    descriptors = [{"platform": "select", "symbol": "MODE", "options": []}]
+    assert _descriptors_require_refresh(descriptors) is True
+
+
+def test_descriptors_require_refresh_accepts_valid_cached_payload() -> None:
+    descriptors = [
+        {"platform": "sensor", "symbol": "TEMP"},
+        {"platform": "select", "symbol": "MODE", "options": ["Eco", "Comfort"]},
+    ]
+    assert _descriptors_require_refresh(descriptors) is False
+
+
+def test_build_ssl_context_returns_default_context() -> None:
+    context = _build_ssl_context()
+    assert isinstance(context, ssl.SSLContext)

--- a/tests/test_init_lifecycle.py
+++ b/tests/test_init_lifecycle.py
@@ -176,27 +176,35 @@ async def test_async_update_listener_reloads_entry(hass: HomeAssistant) -> None:
 
 
 @pytest.mark.asyncio
-async def test_async_migrate_entry_returns_true_for_legacy_style_entry(hass: HomeAssistant) -> None:
+async def test_async_migrate_entry_bumps_legacy_v1_entry_to_version_2(hass: HomeAssistant) -> None:
     entry = MockConfigEntry(
         domain=DOMAIN,
         data={
-            CONF_EMAIL: "user@example.com",
-            CONF_PASSWORD: "secret",
-            CONF_OBJECT_ID: 1,
-            CONF_MODULES: ["DEV1"],
+            "email": "user@example.com",
+            "password": "secret",
+            "object_id": 1,
+            "modules": ["DEV1"],
         },
         version=1,
     )
     entry.add_to_hass(hass)
 
     assert await async_migrate_entry(hass, entry) is True
+    assert entry.version == 2
+    assert entry.data[CONF_EMAIL] == "user@example.com"
+    assert entry.data[CONF_PASSWORD] == "secret"
+    assert entry.data[CONF_OBJECT_ID] == 1
+    assert entry.data[CONF_MODULES] == ["DEV1"]
 
 
 @pytest.mark.asyncio
 async def test_async_migrate_entry_noop_when_already_current(hass: HomeAssistant) -> None:
     entry = make_config_entry()
     entry.add_to_hass(hass)
+    hass.config_entries.async_update_entry(entry, version=2)
     before = dict(entry.data)
+    before_version = entry.version
 
     assert await async_migrate_entry(hass, entry) is True
     assert entry.data == before
+    assert entry.version == before_version

--- a/tests/test_init_lifecycle.py
+++ b/tests/test_init_lifecycle.py
@@ -1,0 +1,202 @@
+"""Tests for integration setup, unload, and migration."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from homeassistant.const import CONF_EMAIL, CONF_PASSWORD
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import ConfigEntryNotReady
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone import (  # noqa: E402
+    _async_update_listener,
+    async_migrate_entry,
+    async_setup_entry,
+    async_unload_entry,
+)
+from custom_components.habragerone.const import (  # noqa: E402
+    BOOTSTRAP_VERSION,
+    CONF_BACKEND_PLATFORM,
+    CONF_BOOTSTRAP_VERSION,
+    CONF_ENTITY_DESCRIPTORS,
+    CONF_MODULES,
+    CONF_MODULES_META,
+    CONF_OBJECT_ID,
+    DATA_RUNTIME,
+    DOMAIN,
+)
+from tests.helpers.config_flow import make_bootstrap_payload  # noqa: E402
+from tests.helpers.fakes import make_runtime  # noqa: E402
+from tests.helpers.init_setup import make_config_entry, patch_setup_dependencies  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_uses_cached_bootstrap(hass: HomeAssistant) -> None:
+    entry = make_config_entry()
+    entry.add_to_hass(hass)
+
+    with patch_setup_dependencies() as deps, patch.object(hass.config_entries, "async_forward_entry_setups", new=AsyncMock()):
+        assert await async_setup_entry(hass, entry) is True
+
+    deps["api"].ensure_auth.assert_awaited_once()
+    deps["runtime"].start.assert_awaited_once()
+    deps["bootstrap"].assert_not_awaited()
+    assert DATA_RUNTIME in hass.data[DOMAIN][entry.entry_id]
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_refreshes_when_options_changed(hass: HomeAssistant) -> None:
+    entry = make_config_entry(options={CONF_OBJECT_ID: 2, CONF_MODULES: ["DEV2"]})
+    entry.add_to_hass(hass)
+    bootstrap_payload = make_bootstrap_payload()
+
+    with (
+        patch_setup_dependencies(bootstrap_payload=bootstrap_payload) as deps,
+        patch.object(hass.config_entries, "async_forward_entry_setups", new=AsyncMock()),
+    ):
+        assert await async_setup_entry(hass, entry) is True
+
+    deps["bootstrap"].assert_awaited_once()
+    assert entry.data[CONF_OBJECT_ID] == 2
+    assert entry.data[CONF_MODULES] == ["DEV2"]
+    assert entry.data[CONF_BOOTSTRAP_VERSION] == BOOTSTRAP_VERSION
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_refreshes_when_cached_bootstrap_missing(hass: HomeAssistant) -> None:
+    entry = make_config_entry(data={CONF_MODULES_META: None, CONF_BOOTSTRAP_VERSION: None})
+    entry.add_to_hass(hass)
+
+    with patch_setup_dependencies() as deps, patch.object(hass.config_entries, "async_forward_entry_setups", new=AsyncMock()):
+        assert await async_setup_entry(hass, entry) is True
+
+    deps["bootstrap"].assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_normalizes_cached_descriptors(hass: HomeAssistant) -> None:
+    entry = make_config_entry(
+        data={
+            CONF_ENTITY_DESCRIPTORS: [
+                {
+                    "symbol": "PARAM_P5_40",
+                    "devid": "MOD1",
+                    "pool": "P5",
+                    "chan": "s",
+                    "idx": 40,
+                    "platform": "sensor",
+                    "mapping": {},
+                    "writable": False,
+                }
+            ]
+        }
+    )
+    entry.add_to_hass(hass)
+
+    with patch_setup_dependencies(), patch.object(hass.config_entries, "async_forward_entry_setups", new=AsyncMock()):
+        assert await async_setup_entry(hass, entry) is True
+
+    stored = entry.data[CONF_ENTITY_DESCRIPTORS]
+    assert isinstance(stored, list)
+    assert stored[0]["platform"] == "binary_sensor"
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_raises_when_auth_fails(hass: HomeAssistant) -> None:
+    entry = make_config_entry()
+    entry.add_to_hass(hass)
+    api = AsyncMock()
+    api.ensure_auth = AsyncMock(side_effect=RuntimeError("auth failed"))
+
+    with patch_setup_dependencies(api=api), pytest.raises(ConfigEntryNotReady, match="Authentication failed"):
+        await async_setup_entry(hass, entry)
+
+
+@pytest.mark.asyncio
+async def test_async_setup_entry_raises_for_unsupported_platform(hass: HomeAssistant) -> None:
+    entry = make_config_entry(data={CONF_BACKEND_PLATFORM: "unknown"})
+    entry.add_to_hass(hass)
+
+    with (
+        patch("custom_components.habragerone.server_for", side_effect=ValueError("bad platform")),
+        pytest.raises(ConfigEntryNotReady, match="Unsupported backend platform"),
+    ):
+        await async_setup_entry(hass, entry)
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_stops_runtime_and_clears_domain_data(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    entry = make_config_entry()
+    entry.add_to_hass(hass)
+    hass.data[DOMAIN] = {entry.entry_id: {DATA_RUNTIME: runtime}}
+
+    with patch.object(hass.config_entries, "async_unload_platforms", new=AsyncMock(return_value=True)):
+        assert await async_unload_entry(hass, entry) is True
+
+    assert entry.entry_id not in hass.data.get(DOMAIN, {})
+    assert DOMAIN not in hass.data
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_returns_false_when_platform_unload_fails(hass: HomeAssistant) -> None:
+    entry = make_config_entry()
+    entry.add_to_hass(hass)
+    hass.data[DOMAIN] = {entry.entry_id: {DATA_RUNTIME: make_runtime()[0]}}
+
+    with patch.object(hass.config_entries, "async_unload_platforms", new=AsyncMock(return_value=False)):
+        assert await async_unload_entry(hass, entry) is False
+
+
+@pytest.mark.asyncio
+async def test_async_unload_entry_without_domain_data(hass: HomeAssistant) -> None:
+    entry = make_config_entry()
+    entry.add_to_hass(hass)
+
+    with patch.object(hass.config_entries, "async_unload_platforms", new=AsyncMock(return_value=True)):
+        assert await async_unload_entry(hass, entry) is True
+
+
+@pytest.mark.asyncio
+async def test_async_update_listener_reloads_entry(hass: HomeAssistant) -> None:
+    entry = make_config_entry()
+    entry.add_to_hass(hass)
+    reload_mock = AsyncMock()
+
+    with patch.object(hass.config_entries, "async_reload", reload_mock):
+        await _async_update_listener(hass, entry)
+
+    reload_mock.assert_awaited_once_with(entry.entry_id)
+
+
+@pytest.mark.asyncio
+async def test_async_migrate_entry_returns_true_for_legacy_style_entry(hass: HomeAssistant) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        data={
+            CONF_EMAIL: "user@example.com",
+            CONF_PASSWORD: "secret",
+            CONF_OBJECT_ID: 1,
+            CONF_MODULES: ["DEV1"],
+        },
+        version=1,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+
+@pytest.mark.asyncio
+async def test_async_migrate_entry_noop_when_already_current(hass: HomeAssistant) -> None:
+    entry = make_config_entry()
+    entry.add_to_hass(hass)
+    before = dict(entry.data)
+
+    assert await async_migrate_entry(hass, entry) is True
+    assert entry.data == before

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -6,11 +6,12 @@ from datetime import UTC, datetime
 
 import pytest
 from homeassistant.core import HomeAssistant
-from pybragerone.models.token import Token
 
 from tests.conftest import install_pybragerone_stubs
 
 install_pybragerone_stubs()
+
+from pybragerone.models.token import Token  # noqa: E402
 
 from custom_components.habragerone.token_store import HATokenStore  # noqa: E402
 

--- a/tests/test_token_store.py
+++ b/tests/test_token_store.py
@@ -1,0 +1,73 @@
+"""Tests for HA token persistence helper."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from homeassistant.core import HomeAssistant
+from pybragerone.models.token import Token
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.token_store import HATokenStore  # noqa: E402
+
+
+@pytest.mark.asyncio
+async def test_token_store_load_returns_none_when_empty(hass: HomeAssistant) -> None:
+    store = HATokenStore(hass, "entry-1")
+    assert await store.load() is None
+
+
+@pytest.mark.asyncio
+async def test_token_store_roundtrip_and_clear(hass: HomeAssistant) -> None:
+    store = HATokenStore(hass, "entry-2")
+    token = Token(
+        access_token="access-123",
+        refresh_token="refresh-456",
+        token_type="bearer",
+        expires_at=datetime(2030, 1, 1, tzinfo=UTC),
+        objects=[{"id": 1, "name": "Site"}],
+    )
+
+    await store.save(token)
+    loaded = await store.load()
+
+    assert loaded is not None
+    assert loaded.access_token == "access-123"
+    assert loaded.refresh_token == "refresh-456"
+    assert loaded.token_type == "bearer"
+    assert loaded.objects == [{"id": 1, "name": "Site"}]
+
+    await store.clear()
+    assert await store.load() is None
+
+
+@pytest.mark.asyncio
+async def test_token_store_load_accepts_legacy_camel_case_keys(hass: HomeAssistant) -> None:
+    store = HATokenStore(hass, "entry-3")
+    await store._store().async_save(
+        {
+            "accessToken": "legacy-access",
+            "refreshToken": "legacy-refresh",
+            "type": "Bearer",
+            "expiresAt": "2030-01-01T00:00:00+00:00",
+            "objects": [],
+        }
+    )
+
+    loaded = await store.load()
+    assert loaded is not None
+    assert loaded.access_token == "legacy-access"
+    assert loaded.refresh_token == "legacy-refresh"
+    assert loaded.token_type == "Bearer"
+
+
+@pytest.mark.asyncio
+async def test_token_store_load_returns_none_for_invalid_payload(hass: HomeAssistant) -> None:
+    store = HATokenStore(hass, "entry-4")
+    await store._store().async_save("not-a-dict")
+
+    assert await store.load() is None


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Final coverage pass for the integration lifecycle layer: `__init__.py` setup/unload/migration, `diagnostics.py` health/trend reporting, and `token_store.py` HA persistence. Stacked on PR #149 (config_flow).

## Coverage

| Module | Before | After |
|--------|--------|-------|
| `__init__.py` | ~13% | **~87%** |
| `diagnostics.py` | 0% | **~83%** |
| `token_store.py` | 0% | **~94%** |
| **project** | ~71% | **~81%** |

199 tests total.

## Stack

```
main
 └── #148 PR3  platforms
      └── #149 PR4  config_flow
           └── #151 PR5  __init__ / diagnostics / token_store
```

## Review follow-ups (addressed)

- `test_token_store.py`: stubs installed before `Token` import
- `conftest.py`: deterministic pybragerone stub install (clear `sys.modules` once)
- `async_migrate_entry`: v1 entries now bump to version 2; migration test uses legacy string keys (`email`, `password`, …) instead of misleading `CONF_*` fixture
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

