### PR TITLE
fix: keep ALL_CAPS sensor states from becoming sTOP

### DIFF
--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -168,4 +168,9 @@ def _normalize_text_state(value: Any) -> Any:
     head = text[0]
     if not head.isalpha():
         return text
+    # Keep unresolved ALL_CAPS enum tags (``STOP``) intact. Lowercasing only the
+    # first letter produced nonsense like ``sTOP`` when unit option labels missed.
+    letters = [ch for ch in text if ch.isalpha()]
+    if letters and all(ch.isupper() for ch in letters):
+        return text
     return f"{head.lower()}{text[1:]}"

--- a/tests/test_sensor_text_normalization.py
+++ b/tests/test_sensor_text_normalization.py
@@ -8,6 +8,13 @@ from custom_components.habragerone.sensor import _normalize_text_state
 def test_normalize_text_state_lowercases_first_letter() -> None:
     assert _normalize_text_state("Włączone") == "włączone"
     assert _normalize_text_state("Załączony") == "załączony"
+    assert _normalize_text_state("Stop") == "stop"
+
+
+def test_normalize_text_state_keeps_all_caps_enum_tags() -> None:
+    assert _normalize_text_state("STOP") == "STOP"
+    assert _normalize_text_state("STOP_BOILER") == "STOP_BOILER"
+    assert _normalize_text_state("WORK") == "WORK"
 
 
 def test_normalize_text_state_leaves_non_text_or_empty() -> None:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sensor text normalization lowercased only the first character, so unresolved ALL_CAPS enum tags like `STOP` became **`sTOP`** on Status kotła.

Keep strings whose letters are all uppercase intact (`STOP`, `STOP_BOILER`). Sentence-case Polish labels such as `Włączone` / `Stop` still become `włączone` / `stop`.

Pairs with py-bragerone fix that resolves `BoilerState['STOP']` → i18n `Stop` so the preferred path is a proper label, not the raw tag.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Tests / CI / tooling / chore

## Checklist

- [x] Commits are signed off (`git commit -s`) — DCO
- [x] `uv run poe validate` passes locally
- [x] Tests updated (`test_sensor_text_normalization.py`)

## Test plan

```bash
uv run poe test tests/test_sensor_text_normalization.py
uv run poe validate
```

## Notes

Independent of a py-bragerone pin bump — safe to merge first as a guard. Full Polish `Stop`/`Praca` labels need the library PR + release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

