### PR TITLE
chore: Cloud Agent native Home Assistant smoke workflow

### DIFF
--- a/.config/configuration.yaml
+++ b/.config/configuration.yaml
@@ -1,19 +1,21 @@
-# Home Assistant development configuration for ha-bragerone
-default_config:
+# Lean Home Assistant config for integration smoke tests (native / Cloud Agent).
+# Avoids ``default_config`` so ``--skip-pip`` does not fail on Bluetooth/cloud/ssdp/…
+# wheels that are irrelevant to BragerOne development.
 
-# Enable frontend
+homeassistant:
+
+http:
+
 frontend:
 
-# Logger configuration
+config:
+
 logger:
   default: info
   logs:
     custom_components.habragerone: debug
     pybragerone: debug
-# Development configuration
-# Uncomment for demo data
-# demo:
 
-# Your ha-bragerone integration configuration
-# habragerone:
-#   # Add your configuration here when implemented
+recorder:
+history:
+logbook:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,6 +70,16 @@ USE_LOCAL_PYBRAGERONE=1 uv run poe hass-prepare && uv run poe hass-cloud
 ```
 
 - `hass-cloud` uses `--skip-pip` so `manifest.json` requirements do not overwrite the uv-managed venv (needed when testing editable sibling `py-bragerone`).
-- First browser visit is HA **onboarding** unless `config/.storage` already exists — create a local owner user, then add the BragerOne integration via UI (live Brager credentials required for end-to-end).
+- First browser visit is HA **onboarding** unless `config/.storage` already exists. Cloud smoke owner account (local only, not a secret): username `cursor` / password `cursor`.
 - Attach logs: `tmux -f /exec-daemon/tmux.portal.conf attach -t ha-bragerone` (or `tmux attach -t ha-bragerone`).
 - Offline unit tests remain the default gate: `uv run poe test` / `uv run poe validate`.
+
+### UI / integration testing — read-only hardware rule
+
+When exercising the live BragerOne / TiSConnect integration in Home Assistant (computer-use, Chrome, or manual):
+
+- **Do not change controller state.** Never toggle switches, press buttons, change `number`/`select` setpoints, or otherwise write to the device through the integration under test.
+- Allowed: open dashboards, inspect entity states/attributes, diagnostics (redacted), config-flow screens that only read/login, logs.
+- Forbidden without an explicit user request for that write: any entity service call or UI control that would send a command to the boiler / module.
+
+This protects a real heating system attached to live credentials. Offline unit tests with stubs remain unconstrained.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,3 +53,23 @@ New config/options/errors strings go into `strings.json` and English `translatio
 - `hacs.json` homeassistant minimum vs the `homeassistant` dependency in `pyproject.toml` (must match; `manifest.json` has no HA version field).
 - `manifest.json` `py-bragerone==X` pin vs `pyproject.toml` `py-bragerone>=X`.
 - ruff `target-version` vs actual runtime Python.
+
+## Cursor Cloud specific instructions
+
+Default Cloud Agent install syncs deps via the sibling `py-bragerone` `.cursor/environment.json` (`uv sync` for both repos). Use `uv run poe …` from this checkout. **Docker is not available** in the current Cloud Agent image — do not use `docker-compose` profiles here.
+
+### Local Home Assistant smoke (UI / pre-release)
+
+Native HA (no Docker), suitable for computer-use / Chrome against `http://127.0.0.1:8123`:
+
+```bash
+uv run poe hass-prepare          # config/ + symlink custom_components
+uv run poe hass-cloud            # tmux session `ha-bragerone`, --skip-pip, wait for :8123
+# optional unreleased library:
+USE_LOCAL_PYBRAGERONE=1 uv run poe hass-prepare && uv run poe hass-cloud
+```
+
+- `hass-cloud` uses `--skip-pip` so `manifest.json` requirements do not overwrite the uv-managed venv (needed when testing editable sibling `py-bragerone`).
+- First browser visit is HA **onboarding** unless `config/.storage` already exists — create a local owner user, then add the BragerOne integration via UI (live Brager credentials required for end-to-end).
+- Attach logs: `tmux -f /exec-daemon/tmux.portal.conf attach -t ha-bragerone` (or `tmux attach -t ha-bragerone`).
+- Offline unit tests remain the default gate: `uv run poe test` / `uv run poe validate`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -71,6 +71,8 @@ USE_LOCAL_PYBRAGERONE=1 uv run poe hass-prepare && uv run poe hass-cloud
 
 - `hass-cloud` uses `--skip-pip` so `manifest.json` requirements do not overwrite the uv-managed venv (needed when testing editable sibling `py-bragerone`).
 - First browser visit is HA **onboarding** unless `config/.storage` already exists. Cloud smoke owner account (local only, not a secret): username `cursor` / password `cursor`.
