### PR TITLE
fix(bootstrap): retry panel-group build when the gated result is empty

### DIFF
--- a/custom_components/habragerone/__init__.py
+++ b/custom_components/habragerone/__init__.py
@@ -39,7 +39,12 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _descriptors_require_refresh(descriptors: Any) -> bool:
-    if not isinstance(descriptors, list):
+    # An empty list is never a legitimate steady state: a module that exists has parameters.
+    # Bootstrap can still produce zero descriptors transiently — an offline module has no primed
+    # values, so every symbol is dropped as `no_display_value`. Caching that would keep the entry
+    # entity-less long after the module returns, because nothing else invalidates the cache until
+    # BOOTSTRAP_VERSION changes. Re-bootstrapping on the next start is the recoverable choice.
+    if not isinstance(descriptors, list) or not descriptors:
         return True
     for descriptor in descriptors:
         if not isinstance(descriptor, dict):

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -656,6 +656,12 @@ async def _build_panel_groups_with_fallback(
     still return no symbols. Both are treated the same way and retried with ``permissions=None``,
     mirroring the symbol-kind fallback used later in the same bootstrap loop.
 
+    A failing ungated retry is left to propagate, as it did before the empty-result case was
+    handled here. Setup then fails and Home Assistant retries it, which is recoverable; swallowing
+    the error would instead persist an empty descriptor list that survives restarts, because
+    ``_descriptors_require_refresh`` accepts an empty list and the entry is stamped with the
+    current ``BOOTSTRAP_VERSION``.
+
     Args:
         resolver: Parameter resolver used for the extraction.
         device_menu: Device menu identifier of the module.
@@ -675,11 +681,7 @@ async def _build_panel_groups_with_fallback(
             return groups
         LOGGER.debug("Panel-group build returned no symbols for %s, retrying without permissions", devid)
 
-    try:
-        groups = await resolver.build_panel_groups(device_menu=device_menu, permissions=None, all_panels=True)
-    except Exception:
-        LOGGER.debug("Panel-group fallback build failed for %s", devid, exc_info=True)
-        groups = {}
+    groups = await resolver.build_panel_groups(device_menu=device_menu, permissions=None, all_panels=True)
 
     if not _panel_group_symbols(groups):
         LOGGER.warning(

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -658,9 +658,7 @@ async def _build_panel_groups_with_fallback(
 
     A failing ungated retry is left to propagate, as it did before the empty-result case was
     handled here. Setup then fails and Home Assistant retries it, which is recoverable; swallowing
-    the error would instead persist an empty descriptor list that survives restarts, because
-    ``_descriptors_require_refresh`` accepts an empty list and the entry is stamped with the
-    current ``BOOTSTRAP_VERSION``.
+    the error would instead hand back an empty result as if the extraction had succeeded.
 
     Args:
         resolver: Parameter resolver used for the extraction.

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -631,6 +631,64 @@ def normalize_cached_descriptors(descriptors_raw: list[Any]) -> list[EntityDescr
     return normalized
 
 
+def _panel_group_symbols(groups: Mapping[str, list[str]]) -> set[str]:
+    """Flatten a panel-group mapping into the set of symbols it contains.
+
+    Args:
+        groups: Mapping of panel name to the symbols assigned to that panel.
+
+    Returns:
+        Set of non-empty symbols found across every panel.
+    """
+    return {symbol for panel_symbols in groups.values() for symbol in panel_symbols if symbol}
+
+
+async def _build_panel_groups_with_fallback(
+    resolver: Any,
+    *,
+    device_menu: Any,
+    permissions: list[str],
+    devid: str,
+) -> dict[str, list[str]]:
+    """Build panel groups, retrying without permissions when the gated attempt yields nothing.
+
+    The permission-gated extraction can fail in two ways: it can raise, or it can succeed and
+    still return no symbols. Both are treated the same way and retried with ``permissions=None``,
+    mirroring the symbol-kind fallback used later in the same bootstrap loop.
+
+    Args:
+        resolver: Parameter resolver used for the extraction.
+        device_menu: Device menu identifier of the module.
+        permissions: Permission strings reported by the API for this module.
+        devid: Module device identifier, used for logging only.
+
+    Returns:
+        Mapping of panel name to symbols, empty when neither attempt produced symbols.
+    """
+    groups: dict[str, list[str]] = {}
+    try:
+        groups = await resolver.build_panel_groups(device_menu=device_menu, permissions=permissions, all_panels=True)
+    except Exception:
+        LOGGER.debug("Panel-group build failed for %s, retrying without permissions", devid, exc_info=True)
+    else:
+        if _panel_group_symbols(groups):
+            return groups
+        LOGGER.debug("Panel-group build returned no symbols for %s, retrying without permissions", devid)
+
+    try:
+        groups = await resolver.build_panel_groups(device_menu=device_menu, permissions=None, all_panels=True)
+    except Exception:
+        LOGGER.debug("Panel-group fallback build failed for %s", devid, exc_info=True)
+        groups = {}
+
+    if not _panel_group_symbols(groups):
+        LOGGER.warning(
+            "No panel symbols discovered for module %s (with and without permissions); this module will get no entities",
+            devid,
+        )
+    return groups
+
+
 class BootstrapPayload(TypedDict):
     """Container persisted in ConfigEntry data for fast startup."""
 
@@ -684,21 +742,14 @@ async def async_build_bootstrap_payload(
         symbols: set[str] = set()
         panel_paths: dict[str, str] = {}
 
-        try:
-            groups = await resolver.build_panel_groups(
-                device_menu=module.deviceMenu,
-                permissions=module_permissions,
-                all_panels=True,
-            )
-        except Exception:
-            LOGGER.debug("Panel-group build failed for %s, retrying without permissions", module.devid, exc_info=True)
-            groups = await resolver.build_panel_groups(
-                device_menu=module.deviceMenu,
-                permissions=None,
-                all_panels=True,
-            )
+        groups = await _build_panel_groups_with_fallback(
+            resolver,
+            device_menu=module.deviceMenu,
+            permissions=module_permissions,
+            devid=str(module.devid),
+        )
 
-        symbols = {symbol for panel_symbols in groups.values() for symbol in panel_symbols if symbol}
+        symbols = _panel_group_symbols(groups)
         for panel_name, panel_symbols in groups.items():
             panel_title = _normalize_panel_path(str(panel_name))
             if not panel_title:

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -682,8 +682,11 @@ async def _build_panel_groups_with_fallback(
     groups = await resolver.build_panel_groups(device_menu=device_menu, permissions=None, all_panels=True)
 
     if not _panel_group_symbols(groups):
+        # Scope the claim to panel-derived symbols: in permissions mode the later secondary pass
+        # can still contribute command-like entities that never came from a panel group.
         LOGGER.warning(
-            "No panel symbols discovered for module %s (with and without permissions); this module will get no entities",
+            "Panel-group discovery returned no symbols for module %s, with and without permissions; "
+            "no panel-derived entities will be created for it",
             devid,
         )
     return groups

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -193,7 +193,14 @@ def test_two_empty_panel_group_attempts_warn_without_failing_bootstrap(
     assert "no entities" in message
 
 
-def test_raising_gated_and_ungated_panel_groups_warn_without_raising(caplog: pytest.LogCaptureFixture) -> None:
+def test_failing_ungated_retry_propagates_instead_of_caching_emptiness() -> None:
+    """A broken ungated retry must fail setup, not persist a bootstrap with zero entities.
+
+    ``_descriptors_require_refresh`` accepts an empty descriptor list and the entry is stamped
+    with the current ``BOOTSTRAP_VERSION``, so swallowing this error would cache the empty state
+    across restarts. Letting it propagate keeps the failure retryable.
+    """
+
     class _AlwaysFailingResolver:
         async def build_panel_groups(
             self,
@@ -205,8 +212,8 @@ def test_raising_gated_and_ungated_panel_groups_warn_without_raising(caplog: pyt
             _ = device_menu, permissions, all_panels
             raise RuntimeError("extraction failed")
 
-    with caplog.at_level(logging.WARNING, logger=BOOTSTRAP_LOGGER):
-        groups = asyncio.run(
+    with pytest.raises(RuntimeError, match="extraction failed"):
+        asyncio.run(
             _build_panel_groups_with_fallback(
                 _AlwaysFailingResolver(),
                 device_menu="M1",
@@ -214,8 +221,3 @@ def test_raising_gated_and_ungated_panel_groups_warn_without_raising(caplog: pyt
                 devid="M1",
             )
         )
-
-    assert groups == {}
-    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
-    assert len(warnings) == 1
-    assert "M1" in warnings[0].getMessage()

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -186,11 +186,10 @@ def test_two_empty_panel_group_attempts_warn_without_failing_bootstrap(
     assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
     assert payload["entity_descriptors"] == []
 
+    # Assert the module is named, not the exact phrasing: rewording the log is not a behaviour change.
     warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
     assert len(warnings) == 1
-    message = warnings[0].getMessage()
-    assert "M1" in message
-    assert "no entities" in message
+    assert "M1" in warnings[0].getMessage()
 
 
 def test_failing_ungated_retry_propagates_instead_of_caching_emptiness() -> None:

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -1,0 +1,221 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import sys
+from types import SimpleNamespace
+from typing import Any, ClassVar, cast
+
+import pytest
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.bootstrap import (  # noqa: E402
+    _build_panel_groups_with_fallback,
+    async_build_bootstrap_payload,
+)
+
+BOOTSTRAP_LOGGER = "custom_components.habragerone.bootstrap"
+
+
+class _FakeParamStore:
+    def ingest_prime_payload(self, _payload: dict[str, object]) -> None:
+        return None
+
+    def flatten(self) -> dict[str, object]:
+        return {"P4.v1": 42}
+
+
+class _RecordingResolver:
+    """Resolver stub that records every `build_panel_groups` call.
+
+    `gated_groups` is returned when permissions are passed, `ungated_groups` when they are not.
+    Either can be replaced by an exception instance to simulate a failing extraction.
+    """
+
+    gated_groups: ClassVar[object] = {}
+    ungated_groups: ClassVar[object] = {}
+    calls: ClassVar[list[list[str] | None]] = []
+
+    @classmethod
+    def from_api(cls, api: object, store: object, lang: object) -> _RecordingResolver:
+        _ = api, store, lang
+        return cls()
+
+    async def build_panel_groups(
+        self,
+        *,
+        device_menu: str,
+        permissions: list[str] | None,
+        all_panels: bool,
+    ) -> dict[str, list[str]]:
+        _ = device_menu, all_panels
+        type(self).calls.append(permissions)
+        result = self.gated_groups if permissions else self.ungated_groups
+        if isinstance(result, Exception):
+            raise result
+        return cast(dict[str, list[str]], result)
+
+    async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:
+        return {
+            symbol: {
+                "label": symbol,
+                "pool": "P4",
+                "chan": "v",
+                "idx": 1,
+                "mapping": {},
+                "min": None,
+                "max": None,
+                "unit": None,
+            }
+            for symbol in symbols
+        }
+
+    def set_runtime_context(self, context: dict[str, object] | None) -> None:
+        _ = context
+
+    async def resolve_value(self, symbol: str) -> SimpleNamespace:
+        _ = symbol
+        return SimpleNamespace(value=1, value_label="1")
+
+    def parameter_visibility_diagnostics(
+        self,
+        *,
+        desc: dict[str, object],
+        resolved: object,
+        flat_values: dict[str, object],
+    ) -> tuple[bool, dict[str, object]]:
+        _ = desc, resolved, flat_values
+        return True, {}
+
+
+class _FakeGateway:
+    def model_dump(self, mode: str = "json") -> dict[str, object]:
+        _ = mode
+        return {}
+
+
+class _FakeApi:
+    async def get_modules(self, object_id: int) -> list[SimpleNamespace]:
+        _ = object_id
+        return [
+            SimpleNamespace(
+                devid="M1",
+                name="Module 1",
+                moduleTitle="Module 1",
+                moduleVersion="1.0",
+                gateway=_FakeGateway(),
+                moduleInterface="if1",
+                moduleAddress="addr1",
+                permissions=["DISPLAY_PARAMETER_LEVEL_1"],
+                deviceMenu="M1",
+                connectedAt="now",
+            )
+        ]
+
+    async def modules_parameters_prime(self, module_ids: list[str], return_data: bool = False) -> tuple[int, dict[str, object]]:
+        _ = module_ids, return_data
+        return 200, {}
+
+
+def _run_bootstrap(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    gated_groups: object,
+    ungated_groups: object,
+) -> tuple[dict[str, Any], list[list[str] | None]]:
+    _RecordingResolver.gated_groups = gated_groups
+    _RecordingResolver.ungated_groups = ungated_groups
+    _RecordingResolver.calls = []
+
+    monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
+    monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", _RecordingResolver)
+
+    payload = asyncio.run(
+        async_build_bootstrap_payload(
+            api=cast(Any, _FakeApi()),  # type: ignore[arg-type]
+            object_id=1,
+            modules=["M1"],
+            language="en",
+        )
+    )
+    return cast(dict[str, Any], payload), _RecordingResolver.calls
+
+
+def test_empty_gated_panel_groups_fall_back_to_ungated_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload, calls = _run_bootstrap(
+        monkeypatch,
+        gated_groups={},
+        ungated_groups={"Panel": ["SYM_FALLBACK"]},
+    )
+
+    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
+    assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_FALLBACK"}
+
+
+def test_non_empty_gated_panel_groups_skip_the_fallback_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload, calls = _run_bootstrap(
+        monkeypatch,
+        gated_groups={"Panel": ["SYM_GATED"]},
+        ungated_groups={"Panel": ["SYM_FALLBACK"]},
+    )
+
+    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"]]
+    assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_GATED"}
+
+
+def test_raising_gated_panel_groups_fall_back_to_ungated_call(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload, calls = _run_bootstrap(
+        monkeypatch,
+        gated_groups=RuntimeError("gated extraction failed"),
+        ungated_groups={"Panel": ["SYM_FALLBACK"]},
+    )
+
+    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
+    assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_FALLBACK"}
+
+
+def test_two_empty_panel_group_attempts_warn_without_failing_bootstrap(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.WARNING, logger=BOOTSTRAP_LOGGER):
+        payload, calls = _run_bootstrap(monkeypatch, gated_groups={}, ungated_groups={"Panel": []})
+
+    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
+    assert payload["entity_descriptors"] == []
+
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    message = warnings[0].getMessage()
+    assert "M1" in message
+    assert "no entities" in message
+
+
+def test_raising_gated_and_ungated_panel_groups_warn_without_raising(caplog: pytest.LogCaptureFixture) -> None:
+    class _AlwaysFailingResolver:
+        async def build_panel_groups(
+            self,
+            *,
+            device_menu: str,
+            permissions: list[str] | None,
+            all_panels: bool,
+        ) -> dict[str, list[str]]:
+            _ = device_menu, permissions, all_panels
+            raise RuntimeError("extraction failed")
+
+    with caplog.at_level(logging.WARNING, logger=BOOTSTRAP_LOGGER):
+        groups = asyncio.run(
+            _build_panel_groups_with_fallback(
+                _AlwaysFailingResolver(),
+                device_menu="M1",
+                permissions=["DISPLAY_PARAMETER_LEVEL_1"],
+                devid="M1",
+            )
+        )
+
+    assert groups == {}
+    warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "M1" in warnings[0].getMessage()

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -194,11 +194,10 @@ def test_two_empty_panel_group_attempts_warn_without_failing_bootstrap(
 
 
 def test_failing_ungated_retry_propagates_instead_of_caching_emptiness() -> None:
-    """A broken ungated retry must fail setup, not persist a bootstrap with zero entities.
+    """A broken ungated retry must fail setup rather than report a bootstrap with zero entities.
 
-    ``_descriptors_require_refresh`` accepts an empty descriptor list and the entry is stamped
-    with the current ``BOOTSTRAP_VERSION``, so swallowing this error would cache the empty state
-    across restarts. Letting it propagate keeps the failure retryable.
+    Home Assistant retries a failed setup, so a transient upstream error recovers on its own.
+    Swallowing it would instead hand back an empty descriptor list as if it were a real result.
     """
 
     class _AlwaysFailingResolver:

--- a/tests/test_init_helpers.py
+++ b/tests/test_init_helpers.py
@@ -19,6 +19,11 @@ def test_descriptors_require_refresh_rejects_non_list() -> None:
     assert _descriptors_require_refresh({"symbol": "X"}) is True
 
 
+def test_descriptors_require_refresh_rejects_empty_list() -> None:
+    """Zero entities is a transient failure (e.g. an offline module), never a valid cache."""
+    assert _descriptors_require_refresh([]) is True
+
+
 def test_descriptors_require_refresh_select_without_options() -> None:
     descriptors = [{"platform": "select", "symbol": "MODE"}]
     assert _descriptors_require_refresh(descriptors) is True


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

`async_build_bootstrap_payload` retried `build_panel_groups` without permissions only when the gated call **raised**. When the gated call succeeded but returned an empty result — the failure mode actually observed in py-bragerone#286, fixed in py-bragerone#288 — bootstrap continued with zero candidate symbols, the module got no entities, and nothing was logged above `DEBUG`.

The retry now also fires on an empty result, mirroring the `per_module_symbol_kinds` fallback a few lines lower in the same loop, which already handled "succeeded but came back empty" correctly. The two behaviours in one function were the inconsistency; this makes them agree. A `WARNING` is emitted when neither attempt yields symbols.

Closes #156

## Zero entities is never a valid cached state

Reviewing the fix surfaced a second, worse defect on the same path, so this PR fixes it too.

Bootstrap can produce zero descriptors at two different layers, and only one of them is a parser bug:

- **Panel groups** (`build_panel_groups`) parse the static `deviceMenu` asset and filter by permissions. No live device state is involved, so a module being offline cannot empty this. Empty here always means a defect: an unparseable/missing menu chunk, or a permission-gating mismatch.
- **Descriptors** are then filtered by `_has_display_value`, which reads primed values. An **offline module has no primed values, so every symbol is dropped as `no_display_value`** — zero descriptors, transiently, with nothing wrong in the parser.

Either way the result was persisted: `_descriptors_require_refresh` returned `False` for an empty list, and the entry was stamped with the current `BOOTSTRAP_VERSION`. Nothing else invalidates that cache, so an entry bootstrapped during an outage stayed **entity-less across restarts** until the version was bumped or the integration re-added.

`_descriptors_require_refresh` now treats an empty list as requiring a refresh. A module that exists has parameters, so zero entities is always transient and re-bootstrapping on the next start is the recoverable choice. This only triggers when the entry has no entities at all.

No changes to `unique_id`, naming, descriptor semantics, `BOOTSTRAP_VERSION`, or `manifest.json` pins. The warning interpolates only the devid.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature / enhancement (non-breaking)
- [ ] Breaking change (`unique_id`, platforms, config flow version, `BOOTSTRAP_VERSION` / descriptor cache) — call this out explicitly
- [ ] Docs only
- [ ] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] `uv run poe validate` passes locally (fmt + lint + mypy --strict + security + tests; sync `--group dev --group test` first)
- [x] Tests added / updated where practical (regression test for bug fixes; cover enum/numeric write safety when touching the write path). Tests pass offline
- [x] Docs / translations updated when user-facing behavior changes — n/a, no documented behavior changes
- [x] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency)
- [x] No secrets / credentials / real device dumps committed; diagnostics remain redacted

## Test plan

New offline unit tests in `tests/test_bootstrap_panel_group_fallback.py`:

- `test_empty_gated_panel_groups_fall_back_to_ungated_call` — regression test for #156
- `test_non_empty_gated_panel_groups_skip_the_fallback_call` — asserts the recorded call list, so the fallback cannot silently double every bootstrap
- `test_raising_gated_panel_groups_fall_back_to_ungated_call` — the pre-existing exception retry is preserved
- `test_two_empty_panel_group_attempts_warn_without_failing_bootstrap` — exactly one WARNING, bootstrap still completes
- `test_failing_ungated_retry_propagates_instead_of_caching_emptiness`

And in `tests/test_init_helpers.py`:

- `test_descriptors_require_refresh_rejects_empty_list`

The first and fourth were verified to fail against pre-fix `bootstrap.py`.

```bash
uv run poe validate
```

Local patch coverage vs `main`: 100% (18/18 statements, 0 miss, 0 partial).

## Notes for reviewers

**Why the ungated retry is deliberately *not* wrapped in `try/except`.** Handling the empty case creates a retry where none happened before, so a raising ungated call can now abort setup on a path that previously could not reach it. Swallowing it would hand back an empty descriptor list as if it were a real result; letting it propagate fails setup, which Home Assistant retries with backoff, so a transient upstream failure recovers on its own.

An empty *result* (no exception) is still tolerated and only warned about — with the cache fix above, the next start simply re-bootstraps.

Related: #155 tracks the absence of a staleness signal on cached descriptors. That is about detecting drift after a *good* bootstrap; this PR is about not trusting an *empty* one.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

