### PR TITLE
chore(deps): bump py-bragerone to 2026.8.4

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,7 +16,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.3",
+    "py-bragerone==2026.8.4",
     "tree-sitter==0.26.0"
   ],
   "version": "2026.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.3",
+    "py-bragerone>=2026.8.4",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.3" },
+    { name = "py-bragerone", specifier = ">=2026.8.4" },
 ]
 
 [package.metadata.requires-dev]
@@ -2190,7 +2190,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.3"
+version = "2026.8.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2200,9 +2200,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/75/2c/97b3b9ac68598dd54a98fc6df8de74846ce5c3b49d50c74c165927fdf128/py_bragerone-2026.8.3.tar.gz", hash = "sha256:242d93bc299179e5b52046ac437f57d97a0c1c6a1124a0eb57e51793602be1a5", size = 100911, upload-time = "2026-08-14T13:04:35.545Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/31/4f/cbf6f4e207c7683a1fbc19d804b01754f6ddeb449851a571c4758258cd57/py_bragerone-2026.8.4.tar.gz", hash = "sha256:306936f1a1707449e5500c53068d68e0394a9daab72f421e2d9749491c623c29", size = 103902, upload-time = "2026-08-14T14:41:19.241Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/de/38/f10933abeaf0c61cafda2423a1cc81c20bfd62940bdbd833b0a5a2751330/py_bragerone-2026.8.3-py3-none-any.whl", hash = "sha256:5a6649aad484cba8bc25c7a42b756617e7a579011737baee271d048e1cc409f4", size = 106720, upload-time = "2026-08-14T13:04:34.122Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/c7/3b6c69e629a56072ef4b016e51e6b4b6381447256fd1eb6c347dcc4dc252/py_bragerone-2026.8.4-py3-none-any.whl", hash = "sha256:fd802d7960c25f15c7e0c484ba9558d0702a5b5e6824a9276fbfd12d74794781", size = 109705, upload-time = "2026-08-14T14:41:17.968Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

[`py-bragerone` 2026.8.4](https://github.com/marpi82/py-bragerone/releases/tag/2026.8.4) is on PyPI. This picks it up for the two regressions fixed after 2026.8.3:

- **Factory builders** (#293 / py #295) — `basicParameterBuilder_P*` statement-block maps in `index-*.js` parse again, so a fresh bootstrap recovers the missing descriptors (was ~17 of ~100 on a live HT DasPell).
- **MAINMENU panel titles** (#294 / py #296) — bare `MAINMENU_*` tokens resolve through string-default i18n namespaces, so entity names no longer look like `MAINMENU_MENU_TERMOSTATU/Pompa CO - …`.

Pins updated in lockstep: `manifest.json` `==2026.8.4`, `pyproject.toml` `>=2026.8.4`, `uv.lock`.

After install: **re-add / re-bootstrap** the config entry so cached descriptors pick up the new panel paths and maps. No `BOOTSTRAP_VERSION` bump in this PR.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature / enhancement (non-breaking)
- [ ] Breaking change (`unique_id`, platforms, config flow version, `BOOTSTRAP_VERSION` / descriptor cache) — call this out explicitly
- [ ] Docs only
- [x] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] `uv run poe validate` / lint + test pass locally (`poe lint`, `poe test` green with `py-bragerone==2026.8.4`)
- [ ] Tests added / updated where practical (deps-only)
- [ ] Docs / translations updated when user-facing behavior changes
- [x] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency)
- [x] No secrets / credentials / real device dumps committed; diagnostics remain redacted

## Test plan

```bash
uv sync --locked --group dev --group test
uv run poe lint
uv run poe test
```

## Notes for reviewers

- Fresh bootstrap required for users already on a broken/cached entry.
- Upstream PL thermostat parent title is now **Menu termostatów** (current asset string), not the older cached **Termostaty**.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

