### PR TITLE
chore(deps): bump py-bragerone to 2026.8.6 for HA 2026.8.3

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,7 +16,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.5",
+    "py-bragerone==2026.8.6",
     "tree-sitter==0.26.0"
   ],
   "version": "2026.8.1"

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -19,5 +19,5 @@
     "py-bragerone==2026.8.6",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.1"
+  "version": "2026.8.3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.5",
+    "py-bragerone>=2026.8.6",
 ]
 classifiers = [
   "Development Status :: 3 - Alpha",

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.5" },
+    { name = "py-bragerone", specifier = ">=2026.8.6" },
 ]
 
 [package.metadata.requires-dev]
@@ -2190,7 +2190,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.5"
+version = "2026.8.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2200,9 +2200,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/85/25/7b628e87707d89e661695328c675fbdf70fbdf0cbb536fb35e35c0cf958e/py_bragerone-2026.8.5.tar.gz", hash = "sha256:eae65b84a56f90491aae76c1bd2ad2a4e89de8b6af195d0321137f42fea58731", size = 104835, upload-time = "2026-08-14T15:22:43.514Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/21/24/5a290e619870eaf98a7dd1f8dc34c80d4773472f272b5b5e216d14eeeb3d/py_bragerone-2026.8.6.tar.gz", hash = "sha256:54252d16b6db0386b29d31488f1e0e60321753a30b67f590c8bf9dbdf85f2198", size = 105232, upload-time = "2026-08-14T15:59:43.87Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/26/de/fb20591d578e2f8bb86f550e9ad740589c7cda4ca25578493b8f38f5fae0/py_bragerone-2026.8.5-py3-none-any.whl", hash = "sha256:c176e930640d7e7f87276f3e9523ce1e1d6cf63c3fcc45bb6cd9682155cc6982", size = 110639, upload-time = "2026-08-14T15:22:42.284Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/cb/955cd2abc7309bdbd25838372ada019d7889eda656aca147f7d68dee07df/py_bragerone-2026.8.6-py3-none-any.whl", hash = "sha256:2be8519cad97084abbf9c086c13986faf9cce5eabe323f9318b256d815d5ab8f", size = 111048, upload-time = "2026-08-14T15:59:42.166Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepares the **ha-bragerone `2026.8.3`** release (component CalVer stays independent of the library):

- `manifest.json` / `pyproject.toml` / `uv.lock`: pin **`py-bragerone==2026.8.6`**
- `manifest.json` `"version"`: **`2026.8.3`** (not `2026.8.6`)

Library `2026.8.6` brings STATUS label/`sTOP` fixes (#301) and restores the six inline `STATUS_P5_*` entities (#302). HA already has bootstrap v5 / select+number classification (#162) and ALL_CAPS state fix (#161) on main.

## Type of change

- [x] Dependency bump / chore
- [x] Breaking change (`BOOTSTRAP_VERSION` / platform reclassification already on main via #162 — call out in release notes)

## Checklist

- [x] Commits are signed off (`git commit -s`) — DCO
- [x] `manifest.json` pin and `pyproject.toml` lower bound match
- [x] `uv.lock` updated
- [x] Integration `version` set to the next HA CalVer (`2026.8.3`), not equalized to the library tag
- [x] No secrets / credentials / real device dumps committed

## Test plan

User dump after #162 (still on library 2026.8.5): **95** entities, platforms look correct (`select`/`number` for the reported PARAMs). After this pin + fresh bootstrap, expect the six inline STATUS entities back as well (~100).

```bash
uv sync --locked --group dev --group test
uv run python -c 'import importlib.metadata as m; print(m.version("py-bragerone"))'
```

## Notes for reviewers

After merge to `main` and green CI: tag **`2026.8.3`** (not `2026.8.6`) to cut the HACS release.

PyPI: https://pypi.org/project/py-bragerone/2026.8.6/  
GitHub Release (lib): https://github.com/marpi82/py-bragerone/releases/tag/2026.8.6
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

