### PR TITLE
test+chore: coverage tests and 80% pre-push gate (align with py-bragerone)

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -13,4 +13,4 @@ applyTo: "tests/**/*.py"
    - command route selection (`parameter_write` vs `raw_command`).
 4. **Bootstrap**: classification/filtering changes need descriptor fixtures covering each platform type.
 5. **Naming tests**: entity naming/unique_id patterns are contractual — keep regression tests for them.
-6. **Style**: same ruff/mypy rules as the integration; coverage gate is `--cov-fail-under=70` (pre-push). CI uploads to Codecov (patch target 100%, project informational).
+6. **Style**: same ruff/mypy rules as the integration; coverage gate is `--cov-fail-under=80` (pre-push). CI uploads to Codecov (patch target 100%, project informational).

--- a/.github/skills/code-review/SKILL.md
+++ b/.github/skills/code-review/SKILL.md
@@ -45,7 +45,7 @@ Review procedure for pull requests to this Home Assistant integration. Work thro
 
 - [ ] Write-path changes include the mandatory conversion/bounds/route tests (see `.github/instructions/tests.instructions.md`).
 - [ ] Bootstrap classification changes have per-platform descriptor fixtures.
-- [ ] Suite passes offline; coverage gate (70%) not weakened.
+- [ ] Suite passes offline; coverage gate (80%) not weakened.
 
 ## 7. Security
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -88,6 +88,6 @@ repos:
       - id: pytest-pre-push
         name: pytest (coverage gate on push)
         language: system
-        entry: bash -lc 'uv run --group test pytest --maxfail=1 --disable-warnings -q --cov=custom_components.habragerone --cov-report=term-missing --cov-fail-under=70'
+        entry: bash -lc 'uv run --group test pytest --maxfail=1 --disable-warnings -q --cov=custom_components.habragerone --cov-report=term-missing --cov-fail-under=80'
         pass_filenames: false
         stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,11 +17,11 @@ uv run poe fmt                   # ruff format
 uv run poe lint                  # ruff check --fix
 uv run poe typecheck             # mypy --strict (python_version 3.14, pydantic plugin)
 uv run poe test                  # pytest (pytest-homeassistant-custom-component)
-uv run poe cov                   # coverage report (the 70% threshold is enforced only by the pre-push hook)
+uv run poe cov                   # coverage report (the 80% threshold is enforced only by the pre-push hook)
 uv run poe validate              # fmt + lint + typecheck + security + test
 ```
 
-CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable. CI uploads `coverage.xml` to Codecov (`codecov-commenter` on PRs; skip Dependabot/Renovate and forks). Patch coverage target is 100%; project coverage is informational — the 70% floor stays on pre-push. Same-repo PRs re-request GitHub Copilot review via `.github/workflows/copilot-rerequest.yml` (`COPILOT_REVIEW_TOKEN`).
+CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable. CI uploads `coverage.xml` to Codecov (`codecov-commenter` on PRs; skip Dependabot/Renovate and forks). Patch coverage target is 100%; project coverage is informational — the 80% floor stays on pre-push. Same-repo PRs re-request GitHub Copilot review via `.github/workflows/copilot-rerequest.yml` (`COPILOT_REVIEW_TOKEN`).
 
 ## Architecture in one paragraph
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -13,8 +13,11 @@ This project uses:
 # Install dependencies
 uv sync --group dev --group test
 
-# Install pre-commit hooks
+# Install pre-commit hooks (commit-stage checks)
 uv run pre-commit install
+
+# Install pre-push hook (80% coverage gate on git push)
+uv run pre-commit install --hook-type pre-push
 
 # Start development environment
 docker-compose up -d
@@ -30,7 +33,7 @@ uv run pytest
 uv run pytest --cov=custom_components.habragerone --cov-report=term-missing
 ```
 
-CI uploads `coverage.xml` to Codecov (skipped for Dependabot/Renovate and fork PRs). Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational (the 80% floor is the pre-push hook).
+CI uploads `coverage.xml` to Codecov (skipped for Dependabot/Renovate and fork PRs). Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational (the 80% floor is the pre-push hook — see setup commands above).
 
 Same-repo PRs also re-request GitHub Copilot code review (`.github/workflows/copilot-rerequest.yml`, secret `COPILOT_REVIEW_TOKEN`). Issue and PR templates live under `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -30,7 +30,7 @@ uv run pytest
 uv run pytest --cov=custom_components.habragerone --cov-report=term-missing
 ```
 
