### PR TITLE
chore(deps): bump py-bragerone to 2026.8.5

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,7 +16,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.4",
+    "py-bragerone==2026.8.5",
     "tree-sitter==0.26.0"
   ],
   "version": "2026.8.1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.4",
+    "py-bragerone>=2026.8.5",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.4" },
+    { name = "py-bragerone", specifier = ">=2026.8.5" },
 ]
 
 [package.metadata.requires-dev]
@@ -2190,7 +2190,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.4"
+version = "2026.8.5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2200,9 +2200,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/31/4f/cbf6f4e207c7683a1fbc19d804b01754f6ddeb449851a571c4758258cd57/py_bragerone-2026.8.4.tar.gz", hash = "sha256:306936f1a1707449e5500c53068d68e0394a9daab72f421e2d9749491c623c29", size = 103902, upload-time = "2026-08-14T14:41:19.241Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/85/25/7b628e87707d89e661695328c675fbdf70fbdf0cbb536fb35e35c0cf958e/py_bragerone-2026.8.5.tar.gz", hash = "sha256:eae65b84a56f90491aae76c1bd2ad2a4e89de8b6af195d0321137f42fea58731", size = 104835, upload-time = "2026-08-14T15:22:43.514Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/c7/3b6c69e629a56072ef4b016e51e6b4b6381447256fd1eb6c347dcc4dc252/py_bragerone-2026.8.4-py3-none-any.whl", hash = "sha256:fd802d7960c25f15c7e0c484ba9558d0702a5b5e6824a9276fbfd12d74794781", size = 109705, upload-time = "2026-08-14T14:41:17.968Z" },
+    { url = "https://files.pythonhosted.org/packages/26/de/fb20591d578e2f8bb86f550e9ad740589c7cda4ca25578493b8f38f5fae0/py_bragerone-2026.8.5-py3-none-any.whl", hash = "sha256:c176e930640d7e7f87276f3e9523ce1e1d6cf63c3fcc45bb6cd9682155cc6982", size = 110639, upload-time = "2026-08-14T15:22:42.284Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bumps `py-bragerone` to **`2026.8.5`** so a fresh bootstrap picks up:

- factory `name` nullish/ternary evaluation → Polish/`parameters.*` labels instead of raw `PARAM_*`
- `MAINMENU_*` / `MENUSERWIS_*` all-panels candidates → ~466 candidates / ~100 entities again (was ~32)

## Changes

- `manifest.json`: `py-bragerone==2026.8.5`
- `pyproject.toml`: `py-bragerone>=2026.8.5`
- `uv.lock`: resolved to `2026.8.5`

## Type of change

- [x] Dependency bump / chore

## Checklist

- [x] Commits are signed off (`git commit -s`) — DCO
- [x] `manifest.json` pin and `pyproject.toml` lower bound match
- [x] `uv.lock` updated

## Test plan

After merge / HACS update:

1. Remove the integration entry (or otherwise force a **fresh bootstrap** — cached descriptors keep old labels/counts).
2. Re-add with filter as before (`ui` / PL).
3. Expect ~100 entities and labels like „Typ dmuchawy” instead of `PARAM_10`.

## Notes

Release: https://github.com/marpi82/py-bragerone/releases/tag/2026.8.5  
Upstream: marpi82/py-bragerone#298, marpi82/py-bragerone#299
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

