### PR TITLE
chore(deps): bump py-bragerone to 2026.8.3

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,7 +16,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.2",
+    "py-bragerone==2026.8.3",
     "tree-sitter==0.26.0"
   ],
   "version": "2026.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.2",
+    "py-bragerone>=2026.8.3",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.2" },
+    { name = "py-bragerone", specifier = ">=2026.8.3" },
 ]
 
 [package.metadata.requires-dev]
@@ -2190,7 +2190,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.2"
+version = "2026.8.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2200,9 +2200,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/86/75/9488bb0ef725c5d802219bb274a7f051e5be7aa6b51160f8b6a974497cac/py_bragerone-2026.8.2.tar.gz", hash = "sha256:78d659b19b348cd8d0724aa00a676b1e2fc4ee0c463673c0509f7a7cf766edf9", size = 94264, upload-time = "2026-08-09T12:14:24.33Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/75/2c/97b3b9ac68598dd54a98fc6df8de74846ce5c3b49d50c74c165927fdf128/py_bragerone-2026.8.3.tar.gz", hash = "sha256:242d93bc299179e5b52046ac437f57d97a0c1c6a1124a0eb57e51793602be1a5", size = 100911, upload-time = "2026-08-14T13:04:35.545Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/29/1f/dee35c2d4a01eb1b271ebe6e136bfc2a0272c6b839a3c3a1c6d6787a5e0b/py_bragerone-2026.8.2-py3-none-any.whl", hash = "sha256:00c9a152a1f49c10e035f17b27816a858748a763bac7c71cf2e948130670fcb3", size = 99792, upload-time = "2026-08-09T12:14:22.864Z" },
+    { url = "https://files.pythonhosted.org/packages/de/38/f10933abeaf0c61cafda2423a1cc81c20bfd62940bdbd833b0a5a2751330/py_bragerone-2026.8.3-py3-none-any.whl", hash = "sha256:5a6649aad484cba8bc25c7a42b756617e7a579011737baee271d048e1cc409f4", size = 106720, upload-time = "2026-08-14T13:04:34.122Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[`py-bragerone` 2026.8.3](https://github.com/marpi82/py-bragerone/releases/tag/2026.8.3) is on PyPI. This picks it up so the integration finally runs on the parser that understands the current obfuscated web-app bundle.

What the integration gains, all of it previously silent breakage:

- **Parameter labels** no longer keep raw escapes — a space used to render as a literal `\x20`, affecting 1303 of 1339 labels on the live bundle.
- **Units resolved through indirection** (kW among them) come back: the hex-keyed descriptor table used to parse to zero entries.
- **Permission gating works** — API `DISPLAY_*` strings now match the obfuscated `_0x521864['DISPLAY_PARAMETER_LEVEL_1']` menu spelling. Gated `deviceMenu` 0 went from **0 to 471 tokens** upstream. This is the exact failure mode #156 hardened bootstrap against.
- **`deviceMenu` 153 and 2190 parse at all** — `array['map']` write lists used to raise thousands of validation errors.
- **Language config, unit 66/47 transforms, `PARAM_*` status conditions and component types** resolve instead of degrading to leftover source text.

Pins kept in sync per AGENTS.md: `manifest.json` `==2026.8.3`, `pyproject.toml` `>=2026.8.3`, `uv.lock` relocked. `hacs.json` and the `homeassistant` bound are untouched.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature / enhancement (non-breaking)
- [ ] Breaking change (`unique_id`, platforms, config flow version, `BOOTSTRAP_VERSION` / descriptor cache) — call this out explicitly
- [ ] Docs only
- [x] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] `uv run poe validate` passes locally (fmt + lint + mypy --strict + security + tests; sync `--group dev --group test` first)
- [x] Tests added / updated where practical — n/a, dependency bump; existing suite runs against the new version
- [x] Docs / translations updated when user-facing behavior changes — n/a
- [x] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency)
- [x] No secrets / credentials / real device dumps committed; diagnostics remain redacted

## Test plan

```bash
uv lock --upgrade-package py-bragerone   # Updated py-bragerone v2026.8.2 -> v2026.8.3
uv sync --locked --group dev --group test
uv run poe validate
```

`poe validate` passes against the **published** package, not a local checkout — including `mypy --strict`, which is the real compatibility check for the library's public surface.

Most of the suite runs on `install_pybragerone_stubs()`, so on top of it I imported every symbol the integration actually uses from the real package and asserted the resolver/catalog methods `bootstrap.py` and `runtime.py` call still exist:

[release_2026_8_3.log](https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Frelease_2026_8_3.log)

## Notes for reviewers

No `BOOTSTRAP_VERSION` bump here. Existing installs keep their cached descriptors until something else invalidates them; #157 already made an *empty* descriptor list stop counting as a valid cache, so an install that bootstrapped to zero entities during the breakage will re-bootstrap on the next start and pick up the fixed parsing. #155 tracks the broader staleness-signal gap — an install with *stale but non-empty* descriptors (for example the `\x20` labels) still needs a manual refresh.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

