### PR TITLE
fix: classify ParamMap value-command PARAMs as writable select/number

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wh
 
 ## Architecture in one paragraph
 
-All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 4`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go the other way: platform entities call `runtime.async_write`, which uses `command_write.prepare_write` (enum label→raw, inverse numeric transform, min/max check, route selection) before dispatching to the gateway.
+All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 5`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go the other way: platform entities call `runtime.async_write`, which uses `command_write.prepare_write` (enum label→raw, inverse numeric transform, min/max check, route selection) before dispatching to the gateway.
 
 ## Non-negotiable conventions
 

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -556,6 +556,49 @@ def _has_named_command_rule(mapping: dict[str, Any] | None) -> bool:
     return False
 
 
+def _mapping_has_parameter_write(mapping: dict[str, Any] | None) -> bool:
+    """Return whether the ParamMap declares a write to a value channel.
+
+    Live menus sometimes list editable PARAMs only under ``status`` (or omit
+    kinds entirely for panel-only candidates). Those still carry
+    ``paths.command`` entries such as ``{group: P6, number: 61, use: v}``.
+    """
+    if not isinstance(mapping, dict):
+        return False
+    paths = mapping.get("paths")
+    if not isinstance(paths, Mapping):
+        return False
+    commands = paths.get("command")
+    if not isinstance(commands, list):
+        return False
+    for entry in commands:
+        if not isinstance(entry, Mapping):
+            continue
+        group = entry.get("group") if entry.get("group") is not None else entry.get("pool")
+        number = entry.get("number")
+        if number is None:
+            number = entry.get("index")
+        if number is None:
+            number = entry.get("idx")
+        use = entry.get("use")
+        if use is None:
+            use = entry.get("path")
+        if use is None:
+            use = entry.get("pathType")
+        if use is None:
+            use = entry.get("chan")
+        if not isinstance(group, str) or not group.strip():
+            continue
+        if not isinstance(number, int):
+            continue
+        if not isinstance(use, str) or not use.strip():
+            continue
+        use_norm = use.strip().lower()
+        if use_norm in {"v", "value"}:
+            return True
+    return False
+
+
 def _command_rule_names(mapping: dict[str, Any] | None) -> set[str]:
     names: set[str] = set()
     if not isinstance(mapping, dict):
@@ -584,7 +627,12 @@ def _is_action_command_name(command: str) -> bool:
 def _is_menu_command_action(*, symbol: str, symbol_kinds: set[str], mapping: dict[str, Any] | None = None) -> bool:
     if "write" in symbol_kinds:
         return True
-    return "special" in symbol_kinds and (_is_command_like_symbol(symbol) or _has_named_command_rule(mapping))
+    if "special" in symbol_kinds and (_is_command_like_symbol(symbol) or _has_named_command_rule(mapping)):
+        return True
+    # STATUS_* computed rules must stay read-only even when they expose command_rules.
+    if symbol.upper().startswith("STATUS_"):
+        return False
+    return _mapping_has_parameter_write(mapping)
 
 
 def normalize_cached_descriptors(descriptors_raw: list[Any]) -> list[EntityDescriptor]:

--- a/custom_components/habragerone/const.py
+++ b/custom_components/habragerone/const.py
@@ -25,7 +25,7 @@ CONF_ENUM_MAP: Final = "enum_map"
 CONF_RAW_TO_LABEL: Final = "raw_to_label"
 CONF_BOOTSTRAP_DEBUG: Final = "bootstrap_debug"
 CONF_BOOTSTRAP_VERSION: Final = "bootstrap_version"
-BOOTSTRAP_VERSION: Final = 4
+BOOTSTRAP_VERSION: Final = 5
 
 DATA_API: Final = "api"
 DATA_GATEWAY: Final = "gateway"

--- a/tests/test_bootstrap_classification.py
+++ b/tests/test_bootstrap_classification.py
@@ -552,9 +552,8 @@ def test_is_menu_command_action_uses_parameter_write_unless_status_symbol() -> N
         )
         is True
     )
-    assert (
-        _mapping_has_parameter_write({"paths": {"command": [{"group": "P6", "number": 1, "chan": "v"}]}}) is True
-    )
+    assert _mapping_has_parameter_write({"paths": {"command": [{"group": "P6", "number": 1, "chan": "v"}]}}) is True
+
 
 def test_normalize_cached_descriptors_treats_status_menu_param_with_write_path_as_select() -> None:
     """Editable Tak/Nie PARAMs listed only under menu status must become select."""

--- a/tests/test_bootstrap_classification.py
+++ b/tests/test_bootstrap_classification.py
@@ -4,6 +4,8 @@ install_pybragerone_stubs()
 
 from custom_components.habragerone.bootstrap import (  # noqa: E402
     _collect_symbol_kinds_from_route,
+    _is_menu_command_action,
+    _mapping_has_parameter_write,
     _normalize_panel_path,
     normalize_cached_descriptors,
 )