-CI uploads `coverage.xml` to Codecov (skipped for Dependabot/Renovate and fork PRs). Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational (the 70% floor is the pre-push hook).
+CI uploads `coverage.xml` to Codecov (skipped for Dependabot/Renovate and fork PRs). Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational (the 80% floor is the pre-push hook).
 
 Same-repo PRs also re-request GitHub Copilot code review (`.github/workflows/copilot-rerequest.yml`, secret `COPILOT_REVIEW_TOKEN`). Issue and PR templates live under `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`.
 

--- a/tests/test_bootstrap_helpers.py
+++ b/tests/test_bootstrap_helpers.py
@@ -1,0 +1,148 @@
+"""Unit tests for bootstrap helper functions."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.bootstrap import (  # noqa: E402
+    _coerce_raw,
+    _command_rule_names,
+    _enum_maps,
+    _extract_symbol_token,
+    _has_display_value,
+    _has_named_command_rule,
+    _has_runtime_raw_value,
+    _is_action_command_name,
+    _is_boiler_panel,
+    _is_command_like_symbol,
+    normalize_cached_descriptors,
+)
+
+
+def test_extract_symbol_token_reads_nested_mapping_and_object_fields() -> None:
+    assert _extract_symbol_token("PARAM_1") == "PARAM_1"
+    assert _extract_symbol_token("bad token") is None
+    assert _extract_symbol_token({"token": "COMMAND_RESTART"}) == "COMMAND_RESTART"
+    assert _extract_symbol_token({"parameter": {"token": "STATUS_P1_0"}}) == "STATUS_P1_0"
+    assert _extract_symbol_token({"symbol": "PARAM_2"}) == "PARAM_2"
+    assert _extract_symbol_token(SimpleNamespace(token="PARAM_3")) == "PARAM_3"
+    assert _extract_symbol_token(SimpleNamespace(parameter=SimpleNamespace(name="PARAM_4"))) == "PARAM_4"
+
+
+def test_extract_symbol_token_respects_recursion_depth() -> None:
+    nested: dict[str, object] = {}
+    current = nested
+    for _ in range(5):
+        child: dict[str, object] = {"parameter": {}}
+        current["parameter"] = child
+        current = child
+    current["parameter"] = {"token": "PARAM_DEEP"}
+
+    assert _extract_symbol_token(nested) is None
+
+
+def test_coerce_raw_parses_bool_int_float_and_text() -> None:
+    assert _coerce_raw(True) is True
+    assert _coerce_raw(3.5) == 3.5
+    assert _coerce_raw("true") is True
+    assert _coerce_raw("42") == 42
+    assert _coerce_raw("3.14") == 3.14
+    assert _coerce_raw("plain") == "plain"
+
+
+def test_enum_maps_builds_from_units_source_and_descriptor_unit() -> None:
+    enum_map, raw_to_label = _enum_maps(
+        {"units_source": {"0": "Off", "1": "On"}, "values": [0, 1]},
+    )
+    assert enum_map == {"Off": 0, "On": 1}
+    assert raw_to_label == {"0": "Off", "1": "On"}
+
+    enum_map, raw_to_label = _enum_maps(
+        {},
+        descriptor_unit={"1": "Low", "2": "High"},
+    )
+    assert enum_map == {"Low": 1, "High": 2}
+    assert raw_to_label == {"1": "Low", "2": "High"}
+
+
+def test_runtime_visibility_helpers() -> None:
+    assert _has_display_value(value=None, value_label="  ready  ") is True
+    assert _has_display_value(value="  ", value_label=None) is False
+    assert _has_display_value(value=0, value_label=None) is True
+
+    assert _has_runtime_raw_value(
+        payload={"pool": "P4", "chan": "v", "idx": 1},
+        mapping=None,
+        flat_values={"P4.v1": 12},
+    )
+    assert _has_runtime_raw_value(
+        payload={"pool": "P4", "chan": "v", "idx": 1},
+        mapping={"inputs": [{"address": "P4.s2"}]},
+        flat_values={"P4.s2": 1},
+    )
+    assert not _has_runtime_raw_value(
+        payload={"pool": "P4", "chan": "v", "idx": 1},
+        mapping={"inputs": [{"address": "P4.s2"}]},
+        flat_values={},
+    )
+
+
+def test_command_symbol_helpers() -> None:
+    assert _is_boiler_panel("Kocioł")
+    assert _is_command_like_symbol("COMMAND_MODULE_RESTART")
+    assert _is_command_like_symbol("MODULE_X_RESTART")
+    assert not _is_command_like_symbol("PARAM_1")
+    assert _has_named_command_rule({"command_rules": [{"command": "START"}]})
+    assert _command_rule_names({"command_rules": [{"command": "void 0"}, {"command": " BOILER_START "}]}) == {"BOILER_START"}
+    assert _is_action_command_name("MODULE_RESTART")
+
+
+def test_normalize_cached_descriptors_classifies_status_fallback_paths() -> None:
+    descriptors = [
+        {
+            "symbol": "STATUS_P5_1",
+            "devid": "MOD1",
+            "pool": "P5",
+            "chan": "s",
+            "idx": 1,
+            "mapping": {"units_source": 12345, "values": [0, 1, 2]},
+            "unit": {"0": "Idle", "1": "Work", "2": "Fault"},
+            "writable": False,
+            "menu_kinds": ["status"],
+        },
+        {
+            "symbol": "PARAM_TOGGLE",
+            "devid": "MOD1",
+            "pool": "P4",
+            "chan": "v",
+            "idx": 9,
+            "mapping": {"component_type": "toggle"},
+            "writable": True,
+            "menu_kinds": ["write"],
+        },
+        {
+            "symbol": "PARAM_SWITCHISH",
+            "devid": "MOD1",
+            "pool": "P4",
+            "chan": "s",
+            "idx": 2,
+            "mapping": {},
+            "writable": True,
+            "menu_kinds": ["write"],
+        },
+    ]
+
+    normalized = normalize_cached_descriptors(descriptors)
+    by_symbol = {item["symbol"]: item for item in normalized}
+
+    assert by_symbol["STATUS_P5_1"]["platform"] == "sensor"
+    assert by_symbol["PARAM_TOGGLE"]["platform"] == "switch"
+    assert by_symbol["PARAM_SWITCHISH"]["platform"] == "switch"
+
+
+def test_normalize_cached_descriptors_skips_non_dict_entries() -> None:
+    assert normalize_cached_descriptors(["bad"]) == []

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -101,7 +101,8 @@ async def test_async_write_raw_command_route_requires_command_mapping() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_delivers_updates_to_listener() -> None:
+async def test_runtime_delivers_updates_when_meta_is_not_dict() -> None:
+    """Cover the non-dict update.meta branch in BragerRuntime._dispatch_updates."""
     runtime, _api, gateway, _store = make_runtime()
     received: list[FakeParamUpdate] = []
     delivered_event = asyncio.Event()
@@ -112,10 +113,11 @@ async def test_runtime_delivers_updates_to_listener() -> None:
 
     runtime.add_listener(_listener)
     await runtime.start()
-
-    update = FakeParamUpdate(pool="P1", chan="v", idx=1, meta={"_source": "ws"})
-    gateway.bus.push(update)
-    await asyncio.wait_for(delivered_event.wait(), timeout=1.0)
-
-    assert received == [update]
-    await runtime.stop()
+    try:
+        update = FakeParamUpdate(pool="P1", chan="v", idx=1)
+        update.meta = "ws"  # type: ignore[assignment]
+        gateway.bus.push(update)
+        await asyncio.wait_for(delivered_event.wait(), timeout=1.0)
+        assert received == [update]
+    finally:
+        await runtime.stop()

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -1,0 +1,114 @@
+"""Tests for BragerRuntime symbol resolution helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone import runtime as runtime_module  # noqa: E402
+from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
+
+
+class _FakeResolver:
+    def __init__(self, resolved: object | None) -> None:
+        self._resolved = resolved
+
+    @classmethod
+    def from_api(cls, api: object, store: object, lang: object) -> _FakeResolver:
+        _ = api, store, lang
+        return cls(SimpleNamespace(value=10, value_label="Ten", unit="°C"))
+
+    async def resolve_value(self, symbol: str) -> object | None:
+        if symbol == "MISSING":
+            return None
+        return self._resolved
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_status_label_uses_value_label(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+
+    assert await runtime.async_resolve_status_label("PARAM_1") is None
+    assert await runtime.async_resolve_status_label("STATUS_P5_0") == "Ten"
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_symbol_value_and_with_unit(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+
+    assert await runtime.async_resolve_symbol_value("MISSING") is None
+    assert await runtime.async_resolve_symbol_value("PARAM_1") == "Ten"
+
+    value, unit = await runtime.async_resolve_symbol_with_unit("PARAM_1")
+    assert value == "Ten"
+    assert unit == "°C"
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_symbol_swallows_resolver_errors(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+
+    class _FailingResolver(_FakeResolver):
+        async def resolve_value(self, symbol: str) -> object | None:
+            _ = symbol
+            raise RuntimeError("boom")
+
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FailingResolver)
+
+    assert await runtime.async_resolve_symbol_value("PARAM_1") is None
+
+
+@pytest.mark.asyncio
+async def test_async_get_resolver_returns_none_when_from_api_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    runtime._status_resolver = None
+
+    class _BrokenFactory:
+        @classmethod
+        def from_api(cls, api: object, store: object, lang: object) -> _BrokenFactory:
+            _ = api, store, lang
+            raise RuntimeError("factory failed")
+
+    monkeypatch.setattr(runtime_module, "ParamResolver", _BrokenFactory)
+
+    assert await runtime._async_get_resolver() is None
+    assert await runtime.async_resolve_symbol_value("PARAM_1") is None
+
+
+@pytest.mark.asyncio
+async def test_async_write_raw_command_route_requires_command_mapping() -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    descriptor = {
+        "symbol": "SYNC_ACTION",
+        "devid": "DEV1",
+        "pool": None,
+        "chan": None,
+        "idx": None,
+        "mapping": {"command_rules": [{"value": "ON"}]},
+    }
+
+    with pytest.raises(HomeAssistantError, match="No raw command mapping"):
+        await runtime.async_write(descriptor=descriptor, input_display_value=True)
+
+
+@pytest.mark.asyncio
+async def test_runtime_logs_first_update() -> None:
+    runtime, _api, gateway, _store = make_runtime()
+    delivered = MagicMock()
+
+    runtime.add_listener(delivered)
+    await runtime.start()
+    gateway.bus.push(FakeParamUpdate(pool="P1", chan="v", idx=1, meta={"_source": "ws"}))
+    await __import__("asyncio").sleep(0.05)
+    await runtime.stop()
+
+    delivered.assert_called_once()

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
-from unittest.mock import MagicMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
@@ -101,14 +101,21 @@ async def test_async_write_raw_command_route_requires_command_mapping() -> None:
 
 
 @pytest.mark.asyncio
-async def test_runtime_logs_first_update() -> None:
+async def test_runtime_delivers_updates_to_listener() -> None:
     runtime, _api, gateway, _store = make_runtime()
-    delivered = MagicMock()
+    received: list[FakeParamUpdate] = []
+    delivered_event = asyncio.Event()
 
-    runtime.add_listener(delivered)
+    def _listener(update: FakeParamUpdate) -> None:
+        received.append(update)
+        delivered_event.set()
+
+    runtime.add_listener(_listener)
     await runtime.start()
-    gateway.bus.push(FakeParamUpdate(pool="P1", chan="v", idx=1, meta={"_source": "ws"}))
-    await __import__("asyncio").sleep(0.05)
-    await runtime.stop()
 
-    delivered.assert_called_once()
+    update = FakeParamUpdate(pool="P1", chan="v", idx=1, meta={"_source": "ws"})
+    gateway.bus.push(update)
+    await asyncio.wait_for(delivered_event.wait(), timeout=1.0)
+
+    assert received == [update]
+    await runtime.stop()

--- a/tests/test_status_rules.py
+++ b/tests/test_status_rules.py
@@ -1,0 +1,128 @@
+"""Unit tests for status_rules helpers."""
+
+from __future__ import annotations
+
+from custom_components.habragerone.status_rules import (
+    compare_condition,
+    normalize_rule_value,
+    read_target_actual,
+    resolve_rule_bool,
+    resolve_rule_display_value,
+    rule_matches,
+)
+
+
+def test_resolve_rule_display_value_returns_none_for_invalid_mapping() -> None:
+    assert resolve_rule_display_value(descriptor={}, flat_values={}, default_actual=0) is None
+    assert resolve_rule_display_value(descriptor={"mapping": "bad"}, flat_values={}, default_actual=0) is None
+    assert (
+        resolve_rule_display_value(
+            descriptor={"mapping": {"command_rules": "bad"}},
+            flat_values={},
+            default_actual=0,
+        )
+        is None
+    )
+
+
+def test_resolve_rule_display_value_skips_invalid_rules_and_none_values() -> None:
+    descriptor = {
+        "mapping": {
+            "command_rules": [
+                "bad",
+                {"conditions": [], "value": None},
+                {
+                    "conditions": [{"operation": "equalTo", "expected": 0, "targets": []}],
+                    "value": "wn.OFF",
+                },
+            ]
+        }
+    }
+
+    display = resolve_rule_display_value(descriptor=descriptor, flat_values={}, default_actual=0)
+
+    assert display == "Off"
+
+
+def test_resolve_rule_bool_maps_on_off_tokens() -> None:
+    descriptor = {
+        "mapping": {
+            "command_rules": [
+                {
+                    "value": "enabled",
+                    "conditions": [{"operation": "equalTo", "expected": 1, "targets": []}],
+                }
+            ]
+        }
+    }
+
+    assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=1) is True
+
+    descriptor["mapping"]["command_rules"][0]["value"] = "disabled"
+    assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=1) is False
+
+    descriptor["mapping"]["command_rules"][0]["value"] = "maybe"
+    assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=1) is None
+
+
+def test_resolve_rule_bool_returns_none_for_non_string_display() -> None:
+    descriptor = {"mapping": {"command_rules": [{"conditions": [], "value": 42}]}}
+
+    assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=0) is None
+
+
+def test_rule_matches_defaults_to_all_logic_and_handles_invalid_conditions() -> None:
+    assert rule_matches({"conditions": []}, flat_values={}, default_actual=1) is True
+
+    assert rule_matches({"conditions": ["bad"]}, flat_values={}, default_actual=1) is False
+
+    rule = {
+        "logic": "any",
+        "conditions": [
+            {"operation": "equalTo", "expected": 0, "targets": [{"address": "P1.v1"}]},
+            {"operation": "equalTo", "expected": 1, "targets": []},
+        ],
+    }
+    assert rule_matches(rule, flat_values={"P1.v1": 5}, default_actual=1) is True
+
+
+def test_rule_matches_uses_default_actual_when_targets_missing() -> None:
+    rule = {"conditions": [{"operation": "equalTo", "expected": 7}]}
+
+    assert rule_matches(rule, flat_values={}, default_actual=7) is True
+    assert rule_matches(rule, flat_values={}, default_actual=8) is False
+
+
+def test_rule_matches_rejects_invalid_target_and_operation() -> None:
+    rule = {
+        "conditions": [
+            {"operation": 123, "expected": 1, "targets": [{"address": "P1.v1"}]},
+        ]
+    }
+    assert rule_matches(rule, flat_values={"P1.v1": 1}, default_actual=0) is False
+
+    rule = {
+        "conditions": [
+            {"operation": "equalTo", "expected": 1, "targets": ["bad"]},
+        ]
+    }
+    assert rule_matches(rule, flat_values={}, default_actual=1) is False
+
+
+def test_read_target_actual_handles_address_bit_and_mask() -> None:
+    assert read_target_actual({"address": ""}, flat_values={"P1.v1": 1}) is None
+    assert read_target_actual({"address": "P1.v1"}, flat_values={"P1.v1": "text"}) == "text"
+    assert read_target_actual({"address": "P1.s0", "bit": 2}, flat_values={"P1.s0": 0b100}) == 1
+    assert read_target_actual({"address": "P1.s0", "mask": 0x0F}, flat_values={"P1.s0": 0xF0}) == 0
+
+
+def test_compare_condition_supports_prefixed_and_not_equal_operations() -> None:
+    assert compare_condition(operation="xa.notEqualTo", actual=1, expected=2) is True
+    assert compare_condition(operation="equalTo", actual=1, expected=1) is True
+    assert compare_condition(operation="unknown", actual=1, expected=1) is False
+
+
+def test_normalize_rule_value_formats_tokens() -> None:
+    assert normalize_rule_value("wn.OFF_MANUAL") == "Off"
+    assert normalize_rule_value("some_state") == "Some State"
+    assert normalize_rule_value(42) == 42


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Raises project coverage above the 80% floor and aligns coverage tooling with **py-bragerone**:

- **Tests**: `status_rules`, `bootstrap` helpers, `runtime` resolve/dispatch paths
- **Infra**: pre-push `--cov-fail-under=80` (was 70%); Codecov project stays **informational** (patch 100% — same as py-bragerone)

**Codecov project on this PR: ~83.5%**

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] `uv run poe validate` passes locally
- [x] Tests added / updated where practical; tests pass offline
- [x] Docs updated (`AGENTS.md`, `DEVELOPMENT.md`, review instructions)
- [ ] Version pins (unchanged)
- [x] No secrets committed

## Test plan

```bash
uv sync --locked --group dev --group test
uv run poe validate
uv run --group test pytest --cov=custom_components.habragerone --cov-fail-under=80 -q
```

## Notes for reviewers

Copilot feedback addressed:
- Runtime listener test uses `asyncio.Event` + `wait_for` (not fixed sleep)
- Suppressed comment: test now covers non-dict `update.meta` branch + `try/finally` cleanup

No production code changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

