### PR TITLE
fix: UI filter uses SPA status visibility (bootstrap v7)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wh
 
 ## Architecture in one paragraph
 
-All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 5`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go the other way: platform entities call `runtime.async_write`, which uses `command_write.prepare_write` (enum label→raw, inverse numeric transform, min/max check, route selection) before dispatching to the gateway.
+All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 6`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go the other way: platform entities call `runtime.async_write`, which uses `command_write.prepare_write` (enum label→raw, inverse numeric transform, min/max check, route selection) before dispatching to the gateway.
 
 ## Non-negotiable conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,7 +25,7 @@ CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wh
 
 ## Architecture in one paragraph
 
-All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 6`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go the other way: platform entities call `runtime.async_write`, which uses `command_write.prepare_write` (enum label→raw, inverse numeric transform, min/max check, route selection) before dispatching to the gateway.
+All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The integration adds a thin HA layer: `config_flow.py` (UI setup, options, reauth; `VERSION = 2`) → `bootstrap.py` (one-time extraction of entity descriptors from the asset catalog, cached in `entry.data[CONF_ENTITY_DESCRIPTORS]`, invalidated by `BOOTSTRAP_VERSION = 7`) → `runtime.py` (`BragerRuntime`: owns the gateway, syncs `ParamStore`, fans out `ParamUpdate`s to listeners — **there is no `DataUpdateCoordinator`**) → platform files create entities from cached descriptors. Writes go the other way: platform entities call `runtime.async_write`, which uses `command_write.prepare_write` (enum label→raw, inverse numeric transform, min/max check, route selection) before dispatching to the gateway.
 
 ## Non-negotiable conventions
 

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -691,7 +691,7 @@ def _panel_group_symbols(groups: Mapping[str, list[str]]) -> set[str]:
     return {symbol for panel_symbols in groups.values() for symbol in panel_symbols if symbol}
 
 
-async def _build_panel_groups_with_fallback(
+async def _build_permission_gated_panel_groups(
     resolver: Any,
     *,
     device_menu: Any,
@@ -791,7 +791,7 @@ async def async_build_bootstrap_payload(
         module_mode = normalized_module_modes.get(str(module.devid), filter_mode)
         web_ui_only = module_mode == FILTER_MODE_UI
 
-        groups = await _build_panel_groups_with_fallback(
+        groups = await _build_permission_gated_panel_groups(
             resolver,
             device_menu=module.deviceMenu,
             permissions=module_permissions,

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -691,52 +691,6 @@ def _panel_group_symbols(groups: Mapping[str, list[str]]) -> set[str]:
     return {symbol for panel_symbols in groups.values() for symbol in panel_symbols if symbol}
 
 
-async def _resolver_build_panel_groups(
-    resolver: Any,
-    *,
-    device_menu: Any,
-    permissions: list[str] | None,
-    web_ui_only: bool,
-) -> dict[str, list[str]]:
-    """Call ``build_panel_groups``, tolerating older py-bragerone without ``web_ui_only``."""
-    kwargs: dict[str, Any] = {
-        "device_menu": device_menu,
-        "permissions": permissions,
-        "all_panels": True,
-        "web_ui_only": web_ui_only,
-    }
-    try:
-        return cast(dict[str, list[str]], await resolver.build_panel_groups(**kwargs))
-    except TypeError:
-        if not web_ui_only:
-            raise
-        kwargs.pop("web_ui_only")
-        LOGGER.warning(
-            "py-bragerone build_panel_groups lacks web_ui_only; UI filter cannot exclude service menus until upgraded"
-        )
-        return cast(dict[str, list[str]], await resolver.build_panel_groups(**kwargs))
-
-
-def _resolver_panel_route_diagnostics(
-    resolver: Any,
-    menu: Any,
-    *,
-    web_ui_only: bool,
-    routes_i18n: Any,
-) -> list[dict[str, Any]]:
-    """Call panel-route diagnostics with optional ``web_ui_only`` for older libraries."""
-    kwargs: dict[str, Any] = {
-        "all_panels": True,
-        "web_ui_only": web_ui_only,
-        "routes_i18n": routes_i18n,
-    }
-    try:
-        return cast(list[dict[str, Any]], resolver.panel_route_diagnostics_from_menu(menu, **kwargs))
-    except TypeError:
-        kwargs.pop("web_ui_only")
-        return cast(list[dict[str, Any]], resolver.panel_route_diagnostics_from_menu(menu, **kwargs))
-
-
 async def _build_panel_groups_with_fallback(
     resolver: Any,
     *,
@@ -767,10 +721,10 @@ async def _build_panel_groups_with_fallback(
     """
     groups: dict[str, list[str]] = {}
     try:
-        groups = await _resolver_build_panel_groups(
-            resolver,
+        groups = await resolver.build_panel_groups(
             device_menu=device_menu,
             permissions=permissions,
+            all_panels=True,
             web_ui_only=web_ui_only,
         )
     except Exception:
@@ -780,10 +734,10 @@ async def _build_panel_groups_with_fallback(
             return groups
         LOGGER.debug("Panel-group build returned no symbols for %s, retrying without permissions", devid)
 
-    groups = await _resolver_build_panel_groups(
-        resolver,
+    groups = await resolver.build_panel_groups(
         device_menu=device_menu,
         permissions=None,
+        all_panels=True,
         web_ui_only=web_ui_only,
     )
 
@@ -881,9 +835,9 @@ async def async_build_bootstrap_payload(
                 menu = await assets.get_module_menu(device_menu=module.deviceMenu, permissions=module_permissions)
                 per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu)
                 per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu)
-                per_module_route_diagnostics[module.devid] = _resolver_panel_route_diagnostics(
-                    resolver,
+                per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
                     menu,
+                    all_panels=True,
                     web_ui_only=web_ui_only,
                     routes_i18n=await resolver._i18n.get_namespace("routes"),
                 )
@@ -894,9 +848,9 @@ async def async_build_bootstrap_payload(
                 menu_all = await assets.get_module_menu(device_menu=module.deviceMenu, permissions=None)
                 per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu_all)
                 per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu_all)
-                per_module_route_diagnostics[module.devid] = _resolver_panel_route_diagnostics(
-                    resolver,
+                per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
                     menu_all,
+                    all_panels=True,
                     web_ui_only=web_ui_only,
                     routes_i18n=await resolver._i18n.get_namespace("routes"),
                 )

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -699,15 +699,12 @@ async def _build_panel_groups_with_fallback(
     devid: str,
     web_ui_only: bool = False,
 ) -> dict[str, list[str]]:
-    """Build panel groups, retrying without permissions when the gated attempt yields nothing.
+    """Build panel groups for *permissions* only — never retry with ``permissions=None``.
 
-    The permission-gated extraction can fail in two ways: it can raise, or it can succeed and
-    still return no symbols. Both are treated the same way and retried with ``permissions=None``,
-    mirroring the symbol-kind fallback used later in the same bootstrap loop.
-
-    A failing ungated retry is left to propagate, as it did before the empty-result case was
-    handled here. Setup then fails and Home Assistant retries it, which is recoverable; swallowing
-    the error would instead hand back an empty result as if the extraction had succeeded.
+    Ungating the menu tree would contradict SPA ``isRouteVisible`` (permission +
+    module permission) and silently create entities the account cannot see. An empty
+    permission-gated result is a valid empty set; extraction errors propagate so
+    Home Assistant can retry setup.
 
     Args:
         resolver: Parameter resolver used for the extraction.
@@ -719,35 +716,17 @@ async def _build_panel_groups_with_fallback(
             status checks still run separately for UI filter mode.
 
     Returns:
-        Mapping of panel name to symbols, empty when neither attempt produced symbols.
+        Mapping of panel name to symbols (possibly empty).
     """
-    groups: dict[str, list[str]] = {}
-    try:
-        groups = await resolver.build_panel_groups(
-            device_menu=device_menu,
-            permissions=permissions,
-            all_panels=True,
-            web_ui_only=web_ui_only,
-        )
-    except Exception:
-        LOGGER.debug("Panel-group build failed for %s, retrying without permissions", devid, exc_info=True)
-    else:
-        if _panel_group_symbols(groups):
-            return groups
-        LOGGER.debug("Panel-group build returned no symbols for %s, retrying without permissions", devid)
-
     groups = await resolver.build_panel_groups(
         device_menu=device_menu,
-        permissions=None,
+        permissions=permissions,
         all_panels=True,
         web_ui_only=web_ui_only,
     )
-
     if not _panel_group_symbols(groups):
-        # Scope the claim to panel-derived symbols: in permissions mode the later secondary pass
-        # can still contribute command-like entities that never came from a panel group.
         LOGGER.warning(
-            "Panel-group discovery returned no symbols for module %s, with and without permissions; "
+            "Panel-group discovery returned no symbols for module %s with the module permissions; "
             "no panel-derived entities will be created for it",
             devid,
         )
@@ -846,18 +825,22 @@ async def async_build_bootstrap_payload(
             except Exception:
                 LOGGER.debug("Menu kind extraction failed for %s", module.devid, exc_info=True)
         if not per_module_symbol_kinds[module.devid] and assets is not None and hasattr(assets, "get_module_menu"):
+            # Retry menu metadata with the same permission set only — never ungate.
             try:
-                menu_all = await assets.get_module_menu(device_menu=module.deviceMenu, permissions=None)
-                per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu_all)
-                per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu_all)
+                menu_retry = await assets.get_module_menu(
+                    device_menu=module.deviceMenu,
+                    permissions=module_permissions or None,
+                )
+                per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu_retry)
+                per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu_retry)
                 per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
-                    menu_all,
+                    menu_retry,
                     all_panels=True,
                     web_ui_only=web_ui_only,
                     routes_i18n=await resolver._i18n.get_namespace("routes"),
                 )
             except Exception:
-                LOGGER.debug("Menu kind fallback extraction failed for %s", module.devid, exc_info=True)
+                LOGGER.debug("Menu kind retry extraction failed for %s", module.devid, exc_info=True)
         all_candidate_symbols.update(symbols)
 
     details = await resolver.describe_symbols(sorted(all_candidate_symbols))
@@ -914,19 +897,18 @@ async def async_build_bootstrap_payload(
             symbol_kinds = per_module_symbol_kinds.get(module.devid, {}).get(symbol, set())
             mapping_raw = payload.get("mapping")
             mapping_dict = mapping_raw if isinstance(mapping_raw, dict) else None
-            is_menu_write = _is_menu_command_action(symbol=symbol, symbol_kinds=symbol_kinds, mapping=mapping_dict)
             panel_path = per_module_panel_paths.get(module.devid, {}).get(symbol, "")
             resolved_value: Any = None
             resolved_value_label: Any = None
-            keep_without_value = False
             has_runtime_raw = False
             visible_diag: Any = None
             try:
                 resolved = await resolver.resolve_value(symbol)
                 resolved_value = resolved.value
                 resolved_value_label = resolved.value_label
-                keep_without_value = is_menu_write and (_is_command_like_symbol(symbol) or _has_named_command_rule(mapping_dict))
-                if not keep_without_value and not _has_display_value(value=resolved.value, value_label=resolved.value_label):
+                # SPA ``isParameterVisible`` requires ``parameter.value !== undefined``.
+                # Command-like writes without a display value are not shown on the web UI.
+                if not _has_display_value(value=resolved.value, value_label=resolved.value_label):
                     if len(module_rejections) < 500:
                         module_rejections.append(
                             {
@@ -960,7 +942,6 @@ async def async_build_bootstrap_payload(
                             "symbol": symbol,
                             "panel_path": panel_path,
                             "menu_kinds": sorted(symbol_kinds),
-                            "keep_without_value": keep_without_value,
                             "has_runtime_raw": has_runtime_raw,
                             "value": resolved_value,
                             "value_label": resolved_value_label,
@@ -972,7 +953,6 @@ async def async_build_bootstrap_payload(
                         {
                             "symbol": symbol,
                             "menu_kinds": sorted(symbol_kinds),
-                            "keep_without_value": keep_without_value,
                             "has_runtime_raw": has_runtime_raw,
                             "value": resolved_value,
                             "value_label": resolved_value_label,

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -691,12 +691,59 @@ def _panel_group_symbols(groups: Mapping[str, list[str]]) -> set[str]:
     return {symbol for panel_symbols in groups.values() for symbol in panel_symbols if symbol}
 
 
+async def _resolver_build_panel_groups(
+    resolver: Any,
+    *,
+    device_menu: Any,
+    permissions: list[str] | None,
+    web_ui_only: bool,
+) -> dict[str, list[str]]:
+    """Call ``build_panel_groups``, tolerating older py-bragerone without ``web_ui_only``."""
+    kwargs: dict[str, Any] = {
+        "device_menu": device_menu,
+        "permissions": permissions,
+        "all_panels": True,
+        "web_ui_only": web_ui_only,
+    }
+    try:
+        return cast(dict[str, list[str]], await resolver.build_panel_groups(**kwargs))
+    except TypeError:
+        if not web_ui_only:
+            raise
+        kwargs.pop("web_ui_only")
+        LOGGER.warning(
+            "py-bragerone build_panel_groups lacks web_ui_only; UI filter cannot exclude service menus until upgraded"
+        )
+        return cast(dict[str, list[str]], await resolver.build_panel_groups(**kwargs))
+
+
+def _resolver_panel_route_diagnostics(
+    resolver: Any,
+    menu: Any,
+    *,
+    web_ui_only: bool,
+    routes_i18n: Any,
+) -> list[dict[str, Any]]:
+    """Call panel-route diagnostics with optional ``web_ui_only`` for older libraries."""
+    kwargs: dict[str, Any] = {
+        "all_panels": True,
+        "web_ui_only": web_ui_only,
+        "routes_i18n": routes_i18n,
+    }
+    try:
+        return cast(list[dict[str, Any]], resolver.panel_route_diagnostics_from_menu(menu, **kwargs))
+    except TypeError:
+        kwargs.pop("web_ui_only")
+        return cast(list[dict[str, Any]], resolver.panel_route_diagnostics_from_menu(menu, **kwargs))
+
+
 async def _build_panel_groups_with_fallback(
     resolver: Any,
     *,
     device_menu: Any,
     permissions: list[str],
     devid: str,
+    web_ui_only: bool = False,
 ) -> dict[str, list[str]]:
     """Build panel groups, retrying without permissions when the gated attempt yields nothing.
 
@@ -713,13 +760,19 @@ async def _build_panel_groups_with_fallback(
         device_menu: Device menu identifier of the module.
         permissions: Permission strings reported by the API for this module.
         devid: Module device identifier, used for logging only.
+        web_ui_only: When True, exclude installer/service routes (everyday web-UI panels only).
 
     Returns:
         Mapping of panel name to symbols, empty when neither attempt produced symbols.
     """
     groups: dict[str, list[str]] = {}
     try:
-        groups = await resolver.build_panel_groups(device_menu=device_menu, permissions=permissions, all_panels=True)
+        groups = await _resolver_build_panel_groups(
+            resolver,
+            device_menu=device_menu,
+            permissions=permissions,
+            web_ui_only=web_ui_only,
+        )
     except Exception:
         LOGGER.debug("Panel-group build failed for %s, retrying without permissions", devid, exc_info=True)
     else:
@@ -727,7 +780,12 @@ async def _build_panel_groups_with_fallback(
             return groups
         LOGGER.debug("Panel-group build returned no symbols for %s, retrying without permissions", devid)
 
-    groups = await resolver.build_panel_groups(device_menu=device_menu, permissions=None, all_panels=True)
+    groups = await _resolver_build_panel_groups(
+        resolver,
+        device_menu=device_menu,
+        permissions=None,
+        web_ui_only=web_ui_only,
+    )
 
     if not _panel_group_symbols(groups):
         # Scope the claim to panel-derived symbols: in permissions mode the later secondary pass
@@ -792,12 +850,15 @@ async def async_build_bootstrap_payload(
         module_permissions = [str(perm) for perm in getattr(module, "permissions", []) or []]
         symbols: set[str] = set()
         panel_paths: dict[str, str] = {}
+        module_mode = normalized_module_modes.get(str(module.devid), filter_mode)
+        web_ui_only = module_mode == FILTER_MODE_UI
 
         groups = await _build_panel_groups_with_fallback(
             resolver,
             device_menu=module.deviceMenu,
             permissions=module_permissions,
             devid=str(module.devid),
+            web_ui_only=web_ui_only,
         )
 
         symbols = _panel_group_symbols(groups)
@@ -820,9 +881,10 @@ async def async_build_bootstrap_payload(
                 menu = await assets.get_module_menu(device_menu=module.deviceMenu, permissions=module_permissions)
                 per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu)
                 per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu)
-                per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
+                per_module_route_diagnostics[module.devid] = _resolver_panel_route_diagnostics(
+                    resolver,
                     menu,
-                    all_panels=True,
+                    web_ui_only=web_ui_only,
                     routes_i18n=await resolver._i18n.get_namespace("routes"),
                 )
             except Exception:
@@ -832,9 +894,10 @@ async def async_build_bootstrap_payload(
                 menu_all = await assets.get_module_menu(device_menu=module.deviceMenu, permissions=None)
                 per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu_all)
                 per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu_all)
-                per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
+                per_module_route_diagnostics[module.devid] = _resolver_panel_route_diagnostics(
+                    resolver,
                     menu_all,
-                    all_panels=True,
+                    web_ui_only=web_ui_only,
                     routes_i18n=await resolver._i18n.get_namespace("routes"),
                 )
             except Exception:

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -714,7 +714,9 @@ async def _build_panel_groups_with_fallback(
         device_menu: Device menu identifier of the module.
         permissions: Permission strings reported by the API for this module.
         devid: Module device identifier, used for logging only.
-        web_ui_only: When True, exclude installer/service routes (everyday web-UI panels only).
+        web_ui_only: When True, apply SPA side-menu gating (hide installer routes /
+            ``isVisibleOnSideMenu=False``). Per-parameter SPA ``isParameterVisible``
+            status checks still run separately for UI filter mode.
 
     Returns:
         Mapping of panel name to symbols, empty when neither attempt produced symbols.

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -718,11 +718,14 @@ async def _build_panel_groups_with_fallback(
     Returns:
         Mapping of panel name to symbols (possibly empty).
     """
-    groups = await resolver.build_panel_groups(
-        device_menu=device_menu,
-        permissions=permissions,
-        all_panels=True,
-        web_ui_only=web_ui_only,
+    groups = cast(
+        dict[str, list[str]],
+        await resolver.build_panel_groups(
+            device_menu=device_menu,
+            permissions=permissions,
+            all_panels=True,
+            web_ui_only=web_ui_only,
+        ),
     )
     if not _panel_group_symbols(groups):
         LOGGER.warning(

--- a/custom_components/habragerone/config_flow.py
+++ b/custom_components/habragerone/config_flow.py
@@ -113,12 +113,12 @@ def _entity_filter_mode_values(*, ui_language: str | None = None) -> dict[str, s
     lang = (ui_language or "").strip().lower()
     if lang.startswith("pl"):
         return {
-            FILTER_MODE_UI: "Filtrowanie po menu UI",
-            FILTER_MODE_PERMISSIONS: "Filtrowanie po uprawnieniach",
+            FILTER_MODE_UI: "Filtrowanie po menu UI (codzienny web UI)",
+            FILTER_MODE_PERMISSIONS: "Filtrowanie po uprawnieniach (wszystkie dozwolone panele)",
         }
     return {
-        FILTER_MODE_UI: "UI menu filtering",
-        FILTER_MODE_PERMISSIONS: "Permission filtering",
+        FILTER_MODE_UI: "UI menu filtering (everyday web UI)",
+        FILTER_MODE_PERMISSIONS: "Permission filtering (all permitted panels)",
     }
 
 

--- a/custom_components/habragerone/const.py
+++ b/custom_components/habragerone/const.py
@@ -25,7 +25,7 @@ CONF_ENUM_MAP: Final = "enum_map"
 CONF_RAW_TO_LABEL: Final = "raw_to_label"
 CONF_BOOTSTRAP_DEBUG: Final = "bootstrap_debug"
 CONF_BOOTSTRAP_VERSION: Final = "bootstrap_version"
-BOOTSTRAP_VERSION: Final = 6
+BOOTSTRAP_VERSION: Final = 7
 
 DATA_API: Final = "api"
 DATA_GATEWAY: Final = "gateway"

--- a/custom_components/habragerone/const.py
+++ b/custom_components/habragerone/const.py
@@ -25,7 +25,7 @@ CONF_ENUM_MAP: Final = "enum_map"
 CONF_RAW_TO_LABEL: Final = "raw_to_label"
 CONF_BOOTSTRAP_DEBUG: Final = "bootstrap_debug"
 CONF_BOOTSTRAP_VERSION: Final = "bootstrap_version"
-BOOTSTRAP_VERSION: Final = 5
+BOOTSTRAP_VERSION: Final = 6
 
 DATA_API: Final = "api"
 DATA_GATEWAY: Final = "gateway"

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -19,5 +19,5 @@
     "py-bragerone==2026.8.7",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.3"
+  "version": "2026.8.4"
 }

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,7 +16,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.6",
+    "py-bragerone==2026.8.7",
     "tree-sitter==0.26.0"
   ],
   "version": "2026.8.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.6",
+    "py-bragerone>=2026.8.7",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/tests/test_bootstrap_filtering.py
+++ b/tests/test_bootstrap_filtering.py
@@ -73,8 +73,9 @@ def test_async_build_bootstrap_payload_applies_filter_mode_per_module(monkeypatc
             device_menu: str,
             permissions: list[str] | None,
             all_panels: bool,
+            web_ui_only: bool = False,
         ) -> dict[str, list[str]]:
-            _ = permissions, all_panels
+            _ = permissions, all_panels, web_ui_only
             return {"panel": [f"SYM_{device_menu}"]}
 
         async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:
@@ -217,8 +218,9 @@ def test_async_build_bootstrap_payload_ui_excludes_non_panel_actions(monkeypatch
             device_menu: str,
             permissions: list[str] | None,
             all_panels: bool,
+            web_ui_only: bool = False,
         ) -> dict[str, list[str]]:
-            _ = device_menu, permissions, all_panels
+            _ = device_menu, permissions, all_panels, web_ui_only
             return {"Kocioł": ["SYM_PANEL"]}
 
         async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -372,3 +372,42 @@ def test_menu_kind_retry_failure_is_logged_without_failing_bootstrap(
     ]
     assert {item["symbol"] for item in payload["entity_descriptors"]} == {"PARAM_GATED"}
     assert any("Menu kind retry extraction failed for M1" in record.getMessage() for record in caplog.records)
+
+
+def test_ui_mode_rejects_symbols_without_display_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    """SPA visibility requires a defined display value — bare writes are dropped."""
+
+    class _NoDisplayResolver(_RecordingResolver):
+        async def resolve_value(self, symbol: str) -> SimpleNamespace:
+            _ = symbol
+            return SimpleNamespace(value=None, value_label=None)
+
+    _NoDisplayResolver.gated_groups = {"Panel": ["PARAM_BLANK"]}
+    _NoDisplayResolver.ungated_groups = {}
+    _NoDisplayResolver.calls = []
+    _NoDisplayResolver.web_ui_flags = []
+
+    monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
+    monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", _NoDisplayResolver)
+
+    payload = asyncio.run(
+        async_build_bootstrap_payload(
+            api=cast(Any, _FakeApi()),  # type: ignore[arg-type]
+            object_id=1,
+            modules=["M1"],
+            language="en",
+            entity_filter_mode="ui",
+        )
+    )
+
+    assert payload["entity_descriptors"] == []
+    rejections = payload["bootstrap_debug"]["modules"]["M1"]["rejections"]
+    assert rejections == [
+        {
+            "symbol": "PARAM_BLANK",
+            "reason": "no_display_value",
+            "value": None,
+            "value_label": None,
+            "menu_kinds": [],
+        }
+    ]

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -38,6 +38,7 @@ class _RecordingResolver:
     gated_groups: ClassVar[object] = {}
     ungated_groups: ClassVar[object] = {}
     calls: ClassVar[list[list[str] | None]] = []
+    web_ui_flags: ClassVar[list[bool]] = []
 
     @classmethod
     def from_api(cls, api: object, store: object, lang: object) -> _RecordingResolver:
@@ -50,9 +51,11 @@ class _RecordingResolver:
         device_menu: str,
         permissions: list[str] | None,
         all_panels: bool,
+        web_ui_only: bool = False,
     ) -> dict[str, list[str]]:
         _ = device_menu, all_panels
         type(self).calls.append(permissions)
+        type(self).web_ui_flags.append(web_ui_only)
         result = self.gated_groups if permissions else self.ungated_groups
         if isinstance(result, Exception):
             raise result
@@ -125,10 +128,12 @@ def _run_bootstrap(
     *,
     gated_groups: object,
     ungated_groups: object,
-) -> tuple[dict[str, Any], list[list[str] | None]]:
+    entity_filter_mode: str = "ui",
+) -> tuple[dict[str, Any], list[list[str] | None], list[bool]]:
     _RecordingResolver.gated_groups = gated_groups
     _RecordingResolver.ungated_groups = ungated_groups
     _RecordingResolver.calls = []
+    _RecordingResolver.web_ui_flags = []
 
     monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
     monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", _RecordingResolver)
@@ -139,35 +144,51 @@ def _run_bootstrap(
             object_id=1,
             modules=["M1"],
             language="en",
+            entity_filter_mode=entity_filter_mode,
         )
     )
-    return cast(dict[str, Any], payload), _RecordingResolver.calls
+    return cast(dict[str, Any], payload), _RecordingResolver.calls, _RecordingResolver.web_ui_flags
 
 
 def test_empty_gated_panel_groups_fall_back_to_ungated_call(monkeypatch: pytest.MonkeyPatch) -> None:
-    payload, calls = _run_bootstrap(
+    payload, calls, web_ui_flags = _run_bootstrap(
         monkeypatch,
         gated_groups={},
         ungated_groups={"Panel": ["SYM_FALLBACK"]},
     )
 
     assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
+    assert web_ui_flags == [True, True]
     assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_FALLBACK"}
 
 
 def test_non_empty_gated_panel_groups_skip_the_fallback_call(monkeypatch: pytest.MonkeyPatch) -> None:
-    payload, calls = _run_bootstrap(
+    payload, calls, web_ui_flags = _run_bootstrap(
         monkeypatch,
         gated_groups={"Panel": ["SYM_GATED"]},
         ungated_groups={"Panel": ["SYM_FALLBACK"]},
     )
 
     assert calls == [["DISPLAY_PARAMETER_LEVEL_1"]]
+    assert web_ui_flags == [True]
+    assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_GATED"}
+
+
+def test_permissions_mode_does_not_request_web_ui_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    payload, calls, web_ui_flags = _run_bootstrap(
+        monkeypatch,
+        gated_groups={"Panel": ["SYM_GATED"]},
+        ungated_groups={"Panel": ["SYM_FALLBACK"]},
+        entity_filter_mode="permissions",
+    )
+
+    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"]]
+    assert web_ui_flags == [False]
     assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_GATED"}
 
 
 def test_raising_gated_panel_groups_fall_back_to_ungated_call(monkeypatch: pytest.MonkeyPatch) -> None:
-    payload, calls = _run_bootstrap(
+    payload, calls, _web_ui_flags = _run_bootstrap(
         monkeypatch,
         gated_groups=RuntimeError("gated extraction failed"),
         ungated_groups={"Panel": ["SYM_FALLBACK"]},
@@ -181,7 +202,7 @@ def test_two_empty_panel_group_attempts_warn_without_failing_bootstrap(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.WARNING, logger=BOOTSTRAP_LOGGER):
-        payload, calls = _run_bootstrap(monkeypatch, gated_groups={}, ungated_groups={"Panel": []})
+        payload, calls, _web_ui_flags = _run_bootstrap(monkeypatch, gated_groups={}, ungated_groups={"Panel": []})
 
     assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
     assert payload["entity_descriptors"] == []
@@ -206,8 +227,9 @@ def test_failing_ungated_retry_propagates_instead_of_caching_emptiness() -> None
             device_menu: str,
             permissions: list[str] | None,
             all_panels: bool,
+            web_ui_only: bool = False,
         ) -> dict[str, list[str]]:
-            _ = device_menu, permissions, all_panels
+            _ = device_menu, permissions, all_panels, web_ui_only
             raise RuntimeError("extraction failed")
 
     with pytest.raises(RuntimeError, match="extraction failed"):

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -236,3 +236,139 @@ def test_failing_panel_group_build_propagates_instead_of_caching_emptiness() -> 
                 devid="M1",
             )
         )
+
+
+class _EmptyThenRetryAssets:
+    """Return an empty menu first, then a usable menu (or raise) on retry."""
+
+    def __init__(self, *, retry_menu: object | Exception) -> None:
+        """Store the second ``get_module_menu`` outcome."""
+        self._retry_menu = retry_menu
+        self.calls: list[list[str] | None] = []
+
+    async def get_module_menu(
+        self,
+        *,
+        device_menu: str,
+        permissions: list[str] | None,
+    ) -> object:
+        """First call yields no kinds; second call uses the configured retry result."""
+        _ = device_menu
+        self.calls.append(permissions)
+        if len(self.calls) == 1:
+            return {"routes": []}
+        if isinstance(self._retry_menu, Exception):
+            raise self._retry_menu
+        return self._retry_menu
+
+
+class _I18nStub:
+    async def get_namespace(self, name: str) -> dict[str, object]:
+        _ = name
+        return {}
+
+
+def _resolver_with_assets(assets: _EmptyThenRetryAssets) -> type[_RecordingResolver]:
+    """Build a ParamResolver stub that carries menu assets for kind retry coverage."""
+
+    class _Resolver(_RecordingResolver):
+        def __init__(self) -> None:
+            self._assets = assets
+            self._i18n = _I18nStub()
+
+        @classmethod
+        def from_api(cls, api: object, store: object, lang: object) -> _Resolver:
+            _ = api, store, lang
+            return cls()
+
+        def panel_route_diagnostics_from_menu(
+            self,
+            menu: object,
+            *,
+            all_panels: bool,
+            web_ui_only: bool,
+            routes_i18n: dict[str, object],
+        ) -> list[dict[str, object]]:
+            _ = menu, all_panels, web_ui_only, routes_i18n
+            return []
+
+    return _Resolver
+
+
+def test_menu_kind_retry_reloads_empty_kinds_with_same_permissions(monkeypatch: pytest.MonkeyPatch) -> None:
+    """When the first menu parse yields no kinds, retry with the same permission set."""
+    assets = _EmptyThenRetryAssets(
+        retry_menu={
+            "routes": [
+                {
+                    "name": "Boiler",
+                    "parameters": {
+                        "read": [{"parameter": {"token": "PARAM_GATED"}}],
+                        "write": [],
+                        "status": [],
+                        "special": [],
+                    },
+                    "children": [],
+                }
+            ]
+        }
+    )
+    resolver_cls = _resolver_with_assets(assets)
+    _RecordingResolver.gated_groups = {"Panel": ["PARAM_GATED"]}
+    _RecordingResolver.ungated_groups = {}
+    _RecordingResolver.calls = []
+    _RecordingResolver.web_ui_flags = []
+
+    monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
+    monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", resolver_cls)
+
+    payload = asyncio.run(
+        async_build_bootstrap_payload(
+            api=cast(Any, _FakeApi()),  # type: ignore[arg-type]
+            object_id=1,
+            modules=["M1"],
+            language="en",
+            entity_filter_mode="ui",
+        )
+    )
+
+    assert assets.calls == [
+        ["DISPLAY_PARAMETER_LEVEL_1"],
+        ["DISPLAY_PARAMETER_LEVEL_1"],
+    ]
+    assert {item["symbol"] for item in payload["entity_descriptors"]} == {"PARAM_GATED"}
+    debug = payload["bootstrap_debug"]["modules"]["M1"]
+    assert debug["menu_symbol_kinds_count"] == 1
+
+
+def test_menu_kind_retry_failure_is_logged_without_failing_bootstrap(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Retry exceptions stay soft — bootstrap continues without menu kinds."""
+    assets = _EmptyThenRetryAssets(retry_menu=RuntimeError("retry menu failed"))
+    resolver_cls = _resolver_with_assets(assets)
+    _RecordingResolver.gated_groups = {"Panel": ["PARAM_GATED"]}
+    _RecordingResolver.ungated_groups = {}
+    _RecordingResolver.calls = []
+    _RecordingResolver.web_ui_flags = []
+
+    monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
+    monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", resolver_cls)
+
+    with caplog.at_level(logging.DEBUG, logger=BOOTSTRAP_LOGGER):
+        payload = asyncio.run(
+            async_build_bootstrap_payload(
+                api=cast(Any, _FakeApi()),  # type: ignore[arg-type]
+                object_id=1,
+                modules=["M1"],
+                language="en",
+                entity_filter_mode="ui",
+            )
+        )
+
+    assert assets.calls == [
+        ["DISPLAY_PARAMETER_LEVEL_1"],
+        ["DISPLAY_PARAMETER_LEVEL_1"],
+    ]
+    assert {item["symbol"] for item in payload["entity_descriptors"]} == {"PARAM_GATED"}
+    assert any("Menu kind retry extraction failed for M1" in record.getMessage() for record in caplog.records)

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -13,7 +13,7 @@ from tests.conftest import install_pybragerone_stubs
 install_pybragerone_stubs()
 
 from custom_components.habragerone.bootstrap import (  # noqa: E402
-    _build_panel_groups_with_fallback,
+    _build_permission_gated_panel_groups,
     async_build_bootstrap_payload,
 )
 
@@ -229,7 +229,7 @@ def test_failing_panel_group_build_propagates_instead_of_caching_emptiness() -> 
 
     with pytest.raises(RuntimeError, match="extraction failed"):
         asyncio.run(
-            _build_panel_groups_with_fallback(
+            _build_permission_gated_panel_groups(
                 _AlwaysFailingResolver(),
                 device_menu="M1",
                 permissions=["DISPLAY_PARAMETER_LEVEL_1"],

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -150,16 +150,17 @@ def _run_bootstrap(
     return cast(dict[str, Any], payload), _RecordingResolver.calls, _RecordingResolver.web_ui_flags
 
 
-def test_empty_gated_panel_groups_fall_back_to_ungated_call(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_empty_gated_panel_groups_stay_empty_without_ungating(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Empty permission-gated panels must not retry with permissions=None."""
     payload, calls, web_ui_flags = _run_bootstrap(
         monkeypatch,
         gated_groups={},
         ungated_groups={"Panel": ["SYM_FALLBACK"]},
     )
 
-    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
-    assert web_ui_flags == [True, True]
-    assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_FALLBACK"}
+    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"]]
+    assert web_ui_flags == [True]
+    assert payload["entity_descriptors"] == []
 
 
 def test_non_empty_gated_panel_groups_skip_the_fallback_call(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -187,38 +188,32 @@ def test_permissions_mode_does_not_request_web_ui_only(monkeypatch: pytest.Monke
     assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_GATED"}
 
 
-def test_raising_gated_panel_groups_fall_back_to_ungated_call(monkeypatch: pytest.MonkeyPatch) -> None:
-    payload, calls, _web_ui_flags = _run_bootstrap(
-        monkeypatch,
-        gated_groups=RuntimeError("gated extraction failed"),
-        ungated_groups={"Panel": ["SYM_FALLBACK"]},
-    )
+def test_raising_gated_panel_groups_propagates(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Extraction errors must fail setup — no silent permissions=None retry."""
+    with pytest.raises(RuntimeError, match="gated extraction failed"):
+        _run_bootstrap(
+            monkeypatch,
+            gated_groups=RuntimeError("gated extraction failed"),
+            ungated_groups={"Panel": ["SYM_FALLBACK"]},
+        )
 
-    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
-    assert {item["symbol"] for item in payload["entity_descriptors"]} == {"SYM_FALLBACK"}
 
-
-def test_two_empty_panel_group_attempts_warn_without_failing_bootstrap(
+def test_empty_panel_groups_warn_without_failing_bootstrap(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
     with caplog.at_level(logging.WARNING, logger=BOOTSTRAP_LOGGER):
         payload, calls, _web_ui_flags = _run_bootstrap(monkeypatch, gated_groups={}, ungated_groups={"Panel": []})
 
-    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"], None]
+    assert calls == [["DISPLAY_PARAMETER_LEVEL_1"]]
     assert payload["entity_descriptors"] == []
 
-    # Assert the module is named, not the exact phrasing: rewording the log is not a behaviour change.
     warnings = [record for record in caplog.records if record.levelno == logging.WARNING]
     assert len(warnings) == 1
     assert "M1" in warnings[0].getMessage()
 
 
-def test_failing_ungated_retry_propagates_instead_of_caching_emptiness() -> None:
-    """A broken ungated retry must fail setup rather than report a bootstrap with zero entities.
-
-    Home Assistant retries a failed setup, so a transient upstream error recovers on its own.
-    Swallowing it would instead hand back an empty descriptor list as if it were a real result.
-    """
+def test_failing_panel_group_build_propagates_instead_of_caching_emptiness() -> None:
+    """A broken panel extraction must fail setup rather than report zero entities."""
 
     class _AlwaysFailingResolver:
         async def build_panel_groups(

--- a/tests/test_config_flow_helpers.py
+++ b/tests/test_config_flow_helpers.py
@@ -42,8 +42,8 @@ def test_ui_field_labels_supports_polish_and_english() -> None:
 
 
 def test_entity_filter_mode_values_supports_polish_and_english() -> None:
-    assert "Filtrowanie po menu UI" in _entity_filter_mode_values(ui_language="pl").values()
-    assert "UI menu filtering" in _entity_filter_mode_values(ui_language="en").values()
+    assert "Filtrowanie po menu UI (codzienny web UI)" in _entity_filter_mode_values(ui_language="pl").values()
+    assert "UI menu filtering (everyday web UI)" in _entity_filter_mode_values(ui_language="en").values()
 
 
 def test_extract_selected_module_filter_modes_rejects_invalid_mode() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.6" },
+    { name = "py-bragerone", specifier = ">=2026.8.7" },
 ]
 
 [package.metadata.requires-dev]
@@ -2190,7 +2190,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.6"
+version = "2026.8.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2200,9 +2200,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/21/24/5a290e619870eaf98a7dd1f8dc34c80d4773472f272b5b5e216d14eeeb3d/py_bragerone-2026.8.6.tar.gz", hash = "sha256:54252d16b6db0386b29d31488f1e0e60321753a30b67f590c8bf9dbdf85f2198", size = 105232, upload-time = "2026-08-14T15:59:43.87Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/08/6d/57d954e76e73ac00949f61429b65c20d8ed857c8272a4658ac4f28049146/py_bragerone-2026.8.7.tar.gz", hash = "sha256:5f183c7b2fc566dfbaf8cc5feb72853ca51ebedf5555550cc6ef59d3de9ced1a", size = 112181, upload-time = "2026-08-15T09:39:42.89Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ad/cb/955cd2abc7309bdbd25838372ada019d7889eda656aca147f7d68dee07df/py_bragerone-2026.8.6-py3-none-any.whl", hash = "sha256:2be8519cad97084abbf9c086c13986faf9cce5eabe323f9318b256d815d5ab8f", size = 111048, upload-time = "2026-08-14T15:59:42.166Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/29/5f0e19f3696466b6bbe867323f8dd4ff66ee0c689603ec6340f3efa20d5e/py_bragerone-2026.8.7-py3-none-any.whl", hash = "sha256:2be01b5c2c8e8c058a591ddeb8a72b151446a9a77a507cdaacab05fd54e9e9c8", size = 117935, upload-time = "2026-08-15T09:39:41.435Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #168. UI mode uses SPA-accurate panel + parameter visibility from py-bragerone **2026.8.7**.

### This PR
- Passes `web_ui_only` in UI filter mode
- `BOOTSTRAP_VERSION = 7`
- **No** `permissions=None` panel fallback (empty gated → empty; errors propagate)
- Helper renamed to `_build_permission_gated_panel_groups`
- **No** `keep_without_value` exception (SPA requires defined value)
- Menu-kind retry keeps the module permission set
- Tests: menu-kind retry + UI `no_display_value` rejection
- Cast `build_panel_groups` result for mypy `--strict`
- Pin `py-bragerone==2026.8.7`; HACS manifest version **2026.8.4**

## Test plan
```bash
uv run pytest tests/test_bootstrap_panel_group_fallback.py tests/test_bootstrap_filtering.py tests/test_config_flow_helpers.py
uv run --group dev mypy
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