+- Prefer **English** UI language on this Cloud HA instance (keeps screenshots/logs consistent for agents).
+- BragerOne / TiSConnect cloud credentials for re-adding the integration may be saved in the **Chrome password store** on this VM — use those if a config entry must be removed and recreated. Do not commit credentials.
 - Attach logs: `tmux -f /exec-daemon/tmux.portal.conf attach -t ha-bragerone` (or `tmux attach -t ha-bragerone`).
 - Offline unit tests remain the default gate: `uv run poe test` / `uv run poe validate`.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -23,6 +23,17 @@ uv run pre-commit install --hook-type pre-push
 docker-compose up -d
 ```
 
+### Cursor Cloud / native HA (no Docker)
+
+When Docker is unavailable (Cloud Agent), use:
+
+```bash
+uv run poe hass-prepare
+uv run poe hass-cloud    # http://127.0.0.1:8123
+```
+
+See `AGENTS.md` → **Cursor Cloud specific instructions**.
+
 ### Running Tests
 
 ```bash

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,8 @@ cov = { cmd = "pytest -q --cov=custom_components.habragerone --cov-report=term-m
 # HA Development
 hass = { shell = "python -m homeassistant --config config --debug" }
 hass-restart = { shell = "pkill -f homeassistant || true && python -m homeassistant --config config --debug" }
+hass-prepare = { shell = "./scripts/cloud_hass_prepare.sh" }
+hass-cloud = { shell = "./scripts/cloud_hass_start.sh" }
 # Docker commands
 docker-up = { cmd = "docker-compose up -d" }
 docker-down = { cmd = "docker-compose down" }

--- a/scripts/cloud_hass_prepare.sh
+++ b/scripts/cloud_hass_prepare.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Prepare a local Home Assistant config tree for Cloud Agent / native `poe hass`.
+# Idempotent. Does not start HA.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+CONFIG_DIR="${HASS_CONFIG:-config}"
+mkdir -p "$CONFIG_DIR"
+
+# Refresh from tracked template unless the operator opts out.
+if [[ "${HASS_KEEP_CONFIG:-0}" != "1" && -f ".config/configuration.yaml" ]]; then
+  cp .config/configuration.yaml "$CONFIG_DIR/configuration.yaml"
+  echo "Synced $CONFIG_DIR/configuration.yaml from .config/configuration.yaml"
+elif [[ ! -f "$CONFIG_DIR/configuration.yaml" ]]; then
+  cat >"$CONFIG_DIR/configuration.yaml" <<'EOF'
+# Lean Home Assistant config for integration smoke tests.
+homeassistant:
+http:
+frontend:
+config:
+logger:
+  default: info
+  logs:
+    custom_components.habragerone: debug
+    pybragerone: debug
+recorder:
+history:
+logbook:
+EOF
+  echo "Created $CONFIG_DIR/configuration.yaml"
+fi
+
+# HA loads custom integrations from <config>/custom_components
+TARGET="$CONFIG_DIR/custom_components"
+SOURCE="$PROJECT_DIR/custom_components"
+if [[ -L "$TARGET" ]]; then
+  ln -sfn "$SOURCE" "$TARGET"
+elif [[ -e "$TARGET" ]]; then
+  echo "WARNING: $TARGET exists and is not a symlink; leave it as-is."
+else
+  ln -s "$SOURCE" "$TARGET"
+  echo "Linked $TARGET -> $SOURCE"
+fi
+
+# Optional: install sibling py-bragerone editable for unreleased library testing.
+# HA startup should then use --skip-pip (see cloud_hass_start.sh) so requirements
+# from manifest.json do not overwrite the editable install.
+if [[ "${USE_LOCAL_PYBRAGERONE:-0}" == "1" ]]; then
+  SIBLING="${PY_BRAGERONE_PATH:-$PROJECT_DIR/../py-bragerone}"
+  if [[ ! -d "$SIBLING" ]]; then
+    echo "ERROR: USE_LOCAL_PYBRAGERONE=1 but sibling not found at $SIBLING" >&2
+    exit 1
+  fi
+  echo "Installing editable py-bragerone from $SIBLING"
+  uv pip install -e "$SIBLING"
+fi
+
+# With --skip-pip (Cloud Agent default), HA will not fetch frontend wheels itself.
+# Ensure UI packages exist in the uv venv.
+if ! uv run python -c 'import hass_frontend, turbojpeg' >/dev/null 2>&1; then
+  echo "Installing HA UI deps (home-assistant-frontend, PyTurboJPEG)…"
+  uv pip install home-assistant-frontend PyTurboJPEG
+else
+  echo "HA UI deps present (hass_frontend, turbojpeg)"
+fi
+
+echo "Home Assistant config ready under $CONFIG_DIR"
+echo "Next: uv run poe hass-cloud   # or ./scripts/cloud_hass_start.sh"

--- a/scripts/cloud_hass_start.sh
+++ b/scripts/cloud_hass_start.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Start Home Assistant for Cloud Agent smoke tests (native, no Docker).
+# Prepares config, launches HA in a tmux session, waits until :8123 answers.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_DIR="$(dirname "$SCRIPT_DIR")"
+cd "$PROJECT_DIR"
+
+CONFIG_DIR="${HASS_CONFIG:-config}"
+SESSION="${HASS_TMUX_SESSION:-ha-bragerone}"
+PORT="${HASS_PORT:-8123}"
+SKIP_PIP="${HASS_SKIP_PIP:-1}"
+TMUX_CONF="${TMUX_CONF:-/exec-daemon/tmux.portal.conf}"
+
+"$SCRIPT_DIR/cloud_hass_prepare.sh"
+
+TMUX=(tmux)
+if [[ -f "$TMUX_CONF" ]]; then
+  TMUX=(tmux -f "$TMUX_CONF")
+fi
+
+if "${TMUX[@]}" has-session -t "=$SESSION" 2>/dev/null; then
+  echo "tmux session '$SESSION' already exists — not starting a second HA."
+else
+  if [[ "$SKIP_PIP" == "1" ]]; then
+    START_CMD="uv run python -m homeassistant --config '$CONFIG_DIR' --debug --skip-pip"
+  else
+    START_CMD="uv run python -m homeassistant --config '$CONFIG_DIR' --debug"
+  fi
+  "${TMUX[@]}" new-session -d -s "$SESSION" -c "$PROJECT_DIR" -- \
+    "${SHELL:-bash}" -lc "$START_CMD 2>&1 | tee '$CONFIG_DIR/home-assistant.boot.log'"
+  echo "Started HA in tmux session '$SESSION'"
+fi
+
+echo "Waiting for http://127.0.0.1:${PORT}/ …"
+for _ in $(seq 1 90); do
+  if curl -sf -o /dev/null "http://127.0.0.1:${PORT}/"; then
+    echo "Home Assistant is up: http://127.0.0.1:${PORT}/"
+    if [[ -f "$TMUX_CONF" ]]; then
+      echo "Attach logs: tmux -f $TMUX_CONF attach -t $SESSION"
+    else
+      echo "Attach logs: tmux attach -t $SESSION"
+    fi
+    echo "First visit shows onboarding unless .storage already exists."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "ERROR: HA did not become ready on :${PORT} within timeout." >&2
+echo "--- last boot log ---" >&2
+tail -n 80 "$CONFIG_DIR/home-assistant.boot.log" 2>/dev/null || true
+exit 1

--- a/scripts/cloud_hass_start.sh
+++ b/scripts/cloud_hass_start.sh
@@ -43,6 +43,8 @@ for _ in $(seq 1 90); do
       echo "Attach logs: tmux attach -t $SESSION"
     fi
     echo "First visit shows onboarding unless .storage already exists."
+    echo "UI smoke login (local): username cursor / password cursor"
+    echo "READ-ONLY: do not toggle switches or change setpoints on live BragerOne entities."
     exit 0
   fi
   sleep 2


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepare a **native** Home Assistant smoke path for Cursor Cloud Agents (no Docker): prepare config, start HA in tmux with `--skip-pip`, and document the workflow.

## Changes

- `scripts/cloud_hass_prepare.sh` / `cloud_hass_start.sh` + `poe hass-prepare` / `poe hass-cloud`
- Lean `.config/configuration.yaml` without `default_config`
- Cloud smoke owner: username `cursor` / password `cursor` (local only)
- Prefer **English** UI on this Cloud HA instance
- Brager cloud credentials may be in the **Chrome password store** for re-add after remove
- **Read-only UI rule**: never toggle switches / change setpoints / press buttons on live BragerOne entities unless the user explicitly asks for a write

## Verification (read-only)

- HA up; onboarding done; login `cursor`/`cursor` works
- BragerOne config entry present (`language: en`), **101** entities registered
- No controller writes performed by the agent

[HA overview after onboarding](https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fha_onboarding_overview.webp)
[Integrations after onboarding](https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fha_integrations_after_onboarding.webp)

## Checklist

- [x] Docs / tooling
- [x] Smoke: onboarding + login + integration present
- [x] Read-only hardware rule documented


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