@@ -486,6 +488,73 @@ def test_collect_symbol_kinds_from_route_reads_parameter_string_token_from_dict(
     assert "COMMAND_MODULE_RESTART" in kinds
     assert "write" in kinds["COMMAND_MODULE_RESTART"]
 
+
+def test_mapping_has_parameter_write_accepts_value_channel_aliases() -> None:
+    """Cover alternate ParamMap field names used by inline/index factories."""
+    assert _mapping_has_parameter_write(None) is False
+    assert _mapping_has_parameter_write({}) is False
+    assert _mapping_has_parameter_write({"paths": "bad"}) is False
+    assert _mapping_has_parameter_write({"paths": {"command": "bad"}}) is False
+    assert _mapping_has_parameter_write({"paths": {"command": ["skip", 1]}}) is False
+
+    assert (
+        _mapping_has_parameter_write(
+            {
+                "paths": {
+                    "command": [
+                        {"pool": "P10", "index": 2, "path": "value"},
+                    ]
+                }
+            }
+        )
+        is True
+    )
+    assert (
+        _mapping_has_parameter_write(
+            {
+                "paths": {
+                    "command": [
+                        {"group": "", "number": 1, "use": "v"},
+                        {"group": "P6", "idx": 61, "pathType": "V"},
+                    ]
+                }
+            }
+        )
+        is True
+    )
+    assert (
+        _mapping_has_parameter_write(
+            {
+                "paths": {
+                    "command": [
+                        {"group": "P6", "number": "61", "use": "v"},
+                        {"group": "P6", "number": 61, "chan": "   "},
+                        {"group": "P6", "number": 61, "chan": "s"},
+                    ]
+                }
+            }
+        )
+        is False
+    )
+
+
+def test_is_menu_command_action_uses_parameter_write_unless_status_symbol() -> None:
+    mapping = {"paths": {"command": [{"group": "P6", "number": 239, "use": "v"}]}}
+    assert _is_menu_command_action(symbol="PARAM_239", symbol_kinds=set(), mapping=mapping) is True
+    assert _is_menu_command_action(symbol="STATUS_P5_10", symbol_kinds={"status"}, mapping=mapping) is False
+    assert _is_menu_command_action(symbol="PARAM_1", symbol_kinds={"read"}, mapping={"paths": {"command": []}}) is False
+    assert _is_menu_command_action(symbol="PARAM_1", symbol_kinds={"write"}, mapping=None) is True
+    assert (
+        _is_menu_command_action(
+            symbol="CUSTOM_ACTION",
+            symbol_kinds={"special"},
+            mapping={"command_rules": [{"command": "MODULE_RESTART"}]},
+        )
+        is True
+    )
+    assert (
+        _mapping_has_parameter_write({"paths": {"command": [{"group": "P6", "number": 1, "chan": "v"}]}}) is True
+    )
 
 def test_normalize_cached_descriptors_treats_status_menu_param_with_write_path_as_select() -> None:
     """Editable Tak/Nie PARAMs listed only under menu status must become select."""

--- a/tests/test_bootstrap_classification.py
+++ b/tests/test_bootstrap_classification.py
@@ -485,3 +485,129 @@ def test_collect_symbol_kinds_from_route_reads_parameter_string_token_from_dict(
 
     assert "COMMAND_MODULE_RESTART" in kinds
     assert "write" in kinds["COMMAND_MODULE_RESTART"]
+
+
+def test_normalize_cached_descriptors_treats_status_menu_param_with_write_path_as_select() -> None:
+    """Editable Tak/Nie PARAMs listed only under menu status must become select."""
+    descriptors = [
+        {
+            "symbol": "PARAM_61",
+            "devid": "MOD1",
+            "pool": "P6",
+            "chan": "v",
+            "idx": 61,
+            "min": 0,
+            "max": 1,
+            "unit": {"0": "Wyłączony", "1": "Załączony"},
+            "mapping": {
+                "paths": {
+                    "value": [{"group": "P6", "number": 61, "use": "v"}],
+                    "command": [{"group": "P6", "number": 61, "use": "v", "raw": "!![]"}],
+                    "min": [],
+                    "max": [],
+                    "unit": [],
+                    "status": [],
+                }
+            },
+            "writable": False,
+            "menu_kinds": ["status"],
+        },
+        {
+            "symbol": "PARAM_239",
+            "devid": "MOD1",
+            "pool": "P6",
+            "chan": "v",
+            "idx": 239,
+            "min": 0,
+            "max": 1,
+            "unit": {"0": "Nie", "1": "Tak"},
+            "mapping": {
+                "paths": {
+                    "command": [{"group": "P6", "number": 239, "use": "v"}],
+                }
+            },
+            "writable": False,
+            "menu_kinds": ["status"],
+        },
+    ]
+
+    normalized = normalize_cached_descriptors(descriptors)
+    by_symbol = {item["symbol"]: item for item in normalized}
+
+    assert by_symbol["PARAM_61"]["writable"] is True
+    assert by_symbol["PARAM_61"]["platform"] == "select"
+    assert by_symbol["PARAM_61"]["options"] == ["Wyłączony", "Załączony"]
+    assert by_symbol["PARAM_239"]["writable"] is True
+    assert by_symbol["PARAM_239"]["platform"] == "select"
+    assert by_symbol["PARAM_239"]["options"] == ["Nie", "Tak"]
+
+
+def test_normalize_cached_descriptors_treats_panel_only_param_with_write_path_as_number() -> None:
+    """PARAM16_* feeder setpoints have empty menu_kinds but still expose paths.command."""
+    descriptors = [
+        {
+            "symbol": "PARAM16_2",
+            "devid": "MOD1",
+            "pool": "P10",
+            "chan": "v",
+            "idx": 2,
+            "min": 259,
+            "max": 370,
+            "unit": None,
+            "mapping": {
+                "paths": {
+                    "value": [{"group": "P10", "number": 2, "use": "v"}],
+                    "command": [{"group": "P10", "number": 2, "use": "v", "raw": "!![]"}],
+                    "min": [{"group": "P10", "number": 2, "use": "n"}],
+                    "max": [{"group": "P10", "number": 2, "use": "x"}],
+                }
+            },
+            "writable": False,
+            "menu_kinds": [],
+        }
+    ]
+
+    normalized = normalize_cached_descriptors(descriptors)
+
+    assert len(normalized) == 1
+    assert normalized[0]["writable"] is True
+    assert normalized[0]["platform"] == "number"
+
+
+def test_normalize_cached_descriptors_keeps_status_symbol_readonly_without_value_write() -> None:
+    descriptors = [
+        {
+            "symbol": "STATUS_P5_14",
+            "devid": "MOD1",
+            "pool": "P5",
+            "chan": "s",
+            "idx": 14,
+            "unit": "wn.9994",
+            "mapping": {
+                "paths": {
+                    "value": [
+                        {
+                            "if": [
+                                {
+                                    "expected": 1,
+                                    "operation": "equalTo",
+                                    "value": [{"group": "P5", "number": 14, "use": "s", "bit": 1}],
+                                }
+                            ],
+                            "then": "ON",
+                        }
+                    ],
+                    "command": [],
+                },
+                "command_rules": [],
+            },
+            "writable": False,
+            "menu_kinds": ["status"],
+        }
+    ]
+
+    normalized = normalize_cached_descriptors(descriptors)
+
+    assert len(normalized) == 1
+    assert normalized[0]["writable"] is False
+    assert normalized[0]["platform"] == "binary_sensor"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Editable parameters that the live menu lists only under `status` (or with empty `menu_kinds` for panel-only candidates) were forced read-only because writability required `menu_kinds=write`.

Those ParamMaps still declare `paths.command` to a value channel (`use: v`). Bootstrap now treats that as writable:

- `PARAM_61` / `PARAM_32` / `PARAM_67` / `PARAM_239` → **select** (Tak/Nie or Wyłączony/Załączony)
- `PARAM16_2` / `PARAM16_4` / `PARAM16_5` → **number** (feeder power / throughput setpoints)

`STATUS_*` stays read-only. `BOOTSTRAP_VERSION` bumped **4 → 5** so cached descriptors reclassify on next setup.

## Type of change

- [x] Bug fix (non-breaking for protocol; platform/`unique_id` suffix changes for the reclassified symbols)
- [ ] New feature / enhancement
- [x] Breaking change (`unique_id` platform suffix for the 7 reclassified symbols; `BOOTSTRAP_VERSION` / descriptor cache) — orphaned old `binary_sensor`/`sensor` entities may need manual cleanup
- [ ] Docs only
- [x] Tests / CI / tooling / chore

## Checklist

- [x] Commits are signed off (`git commit -s`) — DCO
- [x] English only in code, comments, and docs
- [ ] `uv run poe validate` passes locally
- [x] Tests added / updated (`tests/test_bootstrap_classification.py` — helper branch coverage for Codecov patch)
- [x] Docs / AGENTS.md updated for `BOOTSTRAP_VERSION = 5`
- [x] No secrets / credentials / real device dumps committed

## Test plan

```bash
uv run poe test -- tests/test_bootstrap_classification.py
uv run poe lint
uv run poe typecheck
```

Offline reclassification of the latest diagnostic dump confirms the seven entities above flip platforms as expected; true statuses/sensors stay unchanged.

## Notes for reviewers

After merge/release: reload the integration (bootstrap v5 invalidates the cache). Old `binary_sensor.*` / `sensor.*` entity IDs for these symbols will not migrate automatically because `unique_id` includes the platform suffix.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

