### PR TITLE
chore: prepare Cursor Bugbot local pre-push review workflow

### DIFF
--- a/.cursor/BUGBOT.md
+++ b/.cursor/BUGBOT.md
@@ -1,0 +1,33 @@
+# Bugbot rules — ha-bragerone
+
+Project-specific review gates for Cursor Bugbot (PR reviews and local `/review-bugbot`).
+Keep findings actionable; prefer blocking bugs over style nits already covered by ruff/mypy/CI.
+
+## Architecture
+
+- Flag any new polling (`should_poll = True`), `DataUpdateCoordinator`, or periodic REST refresh for state-bearing entities. State updates must come from `runtime.add_listener()` / push. Buttons may stay listener-free.
+- Flag re-implementation of Brager protocol / catalog / Socket.IO logic inside `custom_components/` — that belongs in `py-bragerone`.
+- Flag writes that skip enum label→raw conversion, inverse numeric transform, min/max (`n`/`x`) validation, or route selection (`parameter_write` vs `raw_command`). Invalid input must raise, never send silently.
+
+## Stability / breaking changes
+
+- Treat changes to `unique_id` patterns (`{entry_id}_{devid}_{symbol}` + platform suffix) as **blocking** unless the PR explicitly documents a migration / breaking change.
+- Flag descriptor-shape or classification changes that omit a `BOOTSTRAP_VERSION` bump when cached `CONF_ENTITY_DESCRIPTORS` would go stale.
+- Flag DeviceInfo identifier changes away from `(domain, devid)` without an explicit migration plan.
+
+## Security & secrets
+
+- Flag logs, diagnostics, or committed fixtures that expose passwords, tokens, or live account dumps. Diagnostics must redact credentials.
+- Flag hardcoded credentials or `.env` secrets in the tree.
+
+## Quality
+
+- English only in code, comments, and docstrings.
+- New/changed write-path or classification behavior without matching tests is a blocking bug when practical to test offline.
+- Docs/translations drift: user-facing behavior changes without `README.md` / `docs/` / `strings.json` + `translations/en.json` updates are defects.
+- Version pin drift is blocking: `manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency.
+
+## Non-blocking
+
+- Pure formatting / import-order nits (CI handles them).
+- `TODO` / `FIXME` that reference an existing issue number.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -20,6 +20,7 @@
 - [ ] Docs / translations updated when user-facing behavior changes (`README.md`, `docs/`, `strings.json` + `translations/en.json`)
 - [ ] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency)
 - [ ] No secrets / credentials / real device dumps committed; diagnostics remain redacted
+- [ ] Ran Cursor `/review-bugbot` (or `/review`) on the final diff before push when using Cursor 3.7+ (see `.cursor/BUGBOT.md`)
 
 ## Test plan
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -91,3 +91,14 @@ repos:
         entry: bash -lc 'uv run --group test pytest --maxfail=1 --disable-warnings -q --cov=custom_components.habragerone --cov-report=term-missing --cov-fail-under=80'
         pass_filenames: false
         stages: [pre-push]
+
+      # Soft reminder only: Cursor Bugbot has no CLI/hook yet ("coming soon").
+      # Local review is `/review-bugbot` or `/review` in the Cursor agent (3.7+).
+      - id: bugbot-pre-push-reminder
+        name: remind Cursor /review-bugbot before push
+        language: system
+        entry: bash scripts/bugbot-pre-push-reminder.sh
+        pass_filenames: false
+        always_run: true
+        verbose: true
+        stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,15 @@ New config/options/errors strings go into `strings.json` and English `translatio
 - `hacs.json` homeassistant minimum vs the `homeassistant` dependency in `pyproject.toml` (must match; `manifest.json` has no HA version field).
 - `manifest.json` `py-bragerone==X` pin vs `pyproject.toml` `py-bragerone>=X`.
 - ruff `target-version` vs actual runtime Python.
+
+## Cursor Bugbot (local + PR)
+
+- Rules: `.cursor/BUGBOT.md` (also applied on GitHub Bugbot reviews).
+- Before push (Cursor 3.7+ / [cursor.com/agents](https://cursor.com/agents)): `/review-bugbot` or `/review`. Docs: https://cursor.com/docs/bugbot
+- Pre-push prints a soft reminder only — Bugbot CLI/hook is not available yet; cannot hard-gate push.
+- Patch-ID dedup can skip a duplicate GitHub Bugbot review for an unchanged diff; Copilot re-request remains separate.
+
+## Cursor Cloud specific instructions
+
+- Default Cloud Agent install syncs deps via the sibling `py-bragerone` `.cursor/environment.json` (`uv sync` for both repos). Use `uv run poe …` from this checkout.
+- Optional local HA smoke: `uv run poe hass` then open `http://localhost:8123` (Chrome / computer-use). Docker Compose profiles are not available in the current Cloud Agent image (no Docker). Live Brager config needs credentials.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -28,8 +28,22 @@ See [DEVELOPMENT.md](DEVELOPMENT.md). Short version:
 ```bash
 uv sync --locked --group dev --group test
 uv run pre-commit install
+uv run pre-commit install --hook-type pre-push
 uv run poe validate
 ```
+
+## Pre-push review (Cursor Bugbot)
+
+Before `git push`, run Cursor Bugbot locally so findings land while the change is still warm:
+
+1. In the Cursor agent input (Cursor **3.7+**, or [cursor.com/agents](https://cursor.com/agents)): `/review-bugbot` (or `/review` for Bugbot + Security Review).
+2. Fix findings, then push the same diff when possible.
+
+Official docs: [Bugbot](https://cursor.com/docs/bugbot) · June 2026 update: [blog](https://cursor.com/blog/bugbot-updates-june-2026).
+
+Project rules live in [`.cursor/BUGBOT.md`](.cursor/BUGBOT.md) (read by local `/review-bugbot` and by GitHub Bugbot). Enable the repo in [Bugbot Automations](https://cursor.com/automations/from-cursor/bugbot) if PR reviews are not already on.
+
+**Limits today:** there is no Bugbot CLI, so a git hook cannot *block* on review — the pre-push hook only prints a reminder. Local and PR Bugbot share a [patch ID](https://git-scm.com/docs/git-patch-id); an unchanged diff can skip a duplicate GitHub Bugbot run. That dedup is **Bugbot↔Bugbot**, not GitHub Copilot (`.github/workflows/copilot-rerequest.yml` is separate).
 
 ## Coding standards
 

--- a/scripts/bugbot-pre-push-reminder.sh
+++ b/scripts/bugbot-pre-push-reminder.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Soft pre-push reminder: Cursor Bugbot has no CLI/hook yet ("coming soon").
+# Local review is an agent slash command, not something this hook can enforce.
+set -euo pipefail
+
+cat <<'EOF'
+============================================================
+Reminder: run Cursor Bugbot locally before push (discipline, not a gate).
+  In Cursor agent input (3.7+ / cursor.com/agents): /review-bugbot
+  Or: /review  (Bugbot + Security Review menu)
+  Rules: .cursor/BUGBOT.md  |  Docs: https://cursor.com/docs/bugbot
+  Same patch ID => GitHub Bugbot can skip a duplicate PR review.
+  CLI/hook support is not available yet — this hook always exits 0.
+============================================================
+EOF


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepare both the rules and the developer workflow so Cursor Bugbot can be run **before push** (Cursor 3.7+ `/review-bugbot`), matching the June 2026 Bugbot local-review flow.

Official docs: https://cursor.com/docs/bugbot · https://cursor.com/blog/bugbot-updates-june-2026

## Changes

- Add `.cursor/BUGBOT.md` with HA integration review gates (push-not-poll, write safety, unique_id, bootstrap, secrets, pin sync).
- Soft pre-push reminder via `scripts/bugbot-pre-push-reminder.sh` (always exits 0 — **no Bugbot CLI yet**, cannot hard-gate).
- Document workflow in `CONTRIBUTING.md` / `AGENTS.md`; PR checklist checkbox for `/review-bugbot`.

## Notes

- Patch-ID dedup is **Bugbot↔Bugbot** (local then identical PR diff can skip a duplicate GitHub Bugbot run). GitHub Copilot re-request remains separate.
- Enable Bugbot for this repository in the Cursor Bugbot dashboard if it is not already on.
- Companion PR on `py-bragerone` (same branch name).

## Checklist

- [x] Docs / tooling only
- [x] Reminder hook verified (`pre-commit run bugbot-pre-push-reminder --hook-stage pre-push`)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

