### PR TITLE
feat: module connectivity binary_sensor and availability gate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -29,10 +29,10 @@ All protocol work happens in `pybragerone` (REST prime + Socket.IO deltas). The 
 
 ## Non-negotiable conventions
 
-1. **Push, not poll**: state-bearing entities set `_attr_should_poll = False` and update via `runtime.add_listener()`. Never add polling or a coordinator. Exception: command-only entities (`button.py`) have no state and intentionally no listener.
-2. **Write safety**: every write converts enum label→raw, applies inverse numeric transform, validates against `n`/`x` min/max, and picks the right route (`parameter_write` vs `raw_command`). Invalid input → explicit validation error, never a silent send.
-3. **unique_id stability**: `{entry_id}_{devid}_{symbol}` with platform suffix (`_binary`, `_switch`, `_number`, `_select`, `_button`). Changing these breaks user setups — treat as breaking change.
-4. **Naming**: display name `"{panel_path} - {label}"` via `descriptor_display_name`; suggested object id `slugify(f"{module_name}_{symbol}")`; `_attr_has_entity_name = True`; DeviceInfo identifiers `(domain, devid)`, manufacturer `"BragerOne"`.
+1. **Push, not poll**: state-bearing entities set `_attr_should_poll = False` and update via `runtime.add_listener()` (and `add_connectivity_listener()` for module online/offline). Never add polling or a coordinator. Command-only entities (`button.py`) have no ParamStore state but still listen for connectivity to drive availability.
+2. **Write safety**: every write converts enum label→raw, applies inverse numeric transform, validates against `n`/`x` min/max, and picks the right route (`parameter_write` vs `raw_command`). Invalid input → explicit validation error, never a silent send. Writes are refused when the module is known offline.
+3. **unique_id stability**: `{entry_id}_{devid}_{symbol}` with platform suffix (`_binary`, `_switch`, `_number`, `_select`, `_button`). Module cloud connectivity uses `{entry_id}_{devid}_connectivity_binary` on a child device `identifiers={(domain, f"{devid}:module.connection")}` with `via_device`. Changing these breaks user setups — treat as breaking change.
+4. **Naming**: display name `"{panel_path} - {label}"` via `descriptor_display_name`; suggested object id `slugify(f"{module_name}_{symbol}")`; `_attr_has_entity_name = True`; DeviceInfo identifiers `(domain, devid)`, manufacturer `"BragerOne"`. Connection entities use SPA `module` i18n labels (never hardcoded).
 5. **English only** in code/comments/docstrings; mypy `--strict`; ruff (line-length 130, Google docstrings).
 6. **Credentials**: diagnostics and logs must redact password/tokens.
 7. **Library boundary**: don't re-implement protocol logic in the integration — that belongs to `py-bragerone`. Keep `manifest.json` pins and `pyproject.toml` bounds in sync.

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ This custom component provides integration between Home Assistant and the Brager
 - Device control via Home Assistant
 - Configurable through Home Assistant UI
 - Support for multiple device types
+- Per-module cloud connectivity diagnostic (SPA `connectedAt` / `module.connection.*` labels) on a child device; parameter entities go unavailable when the module is offline; writes are refused while offline
 
 ## Installation
 

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -12,7 +12,13 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pybragerone.models.events import ParamUpdate
 
-from .const import CONF_MODULES_META, DATA_RUNTIME, DOMAIN
+from .const import (
+    CONF_CONNECTION_DESCRIPTORS,
+    CONF_MODULES_META,
+    CONNECTION_MENU_KEY,
+    DATA_RUNTIME,
+    DOMAIN,
+)
 from .entity_common import (
     descriptor_current_raw_value,
     descriptor_display_name,
@@ -41,7 +47,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     entry_data = hass.data[DOMAIN][entry.entry_id]
     runtime_obj = entry_data.get(DATA_RUNTIME)
     modules_meta = entry.data.get(CONF_MODULES_META)
+    connection_descriptors = entry.data.get(CONF_CONNECTION_DESCRIPTORS)
     if isinstance(runtime_obj, BragerRuntime) and isinstance(modules_meta, dict):
+        by_devid: dict[str, dict[str, Any]] = {}
+        if isinstance(connection_descriptors, list):
+            for raw in connection_descriptors:
+                if not isinstance(raw, dict):
+                    continue
+                devid_key = str(raw.get("devid") or "").strip()
+                if devid_key:
+                    by_devid[devid_key] = raw
         for devid, meta in modules_meta.items():
             if not isinstance(devid, str) or not devid.strip():
                 continue
@@ -53,6 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     runtime=runtime_obj,
                     devid=devid,
                     module_meta=meta,
+                    connection_descriptor=by_devid.get(devid),
                 )
             )
 
@@ -140,13 +156,12 @@ class BragerStatusBinarySensor(BinarySensorEntity):
 
 
 class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
-    """Diagnostic binary sensor for module cloud connectivity."""
+    """Diagnostic binary sensor for SPA module connection status."""
 
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_name = "Cloud connectivity"
 
     def __init__(
         self,
@@ -155,13 +170,23 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
         runtime: BragerRuntime,
         devid: str,
         module_meta: dict[str, Any],
+        connection_descriptor: dict[str, Any] | None = None,
     ) -> None:
-        """Initialize connectivity sensor for one module device."""
+        """Initialize connectivity sensor for one module connection device."""
         self._runtime = runtime
         self._devid = devid
         self._module_meta = module_meta
+        self._descriptor = connection_descriptor if isinstance(connection_descriptor, dict) else {}
+        labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
+        label = (
+            str(self._descriptor.get("label") or "").strip()
+            or str(labels.get("connection.status") or "").strip()
+            or str(labels.get("serverConnection") or "").strip()
+            or "connection.status"
+        )
+        self._attr_name = label
         self._attr_unique_id = f"{entry.entry_id}_{devid}_connectivity_binary".lower().replace(" ", "_")
-        self._attr_suggested_object_id = f"{devid}_cloud_connectivity".lower().replace(" ", "_")
+        self._attr_suggested_object_id = f"{devid}_connection_status".lower().replace(" ", "_")
         online = runtime.module_online(devid)
         self._attr_is_on = bool(online) if online is not None else False
         self._attr_available = True
@@ -169,14 +194,47 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
 
     @property
     def device_info(self) -> DeviceInfo:
-        """Attach connectivity entity to the module device."""
+        """Attach to a connection child device via the internet module.
+
+        Stable id uses SPA i18n path ``module.connection`` (not a menu-router route)
+        so HA #165 can keep these entities separable from panel-grouped devices.
+        """
+        labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
+        device_name = (
+            str(self._descriptor.get("device_name") or "").strip()
+            or str(labels.get("connection.index") or "").strip()
+            or str(self._module_meta.get("name") or self._devid)
+        )
+        menu_key = str(self._descriptor.get("menu_key") or CONNECTION_MENU_KEY)
         return DeviceInfo(
-            identifiers={(DOMAIN, self._devid)},
+            identifiers={(DOMAIN, f"{self._devid}:{menu_key}")},
             manufacturer="BragerOne",
-            name=str(self._module_meta.get("name") or self._devid),
+            name=device_name,
             model=str(self._module_meta.get("title") or "Brager module"),
             sw_version=str(self._module_meta.get("version") or "") or None,
+            via_device=(DOMAIN, self._devid),
         )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose SPA connection fields (connectedAt + gateway) as attributes."""
+        meta = self._runtime.modules_meta.get(self._devid, self._module_meta)
+        attrs: dict[str, Any] = {}
+        connected_at = meta.get("connectedAt") if isinstance(meta, dict) else None
+        if isinstance(connected_at, int):
+            attrs["connected_at"] = connected_at
+        gateway = meta.get("gateway") if isinstance(meta, dict) else None
+        if isinstance(gateway, dict):
+            for key in ("address", "interface", "version"):
+                value = gateway.get(key)
+                if value is not None and value != "":
+                    attrs[f"gateway_{key}"] = value
+        labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
+        if isinstance(labels.get("connection.connected"), str):
+            attrs["state_label_on"] = labels["connection.connected"]
+        if isinstance(labels.get("connection.notConnected"), str):
+            attrs["state_label_off"] = labels["connection.notConnected"]
+        return attrs
 
     async def async_added_to_hass(self) -> None:
         """Attach connectivity listener when entity is added."""

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -1,23 +1,25 @@
-"""Binary sensor platform for BragerOne status symbols."""
+"""Binary sensor platform for BragerOne status symbols and module connectivity."""
 
 from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.binary_sensor import BinarySensorEntity
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass, BinarySensorEntity
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from pybragerone.models.events import ParamUpdate
 
-from .const import DOMAIN
+from .const import CONF_MODULES_META, DATA_RUNTIME, DOMAIN
 from .entity_common import (
     descriptor_current_raw_value,
     descriptor_display_name,
     descriptor_refresh_keys,
     descriptor_suggested_object_id,
     device_info_from_descriptor,
+    entity_is_available,
     get_runtime_and_descriptors,
     record_platform_entity_stats,
 )
@@ -32,7 +34,28 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         return
     runtime, descriptors = runtime_and_descriptors
 
-    entities = [BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor) for descriptor in descriptors]
+    entities: list[BinarySensorEntity] = [
+        BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor) for descriptor in descriptors
+    ]
+
+    entry_data = hass.data[DOMAIN][entry.entry_id]
+    runtime_obj = entry_data.get(DATA_RUNTIME)
+    modules_meta = entry.data.get(CONF_MODULES_META)
+    if isinstance(runtime_obj, BragerRuntime) and isinstance(modules_meta, dict):
+        for devid, meta in modules_meta.items():
+            if not isinstance(devid, str) or not devid.strip():
+                continue
+            if not isinstance(meta, dict):
+                meta = {}
+            entities.append(
+                BragerModuleConnectivityBinarySensor(
+                    entry=entry,
+                    runtime=runtime_obj,
+                    devid=devid,
+                    module_meta=meta,
+                )
+            )
+
     record_platform_entity_stats(
         hass,
         entry,
@@ -64,6 +87,7 @@ class BragerStatusBinarySensor(BinarySensorEntity):
         self._attr_available = True
         self._refresh_keys = descriptor_refresh_keys(descriptor)
         self._unsubscribe_listener: Any = None
+        self._unsubscribe_connectivity: Any = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -71,24 +95,31 @@ class BragerStatusBinarySensor(BinarySensorEntity):
         return device_info_from_descriptor(self._descriptor, domain=DOMAIN)
 
     async def async_added_to_hass(self) -> None:
-        """Attach runtime listener when entity is added."""
+        """Attach runtime listeners when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
+        self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
-        """Detach runtime listener before entity removal."""
+        """Detach runtime listeners before entity removal."""
         if callable(self._unsubscribe_listener):
             self._unsubscribe_listener()
             self._unsubscribe_listener = None
+        if callable(self._unsubscribe_connectivity):
+            self._unsubscribe_connectivity()
+            self._unsubscribe_connectivity = None
 
     async def async_update(self) -> None:
         """Refresh state from ParamStore value."""
         raw_value = descriptor_current_raw_value(self._runtime.store, self._descriptor)
+        self._attr_available = entity_is_available(
+            self._runtime,
+            devid=self._devid,
+            has_value=raw_value is not None,
+        )
         if raw_value is None:
-            self._attr_available = False
             return
 
-        self._attr_available = True
         rule_value = resolve_rule_bool(
             descriptor=self._descriptor,
             flat_values=self._runtime.store.flatten(),
@@ -99,6 +130,74 @@ class BragerStatusBinarySensor(BinarySensorEntity):
     def _on_runtime_update(self, _update: ParamUpdate) -> None:
         update_key = f"{_update.pool}.{_update.chan}{_update.idx}"
         if self._refresh_keys and update_key not in self._refresh_keys:
+            return
+        self.async_schedule_update_ha_state(True)
+
+    def _on_connectivity(self, devid: str, _online: bool) -> None:
+        if devid != self._devid:
+            return
+        self.async_schedule_update_ha_state(True)
+
+
+class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
+    """Diagnostic binary sensor for module cloud connectivity."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_name = "Cloud connectivity"
+    _attr_translation_key = "module_connectivity"
+
+    def __init__(
+        self,
+        *,
+        entry: ConfigEntry,
+        runtime: BragerRuntime,
+        devid: str,
+        module_meta: dict[str, Any],
+    ) -> None:
+        """Initialize connectivity sensor for one module device."""
+        self._runtime = runtime
+        self._devid = devid
+        self._module_meta = module_meta
+        self._attr_unique_id = f"{entry.entry_id}_{devid}_connectivity_binary".lower().replace(" ", "_")
+        self._attr_suggested_object_id = f"{devid}_cloud_connectivity".lower().replace(" ", "_")
+        online = runtime.module_online(devid)
+        self._attr_is_on = bool(online) if online is not None else False
+        self._attr_available = True
+        self._unsubscribe_connectivity: Any = None
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach connectivity entity to the module device."""
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._devid)},
+            manufacturer="BragerOne",
+            name=str(self._module_meta.get("name") or self._devid),
+            model=str(self._module_meta.get("title") or "Brager module"),
+            sw_version=str(self._module_meta.get("version") or "") or None,
+        )
+
+    async def async_added_to_hass(self) -> None:
+        """Attach connectivity listener when entity is added."""
+        self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        self.async_schedule_update_ha_state(True)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Detach connectivity listener before entity removal."""
+        if callable(self._unsubscribe_connectivity):
+            self._unsubscribe_connectivity()
+            self._unsubscribe_connectivity = None
+
+    async def async_update(self) -> None:
+        """Refresh on/off from runtime module online cache."""
+        online = self._runtime.module_online(self._devid)
+        self._attr_available = True
+        self._attr_is_on = bool(online) if online is not None else False
+
+    def _on_connectivity(self, devid: str, _online: bool) -> None:
+        if devid != self._devid:
             return
         self.async_schedule_update_ha_state(True)
 

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -33,6 +33,12 @@ from .runtime import BragerRuntime
 from .status_rules import resolve_rule_bool
 
 
+def _descriptor_labels(descriptor: dict[str, Any]) -> dict[str, Any]:
+    """Return the SPA label map from a connection descriptor, or an empty dict."""
+    raw = descriptor.get("labels")
+    return raw if isinstance(raw, dict) else {}
+
+
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_entities: AddEntitiesCallback) -> None:
     """Set up BragerOne binary sensor entities."""
     runtime_and_descriptors = get_runtime_and_descriptors(hass, entry, platform="binary_sensor")
@@ -183,7 +189,7 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
         self._devid = devid
         self._module_meta = module_meta
         self._descriptor = connection_descriptor
-        labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
+        labels = _descriptor_labels(self._descriptor)
         label = (
             str(self._descriptor.get("label") or "").strip()
             or str(labels.get("connection.status") or "").strip()
@@ -207,7 +213,7 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
         Stable id uses SPA i18n path ``module.connection`` (not a menu-router route)
         so HA #165 can keep these entities separable from panel-grouped devices.
         """
-        labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
+        labels = _descriptor_labels(self._descriptor)
         module_name = str(self._module_meta.get("name") or self._descriptor.get("module_name") or self._devid)
         index_label = str(labels.get("connection.index") or "").strip()
         device_name = str(self._descriptor.get("device_name") or "").strip() or (
@@ -237,11 +243,13 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
                 value = gateway.get(key)
                 if value is not None and value != "":
                     attrs[f"gateway_{key}"] = value
-        labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
-        if isinstance(labels.get("connection.connected"), str):
-            attrs["state_label_on"] = labels["connection.connected"]
-        if isinstance(labels.get("connection.notConnected"), str):
-            attrs["state_label_off"] = labels["connection.notConnected"]
+        labels = _descriptor_labels(self._descriptor)
+        connected_label = labels.get("connection.connected")
+        if isinstance(connected_label, str):
+            attrs["state_label_on"] = connected_label
+        not_connected_label = labels.get("connection.notConnected")
+        if isinstance(not_connected_label, str):
+            attrs["state_label_off"] = not_connected_label
         return attrs
 
     async def async_added_to_hass(self) -> None:

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -147,7 +147,6 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
     _attr_device_class = BinarySensorDeviceClass.CONNECTIVITY
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_name = "Cloud connectivity"
-    _attr_translation_key = "module_connectivity"
 
     def __init__(
         self,

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -210,9 +210,8 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
         labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
         module_name = str(self._module_meta.get("name") or self._descriptor.get("module_name") or self._devid)
         index_label = str(labels.get("connection.index") or "").strip()
-        device_name = (
-            str(self._descriptor.get("device_name") or "").strip()
-            or (f"{module_name} — {index_label}" if index_label else module_name)
+        device_name = str(self._descriptor.get("device_name") or "").strip() or (
+            f"{module_name} — {index_label}" if index_label else module_name
         )
         menu_key = str(self._descriptor.get("menu_key") or CONNECTION_MENU_KEY)
         return DeviceInfo(

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -48,7 +48,8 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
     runtime_obj = entry_data.get(DATA_RUNTIME)
     modules_meta = entry.data.get(CONF_MODULES_META)
     connection_descriptors = entry.data.get(CONF_CONNECTION_DESCRIPTORS)
-    if isinstance(runtime_obj, BragerRuntime) and isinstance(modules_meta, dict):
+    connection_count = 0
+    if isinstance(runtime_obj, BragerRuntime) and isinstance(modules_meta, dict) and runtime_obj.supports_module_connectivity:
         by_devid: dict[str, dict[str, Any]] = {}
         if isinstance(connection_descriptors, list):
             for raw in connection_descriptors:
@@ -60,6 +61,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         for devid, meta in modules_meta.items():
             if not isinstance(devid, str) or not devid.strip():
                 continue
+            descriptor = by_devid.get(devid)
+            if not isinstance(descriptor, dict):
+                # Fail closed: never create a sensor with hardcoded/untranslated labels.
+                continue
             if not isinstance(meta, dict):
                 meta = {}
             entities.append(
@@ -68,15 +73,16 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
                     runtime=runtime_obj,
                     devid=devid,
                     module_meta=meta,
-                    connection_descriptor=by_devid.get(devid),
+                    connection_descriptor=descriptor,
                 )
             )
+            connection_count += 1
 
     record_platform_entity_stats(
         hass,
         entry,
         platform="binary_sensor",
-        descriptor_count=len(descriptors),
+        descriptor_count=len(descriptors) + connection_count,
         created_count=len(entities),
     )
     async_add_entities(entities)
@@ -149,8 +155,8 @@ class BragerStatusBinarySensor(BinarySensorEntity):
             return
         self.async_schedule_update_ha_state(True)
 
-    def _on_connectivity(self, devid: str, _online: bool) -> None:
-        if devid != self._devid:
+    def _on_connectivity(self, devid: str, _online: bool, online_changed: bool = True) -> None:
+        if devid != self._devid or not online_changed:
             return
         self.async_schedule_update_ha_state(True)
 
@@ -170,26 +176,28 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
         runtime: BragerRuntime,
         devid: str,
         module_meta: dict[str, Any],
-        connection_descriptor: dict[str, Any] | None = None,
+        connection_descriptor: dict[str, Any],
     ) -> None:
         """Initialize connectivity sensor for one module connection device."""
         self._runtime = runtime
         self._devid = devid
         self._module_meta = module_meta
-        self._descriptor = connection_descriptor if isinstance(connection_descriptor, dict) else {}
+        self._descriptor = connection_descriptor
         labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
         label = (
             str(self._descriptor.get("label") or "").strip()
             or str(labels.get("connection.status") or "").strip()
             or str(labels.get("serverConnection") or "").strip()
-            or "connection.status"
         )
+        if not label:
+            raise ValueError("connection descriptor missing SPA i18n label")
         self._attr_name = label
         self._attr_unique_id = f"{entry.entry_id}_{devid}_connectivity_binary".lower().replace(" ", "_")
         self._attr_suggested_object_id = f"{devid}_connection_status".lower().replace(" ", "_")
         online = runtime.module_online(devid)
-        self._attr_is_on = bool(online) if online is not None else False
-        self._attr_available = True
+        # Unknown stays unknown — never coerce None to offline.
+        self._attr_is_on = online
+        self._attr_available = online is not None
         self._unsubscribe_connectivity: Any = None
 
     @property
@@ -200,17 +208,18 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
         so HA #165 can keep these entities separable from panel-grouped devices.
         """
         labels = self._descriptor.get("labels") if isinstance(self._descriptor.get("labels"), dict) else {}
+        module_name = str(self._module_meta.get("name") or self._descriptor.get("module_name") or self._devid)
+        index_label = str(labels.get("connection.index") or "").strip()
         device_name = (
             str(self._descriptor.get("device_name") or "").strip()
-            or str(labels.get("connection.index") or "").strip()
-            or str(self._module_meta.get("name") or self._devid)
+            or (f"{module_name} — {index_label}" if index_label else module_name)
         )
         menu_key = str(self._descriptor.get("menu_key") or CONNECTION_MENU_KEY)
         return DeviceInfo(
             identifiers={(DOMAIN, f"{self._devid}:{menu_key}")},
             manufacturer="BragerOne",
             name=device_name,
-            model=str(self._module_meta.get("title") or "Brager module"),
+            model=str(self._module_meta.get("title") or self._descriptor.get("module_title") or module_name),
             sw_version=str(self._module_meta.get("version") or "") or None,
             via_device=(DOMAIN, self._devid),
         )
@@ -250,12 +259,13 @@ class BragerModuleConnectivityBinarySensor(BinarySensorEntity):
     async def async_update(self) -> None:
         """Refresh on/off from runtime module online cache."""
         online = self._runtime.module_online(self._devid)
-        self._attr_available = True
-        self._attr_is_on = bool(online) if online is not None else False
+        self._attr_is_on = online
+        self._attr_available = online is not None
 
-    def _on_connectivity(self, devid: str, _online: bool) -> None:
+    def _on_connectivity(self, devid: str, _online: bool, online_changed: bool = True) -> None:
         if devid != self._devid:
             return
+        # Refresh on online flips and on metadata-only connectedAt/gateway updates.
         self.async_schedule_update_ha_state(True)
 
 

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -10,6 +10,7 @@ from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from .const import (
     CONF_BOOTSTRAP_DEBUG,
+    CONF_CONNECTION_DESCRIPTORS,
     CONF_ENTITY_DESCRIPTORS,
     CONF_ENTITY_FILTER_MODE,
     CONF_ENUM_MAP,
@@ -18,6 +19,7 @@ from .const import (
     CONF_OPTIONS,
     CONF_PLATFORM,
     CONF_RAW_TO_LABEL,
+    CONNECTION_MENU_KEY,
     DEFAULT_ENTITY_FILTER_MODE,
     FILTER_MODE_PERMISSIONS,
     FILTER_MODE_UI,
@@ -740,6 +742,7 @@ class BootstrapPayload(TypedDict):
     """Container persisted in ConfigEntry data for fast startup."""
 
     entity_descriptors: list[EntityDescriptor]
+    connection_descriptors: list[dict[str, Any]]
     modules_meta: dict[str, dict[str, Any]]
     entity_filter_mode: str
     module_filter_modes: dict[str, str]
@@ -1144,12 +1147,59 @@ async def async_build_bootstrap_payload(
             )
             descriptors.append(descriptor)
 
+    connection_labels = await _resolve_connection_labels(resolver, language=language)
+    connection_descriptors = [
+        _build_connection_descriptor(
+            module=module,
+            labels=connection_labels,
+        )
+        for module in effective_modules
+    ]
+
     return {
         CONF_ENTITY_DESCRIPTORS: descriptors,
+        CONF_CONNECTION_DESCRIPTORS: connection_descriptors,
         CONF_MODULES_META: modules_meta,
         CONF_ENTITY_FILTER_MODE: filter_mode,
         CONF_MODULE_FILTER_MODES: {
             str(module.devid): normalized_module_modes.get(str(module.devid), filter_mode) for module in effective_modules
         },
         CONF_BOOTSTRAP_DEBUG: bootstrap_debug,
+    }
+
+
+async def _resolve_connection_labels(resolver: Any, *, language: str | None) -> dict[str, str]:
+    """Load SPA ``module`` / ``module.connection.*`` labels via pybragerone i18n."""
+    resolve = getattr(resolver, "resolve_module_connection_labels", None)
+    if not callable(resolve):
+        LOGGER.warning("pybragerone lacks resolve_module_connection_labels; connection labels will fall back")
+        return {}
+    try:
+        labels = await resolve(lang=language)
+    except Exception:
+        LOGGER.exception("Failed to resolve module connection i18n labels")
+        return {}
+    if not isinstance(labels, dict):
+        return {}
+    return {str(key): str(value) for key, value in labels.items() if isinstance(key, str) and isinstance(value, str)}
+
+
+def _build_connection_descriptor(*, module: Any, labels: Mapping[str, str]) -> dict[str, Any]:
+    """Build a non-menu connection descriptor for one module (HA #165-ready)."""
+    devid = str(getattr(module, "devid", "") or "")
+    status_label = labels.get("connection.status") or labels.get("serverConnection") or "connection.status"
+    device_name = labels.get("connection.index") or status_label
+    return {
+        "kind": "module_connection",
+        "source": "module_i18n",
+        "menu_key": CONNECTION_MENU_KEY,
+        "devid": devid,
+        "module_name": str(getattr(module, "name", "") or devid),
+        "module_title": str(getattr(module, "moduleTitle", "") or ""),
+        "module_version": str(getattr(module, "moduleVersion", "") or ""),
+        "label": status_label,
+        "device_name": device_name,
+        "labels": dict(labels),
+        "platform": "binary_sensor",
+        CONF_PLATFORM: "binary_sensor",
     }

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -1052,6 +1052,7 @@ async def async_build_bootstrap_payload(
             "device_menu": module.deviceMenu,
             "module_interface": module.moduleInterface,
             "module_address": module.moduleAddress,
+            "connectedAt": module.connectedAt,
         }
 
         for symbol in sorted(per_module_symbols.get(module.devid, set())):

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -1146,7 +1146,7 @@ async def async_build_bootstrap_payload(
             )
             descriptors.append(descriptor)
 
-    connection_labels = await _resolve_connection_labels(resolver, language=language)
+    connection_labels, connection_labels_supported = await _resolve_connection_labels(resolver, language=language)
     connection_descriptors: list[dict[str, Any]] = []
     if connection_labels.get("connection.status") or connection_labels.get("serverConnection"):
         for module in effective_modules:
@@ -1156,11 +1156,12 @@ async def async_build_bootstrap_payload(
                     labels=connection_labels,
                 )
             )
-    elif effective_modules:
+    elif effective_modules and connection_labels_supported:
         LOGGER.warning(
-            "Skipping connection_descriptors: SPA module connection i18n labels unavailable "
-            "(would persist untranslated keys)"
+            "Skipping connection_descriptors: SPA module connection i18n labels unavailable (would persist untranslated keys)"
         )
+    elif effective_modules:
+        LOGGER.debug("Skipping connection_descriptors: pybragerone connection-label API unavailable")
 
     return {
         CONF_ENTITY_DESCRIPTORS: descriptors,
@@ -1174,20 +1175,28 @@ async def async_build_bootstrap_payload(
     }
 
 
-async def _resolve_connection_labels(resolver: Any, *, language: str | None) -> dict[str, str]:
-    """Load SPA ``module`` / ``module.connection.*`` labels via pybragerone i18n."""
+async def _resolve_connection_labels(resolver: Any, *, language: str | None) -> tuple[dict[str, str], bool]:
+    """Load SPA ``module`` / ``module.connection.*`` labels via pybragerone i18n.
+
+    Returns ``(labels, supported)`` where ``supported`` is False when the installed
+    pybragerone build lacks ``resolve_module_connection_labels`` (expected under unit
+    stubs / older pins — log at DEBUG, not WARNING).
+    """
     resolve = getattr(resolver, "resolve_module_connection_labels", None)
     if not callable(resolve):
-        LOGGER.warning("pybragerone lacks resolve_module_connection_labels; connection labels will fall back")
-        return {}
+        LOGGER.debug("pybragerone lacks resolve_module_connection_labels; connection labels unavailable")
+        return {}, False
     try:
         labels = await resolve(lang=language)
     except Exception:
         LOGGER.exception("Failed to resolve module connection i18n labels")
-        return {}
+        return {}, True
     if not isinstance(labels, dict):
-        return {}
-    return {str(key): str(value) for key, value in labels.items() if isinstance(key, str) and isinstance(value, str)}
+        return {}, True
+    return (
+        {str(key): str(value) for key, value in labels.items() if isinstance(key, str) and isinstance(value, str)},
+        True,
+    )
 
 
 def _build_connection_descriptor(*, module: Any, labels: Mapping[str, str]) -> dict[str, Any]:

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -1055,7 +1055,6 @@ async def async_build_bootstrap_payload(
             "device_menu": module.deviceMenu,
             "module_interface": module.moduleInterface,
             "module_address": module.moduleAddress,
-            "connectedAt": module.connectedAt,
         }
 
         for symbol in sorted(per_module_symbols.get(module.devid, set())):
@@ -1148,13 +1147,20 @@ async def async_build_bootstrap_payload(
             descriptors.append(descriptor)
 
     connection_labels = await _resolve_connection_labels(resolver, language=language)
-    connection_descriptors = [
-        _build_connection_descriptor(
-            module=module,
-            labels=connection_labels,
+    connection_descriptors: list[dict[str, Any]] = []
+    if connection_labels.get("connection.status") or connection_labels.get("serverConnection"):
+        for module in effective_modules:
+            connection_descriptors.append(
+                _build_connection_descriptor(
+                    module=module,
+                    labels=connection_labels,
+                )
+            )
+    elif effective_modules:
+        LOGGER.warning(
+            "Skipping connection_descriptors: SPA module connection i18n labels unavailable "
+            "(would persist untranslated keys)"
         )
-        for module in effective_modules
-    ]
 
     return {
         CONF_ENTITY_DESCRIPTORS: descriptors,
@@ -1187,19 +1193,20 @@ async def _resolve_connection_labels(resolver: Any, *, language: str | None) -> 
 def _build_connection_descriptor(*, module: Any, labels: Mapping[str, str]) -> dict[str, Any]:
     """Build a non-menu connection descriptor for one module (HA #165-ready)."""
     devid = str(getattr(module, "devid", "") or "")
-    status_label = labels.get("connection.status") or labels.get("serverConnection") or "connection.status"
-    device_name = labels.get("connection.index") or status_label
+    module_name = str(getattr(module, "name", "") or devid)
+    status_label = str(labels.get("connection.status") or labels.get("serverConnection") or "").strip()
+    index_label = str(labels.get("connection.index") or status_label).strip()
+    device_name = f"{module_name} — {index_label}" if index_label else module_name
     return {
         "kind": "module_connection",
         "source": "module_i18n",
         "menu_key": CONNECTION_MENU_KEY,
         "devid": devid,
-        "module_name": str(getattr(module, "name", "") or devid),
+        "module_name": module_name,
         "module_title": str(getattr(module, "moduleTitle", "") or ""),
         "module_version": str(getattr(module, "moduleVersion", "") or ""),
         "label": status_label,
         "device_name": device_name,
         "labels": dict(labels),
-        "platform": "binary_sensor",
         CONF_PLATFORM: "binary_sensor",
     }

--- a/custom_components/habragerone/button.py
+++ b/custom_components/habragerone/button.py
@@ -16,6 +16,7 @@ from .entity_common import (
     descriptor_suggested_object_id,
     device_info_from_descriptor,
     get_runtime_and_descriptors,
+    module_is_reachable,
     record_platform_entity_stats,
 )
 from .runtime import BragerRuntime
@@ -43,6 +44,7 @@ class BragerActionButton(ButtonEntity):
     """Button entity for command-only BragerOne symbols."""
 
     _attr_has_entity_name = True
+    _attr_should_poll = False
 
     def __init__(self, *, entry: ConfigEntry, runtime: BragerRuntime, descriptor: dict[str, Any]) -> None:
         """Initialize action button from one cached descriptor."""
@@ -55,11 +57,33 @@ class BragerActionButton(ButtonEntity):
         self._attr_name = label
         self._attr_suggested_object_id = descriptor_suggested_object_id(descriptor)
         self._attr_unique_id = f"{entry.entry_id}_{self._devid}_{self._symbol}_button".lower().replace(" ", "_")
+        self._attr_available = module_is_reachable(runtime, self._devid)
+        self._unsubscribe_connectivity: Any = None
 
     @property
     def device_info(self) -> DeviceInfo:
         """Return device metadata for HA device registry."""
         return device_info_from_descriptor(self._descriptor, domain=DOMAIN)
+
+    async def async_added_to_hass(self) -> None:
+        """Attach connectivity listener when entity is added."""
+        self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        self.async_schedule_update_ha_state(True)
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Detach connectivity listener before entity removal."""
+        if callable(self._unsubscribe_connectivity):
+            self._unsubscribe_connectivity()
+            self._unsubscribe_connectivity = None
+
+    async def async_update(self) -> None:
+        """Refresh availability from module cloud connectivity."""
+        self._attr_available = module_is_reachable(self._runtime, self._devid)
+
+    def _on_connectivity(self, devid: str, _online: bool) -> None:
+        if devid != self._devid:
+            return
+        self.async_schedule_update_ha_state(True)
 
     async def async_press(self) -> None:
         """Dispatch action command to backend."""

--- a/custom_components/habragerone/button.py
+++ b/custom_components/habragerone/button.py
@@ -80,8 +80,8 @@ class BragerActionButton(ButtonEntity):
         """Refresh availability from module cloud connectivity."""
         self._attr_available = module_is_reachable(self._runtime, self._devid)
 
-    def _on_connectivity(self, devid: str, _online: bool) -> None:
-        if devid != self._devid:
+    def _on_connectivity(self, devid: str, _online: bool, online_changed: bool = True) -> None:
+        if devid != self._devid or not online_changed:
             return
         self.async_schedule_update_ha_state(True)
 

--- a/custom_components/habragerone/const.py
+++ b/custom_components/habragerone/const.py
@@ -18,6 +18,7 @@ FILTER_MODE_PERMISSIONS: Final = "permissions"
 FILTER_MODES: Final[tuple[str, str]] = (FILTER_MODE_UI, FILTER_MODE_PERMISSIONS)
 DEFAULT_ENTITY_FILTER_MODE: Final = FILTER_MODE_UI
 CONF_ENTITY_DESCRIPTORS: Final = "entity_descriptors"
+CONF_CONNECTION_DESCRIPTORS: Final = "connection_descriptors"
 CONF_MODULES_META: Final = "modules_meta"
 CONF_PLATFORM: Final = "platform"
 CONF_OPTIONS: Final = "options"
@@ -26,6 +27,10 @@ CONF_RAW_TO_LABEL: Final = "raw_to_label"
 CONF_BOOTSTRAP_DEBUG: Final = "bootstrap_debug"
 CONF_BOOTSTRAP_VERSION: Final = "bootstrap_version"
 BOOTSTRAP_VERSION: Final = 7
+
+# Stable non-menu source key for module connectivity (SPA ``module.connection.*`` i18n).
+# Kept separate from menu-router paths so HA #165 can place these on a child device.
+CONNECTION_MENU_KEY: Final = "module.connection"
 
 DATA_API: Final = "api"
 DATA_GATEWAY: Final = "gateway"

--- a/custom_components/habragerone/diagnostics.py
+++ b/custom_components/habragerone/diagnostics.py
@@ -41,6 +41,8 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
             if isinstance(gateway_modules, list):
                 devids.update(str(devid) for devid in gateway_modules)
             for devid in sorted(devids):
+                if not devid:
+                    continue
                 meta = brager_runtime.modules_meta.get(devid, {})
                 connected_at = meta.get("connectedAt") if isinstance(meta, dict) else None
                 connectivity[devid] = {

--- a/custom_components/habragerone/diagnostics.py
+++ b/custom_components/habragerone/diagnostics.py
@@ -17,9 +17,11 @@ from .const import (
     CONF_PLATFORM,
     DATA_DIAGNOSTIC_TREND,
     DATA_ENTITY_STATS,
+    DATA_RUNTIME,
     DOMAIN,
     PLATFORMS,
 )
+from .runtime import BragerRuntime
 
 REDACT_KEYS = {CONF_PASSWORD}
 
@@ -29,6 +31,22 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
     runtime = hass.data.get(DOMAIN, {}).get(entry.entry_id, {})
     descriptors_raw = runtime.get(CONF_ENTITY_DESCRIPTORS) if isinstance(runtime, dict) else None
     descriptors = descriptors_raw if isinstance(descriptors_raw, list) else []
+
+    connectivity: dict[str, dict[str, object]] = {}
+    if isinstance(runtime, dict):
+        brager_runtime = runtime.get(DATA_RUNTIME)
+        if isinstance(brager_runtime, BragerRuntime):
+            devids: set[str] = set(brager_runtime.modules_meta)
+            gateway_modules = getattr(brager_runtime.gateway, "modules", None)
+            if isinstance(gateway_modules, list):
+                devids.update(str(devid) for devid in gateway_modules)
+            for devid in sorted(devids):
+                meta = brager_runtime.modules_meta.get(devid, {})
+                connected_at = meta.get("connectedAt") if isinstance(meta, dict) else None
+                connectivity[devid] = {
+                    "online": brager_runtime.module_online(devid),
+                    "connectedAt": connected_at if isinstance(connected_at, int) else None,
+                }
 
     platform_counter: Counter[str] = Counter()
     writable_counter = 0
@@ -247,6 +265,7 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
             "entry": dict(entry.data),
             "runtime_keys": sorted(runtime.keys()) if isinstance(runtime, dict) else [],
             "descriptor_summary": summary_core,
+            "connectivity": connectivity,
         },
         REDACT_KEYS,
     )

--- a/custom_components/habragerone/entity_common.py
+++ b/custom_components/habragerone/entity_common.py
@@ -130,6 +130,23 @@ def device_info_from_descriptor(descriptor: dict[str, Any], *, domain: str) -> D
     )
 
 
+def module_is_reachable(runtime: BragerRuntime, devid: str) -> bool:
+    """Return whether entities for *devid* should be treated as reachable.
+
+    Unknown connectivity (``None``) keeps previous value-based availability so
+    startups before the first REST poll do not blank the UI.
+    """
+    online = runtime.module_online(devid)
+    if online is None:
+        return True
+    return online
+
+
+def entity_is_available(runtime: BragerRuntime, *, devid: str, has_value: bool) -> bool:
+    """Combine ParamStore value presence with module cloud connectivity."""
+    return bool(has_value) and module_is_reachable(runtime, devid)
+
+
 def descriptor_options(descriptor: dict[str, Any]) -> list[str]:
     """Return select options from descriptor."""
     options = descriptor.get(CONF_OPTIONS, [])

--- a/custom_components/habragerone/number.py
+++ b/custom_components/habragerone/number.py
@@ -118,7 +118,7 @@ class BragerSymbolNumber(NumberEntity):
             return
         self.async_schedule_update_ha_state(True)
 
-    def _on_connectivity(self, devid: str, _online: bool) -> None:
-        if devid != self._devid:
+    def _on_connectivity(self, devid: str, _online: bool, online_changed: bool = True) -> None:
+        if devid != self._devid or not online_changed:
             return
         self.async_schedule_update_ha_state(True)

--- a/custom_components/habragerone/number.py
+++ b/custom_components/habragerone/number.py
@@ -18,6 +18,7 @@ from .entity_common import (
     descriptor_refresh_keys,
     descriptor_suggested_object_id,
     device_info_from_descriptor,
+    entity_is_available,
     get_runtime_and_descriptors,
     record_platform_entity_stats,
 )
@@ -64,6 +65,7 @@ class BragerSymbolNumber(NumberEntity):
         self._attr_available = True
         self._refresh_keys = descriptor_refresh_keys(descriptor)
         self._unsubscribe_listener: Any = None
+        self._unsubscribe_connectivity: Any = None
 
         min_value = descriptor.get("min")
         max_value = descriptor.get("max")
@@ -78,24 +80,30 @@ class BragerSymbolNumber(NumberEntity):
         return device_info_from_descriptor(self._descriptor, domain=DOMAIN)
 
     async def async_added_to_hass(self) -> None:
-        """Attach runtime listener when entity is added."""
+        """Attach runtime listeners when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
+        self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
-        """Detach runtime listener before entity removal."""
+        """Detach runtime listeners before entity removal."""
         if callable(self._unsubscribe_listener):
             self._unsubscribe_listener()
             self._unsubscribe_listener = None
+        if callable(self._unsubscribe_connectivity):
+            self._unsubscribe_connectivity()
+            self._unsubscribe_connectivity = None
 
     async def async_update(self) -> None:
         """Refresh numeric value from ParamStore."""
         raw_value = descriptor_current_raw_value(self._runtime.store, self._descriptor)
+        self._attr_available = entity_is_available(
+            self._runtime,
+            devid=self._devid,
+            has_value=raw_value is not None,
+        )
         if raw_value is None:
-            self._attr_available = False
             return
-
-        self._attr_available = True
         if isinstance(raw_value, int | float) and not isinstance(raw_value, bool):
             self._attr_native_value = float(raw_value)
 
@@ -107,5 +115,10 @@ class BragerSymbolNumber(NumberEntity):
     def _on_runtime_update(self, _update: ParamUpdate) -> None:
         update_key = f"{_update.pool}.{_update.chan}{_update.idx}"
         if self._refresh_keys and update_key not in self._refresh_keys:
+            return
+        self.async_schedule_update_ha_state(True)
+
+    def _on_connectivity(self, devid: str, _online: bool) -> None:
+        if devid != self._devid:
             return
         self.async_schedule_update_ha_state(True)

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -110,6 +110,7 @@ class BragerRuntime:
             return
         online_getter = getattr(self.gateway, "module_online", None)
         connected_at_getter = getattr(self.gateway, "module_connected_at", None)
+        gateway_getter = getattr(self.gateway, "module_gateway", None)
         if not callable(online_getter):
             return
         for raw_devid in modules:
@@ -118,7 +119,13 @@ class BragerRuntime:
             if not isinstance(online, bool):
                 continue
             connected_at = connected_at_getter(devid) if callable(connected_at_getter) else None
-            self._apply_module_online(devid, online, connected_at=connected_at if isinstance(connected_at, int) else None)
+            gateway = gateway_getter(devid) if callable(gateway_getter) else None
+            self._apply_module_online(
+                devid,
+                online,
+                connected_at=connected_at if isinstance(connected_at, int) else None,
+                gateway=gateway if isinstance(gateway, dict) else None,
+            )
 
     def _on_gateway_connectivity(self, event: Any) -> None:
         """Handle ``ModuleConnectivity`` (or duck-typed) events from the gateway."""
@@ -127,19 +134,30 @@ class BragerRuntime:
         if not devid or not isinstance(online, bool):
             return
         connected_at = getattr(event, "connected_at", None)
+        gateway = getattr(event, "gateway", None)
         self._apply_module_online(
             devid,
             online,
             connected_at=connected_at if isinstance(connected_at, int) else None,
+            gateway=gateway if isinstance(gateway, dict) else None,
         )
 
-    def _apply_module_online(self, devid: str, online: bool, *, connected_at: int | None) -> None:
+    def _apply_module_online(
+        self,
+        devid: str,
+        online: bool,
+        *,
+        connected_at: int | None,
+        gateway: dict[str, Any] | None = None,
+    ) -> None:
         """Update cache/modules_meta and notify connectivity listeners on change."""
         previous = self._module_online.get(devid)
         self._module_online[devid] = online
+        meta = self.modules_meta.setdefault(devid, {})
         if connected_at is not None:
-            meta = self.modules_meta.setdefault(devid, {})
             meta["connectedAt"] = connected_at
+        if gateway is not None:
+            meta["gateway"] = dict(gateway)
         if previous is online:
             return
         for callback in list(self._connectivity_listeners):

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -196,7 +196,7 @@ class BragerRuntime:
         """
         try:
             parameters = inspect.signature(callback).parameters.values()
-        except (TypeError, ValueError):
+        except TypeError, ValueError:
             callback(devid, online, flipped)
             return
         positional = [param for param in parameters if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)]

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -19,7 +19,8 @@ from pybragerone.models.param_resolver import ParamResolver
 from .command_write import WriteContext, WriteValidationError, prepare_write
 
 UpdateCallback = Callable[[ParamUpdate], None]
-ConnectivityCallback = Callable[[str, bool], None]
+# devid, online, online_changed — metadata-only updates set online_changed=False.
+ConnectivityCallback = Callable[[str, bool, bool], None]
 LOGGER = logging.getLogger(__name__)
 
 
@@ -49,7 +50,7 @@ class BragerRuntime:
         self._tasks.append(asyncio.create_task(self.store.run_with_bus(self.gateway.bus), name="habragerone-store-sync"))
         self._tasks.append(asyncio.create_task(self._dispatch_updates(), name="habragerone-update-dispatch"))
         register = getattr(self.gateway, "on_module_connectivity", None)
-        if callable(register):
+        if self.supports_module_connectivity and callable(register):
             register(self._on_gateway_connectivity)
         try:
             await self.gateway.start()
@@ -103,8 +104,17 @@ class BragerRuntime:
         """Return cached module online state, or ``None`` if not yet known."""
         return self._module_online.get(devid)
 
+    @property
+    def supports_module_connectivity(self) -> bool:
+        """Return whether the gateway exposes the module connectivity API."""
+        return callable(getattr(self.gateway, "on_module_connectivity", None)) and callable(
+            getattr(self.gateway, "module_online", None)
+        )
+
     def _seed_module_online_from_gateway(self) -> None:
         """Pull initial online bits from the gateway after start."""
+        if not self.supports_module_connectivity:
+            return
         modules = getattr(self.gateway, "modules", None)
         if not isinstance(modules, list):
             return
@@ -125,6 +135,7 @@ class BragerRuntime:
                 online,
                 connected_at=connected_at if isinstance(connected_at, int) else None,
                 gateway=gateway if isinstance(gateway, dict) else None,
+                online_changed=True,
             )
 
     def _on_gateway_connectivity(self, event: Any) -> None:
@@ -135,11 +146,15 @@ class BragerRuntime:
             return
         connected_at = getattr(event, "connected_at", None)
         gateway = getattr(event, "gateway", None)
+        online_changed = getattr(event, "online_changed", True)
+        if not isinstance(online_changed, bool):
+            online_changed = True
         self._apply_module_online(
             devid,
             online,
             connected_at=connected_at if isinstance(connected_at, int) else None,
             gateway=gateway if isinstance(gateway, dict) else None,
+            online_changed=online_changed,
         )
 
     def _apply_module_online(
@@ -149,8 +164,9 @@ class BragerRuntime:
         *,
         connected_at: int | None,
         gateway: dict[str, Any] | None = None,
+        online_changed: bool | None = None,
     ) -> None:
-        """Update cache/modules_meta and notify connectivity listeners on change."""
+        """Update cache/modules_meta and notify connectivity listeners."""
         previous = self._module_online.get(devid)
         self._module_online[devid] = online
         meta = self.modules_meta.setdefault(devid, {})
@@ -158,11 +174,13 @@ class BragerRuntime:
             meta["connectedAt"] = connected_at
         if gateway is not None:
             meta["gateway"] = dict(gateway)
-        if previous is online:
-            return
+        flipped = previous is not online if online_changed is None else online_changed
         for callback in list(self._connectivity_listeners):
             try:
-                callback(devid, online)
+                callback(devid, online, flipped)
+            except TypeError:
+                # Older test doubles / listeners that still take (devid, online).
+                callback(devid, online)  # type: ignore[call-arg]
             except Exception:
                 LOGGER.exception("Connectivity listener failed for devid=%s", devid)
 
@@ -184,6 +202,9 @@ class BragerRuntime:
 
         if not devid:
             raise HomeAssistantError(f"Missing device id for symbol '{symbol}'")
+
+        if self.module_online(devid) is False:
+            raise HomeAssistantError(f"Module '{devid}' is offline; refusing write for '{symbol}'")
 
         has_parameter_address = isinstance(pool, str) and isinstance(chan, str) and isinstance(idx, int)
         if isinstance(command_rules, list):

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -196,7 +196,7 @@ class BragerRuntime:
         """
         try:
             parameters = inspect.signature(callback).parameters.values()
-        except TypeError, ValueError:
+        except (TypeError, ValueError):
             callback(devid, online, flipped)
             return
         positional = [param for param in parameters if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)]

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -19,6 +19,7 @@ from pybragerone.models.param_resolver import ParamResolver
 from .command_write import WriteContext, WriteValidationError, prepare_write
 
 UpdateCallback = Callable[[ParamUpdate], None]
+ConnectivityCallback = Callable[[str, bool], None]
 LOGGER = logging.getLogger(__name__)
 
 
@@ -34,6 +35,8 @@ class BragerRuntime:
 
     _tasks: list[asyncio.Task[Any]] = field(default_factory=list)
     _listeners: set[UpdateCallback] = field(default_factory=set)
+    _connectivity_listeners: set[ConnectivityCallback] = field(default_factory=set)
+    _module_online: dict[str, bool] = field(default_factory=dict)
     _start_monotonic: float | None = None
     _first_update_logged: bool = False
     _status_resolver: ParamResolver | None = None
@@ -45,6 +48,9 @@ class BragerRuntime:
         self._first_update_logged = False
         self._tasks.append(asyncio.create_task(self.store.run_with_bus(self.gateway.bus), name="habragerone-store-sync"))
         self._tasks.append(asyncio.create_task(self._dispatch_updates(), name="habragerone-update-dispatch"))
+        register = getattr(self.gateway, "on_module_connectivity", None)
+        if callable(register):
+            register(self._on_gateway_connectivity)
         try:
             await self.gateway.start()
         except Exception:
@@ -55,6 +61,7 @@ class BragerRuntime:
                     await task
             self._tasks.clear()
             raise
+        self._seed_module_online_from_gateway()
         if self._start_monotonic is not None:
             LOGGER.debug(
                 "Runtime gateway.start completed in %.3fs (modules=%s)",
@@ -82,6 +89,64 @@ class BragerRuntime:
             self._listeners.discard(callback)
 
         return _remove
+
+    def add_connectivity_listener(self, callback: ConnectivityCallback) -> Callable[[], None]:
+        """Register a module online/offline listener and return unsubscribe callable."""
+        self._connectivity_listeners.add(callback)
+
+        def _remove() -> None:
+            self._connectivity_listeners.discard(callback)
+
+        return _remove
+
+    def module_online(self, devid: str) -> bool | None:
+        """Return cached module online state, or ``None`` if not yet known."""
+        return self._module_online.get(devid)
+
+    def _seed_module_online_from_gateway(self) -> None:
+        """Pull initial online bits from the gateway after start."""
+        modules = getattr(self.gateway, "modules", None)
+        if not isinstance(modules, list):
+            return
+        online_getter = getattr(self.gateway, "module_online", None)
+        connected_at_getter = getattr(self.gateway, "module_connected_at", None)
+        if not callable(online_getter):
+            return
+        for raw_devid in modules:
+            devid = str(raw_devid)
+            online = online_getter(devid)
+            if not isinstance(online, bool):
+                continue
+            connected_at = connected_at_getter(devid) if callable(connected_at_getter) else None
+            self._apply_module_online(devid, online, connected_at=connected_at if isinstance(connected_at, int) else None)
+
+    def _on_gateway_connectivity(self, event: Any) -> None:
+        """Handle ``ModuleConnectivity`` (or duck-typed) events from the gateway."""
+        devid = str(getattr(event, "devid", "") or "")
+        online = getattr(event, "online", None)
+        if not devid or not isinstance(online, bool):
+            return
+        connected_at = getattr(event, "connected_at", None)
+        self._apply_module_online(
+            devid,
+            online,
+            connected_at=connected_at if isinstance(connected_at, int) else None,
+        )
+
+    def _apply_module_online(self, devid: str, online: bool, *, connected_at: int | None) -> None:
+        """Update cache/modules_meta and notify connectivity listeners on change."""
+        previous = self._module_online.get(devid)
+        self._module_online[devid] = online
+        if connected_at is not None:
+            meta = self.modules_meta.setdefault(devid, {})
+            meta["connectedAt"] = connected_at
+        if previous is online:
+            return
+        for callback in list(self._connectivity_listeners):
+            try:
+                callback(devid, online)
+            except Exception:
+                LOGGER.exception("Connectivity listener failed for devid=%s", devid)
 
     async def async_write(
         self,

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import inspect
 import logging
 import time
 from collections.abc import Callable, Mapping
@@ -177,12 +178,33 @@ class BragerRuntime:
         flipped = previous is not online if online_changed is None else online_changed
         for callback in list(self._connectivity_listeners):
             try:
-                callback(devid, online, flipped)
-            except TypeError:
-                # Older test doubles / listeners that still take (devid, online).
-                callback(devid, online)  # type: ignore[call-arg]
+                self._invoke_connectivity_listener(callback, devid, online, flipped)
             except Exception:
                 LOGGER.exception("Connectivity listener failed for devid=%s", devid)
+
+    @staticmethod
+    def _invoke_connectivity_listener(
+        callback: ConnectivityCallback,
+        devid: str,
+        online: bool,
+        flipped: bool,
+    ) -> None:
+        """Call a connectivity listener with 2- or 3-arg compatibility.
+
+        Signature inspection avoids treating a ``TypeError`` raised *inside* a
+        modern 3-arg listener as an old 2-arg signature mismatch.
+        """
+        try:
+            parameters = inspect.signature(callback).parameters.values()
+        except TypeError, ValueError:
+            callback(devid, online, flipped)
+            return
+        positional = [param for param in parameters if param.kind in (param.POSITIONAL_ONLY, param.POSITIONAL_OR_KEYWORD)]
+        accepts_varargs = any(param.kind == param.VAR_POSITIONAL for param in parameters)
+        if accepts_varargs or len(positional) >= 3:
+            callback(devid, online, flipped)
+            return
+        callback(devid, online)  # type: ignore[call-arg]
 
     async def async_write(
         self,

--- a/custom_components/habragerone/select.py
+++ b/custom_components/habragerone/select.py
@@ -21,6 +21,7 @@ from .entity_common import (
     descriptor_refresh_keys,
     descriptor_suggested_object_id,
     device_info_from_descriptor,
+    entity_is_available,
     get_runtime_and_descriptors,
     record_platform_entity_stats,
 )
@@ -70,6 +71,7 @@ class BragerSymbolSelect(SelectEntity):
         self._attr_available = True
         self._refresh_keys = descriptor_refresh_keys(descriptor)
         self._unsubscribe_listener: Any = None
+        self._unsubscribe_connectivity: Any = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -77,24 +79,30 @@ class BragerSymbolSelect(SelectEntity):
         return device_info_from_descriptor(self._descriptor, domain=DOMAIN)
 
     async def async_added_to_hass(self) -> None:
-        """Attach runtime listener when entity is added."""
+        """Attach runtime listeners when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
+        self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
-        """Detach runtime listener before entity removal."""
+        """Detach runtime listeners before entity removal."""
         if callable(self._unsubscribe_listener):
             self._unsubscribe_listener()
             self._unsubscribe_listener = None
+        if callable(self._unsubscribe_connectivity):
+            self._unsubscribe_connectivity()
+            self._unsubscribe_connectivity = None
 
     async def async_update(self) -> None:
         """Refresh current option from ParamStore value."""
         raw_value = descriptor_current_raw_value(self._runtime.store, self._descriptor)
+        self._attr_available = entity_is_available(
+            self._runtime,
+            devid=self._devid,
+            has_value=raw_value is not None,
+        )
         if raw_value is None:
-            self._attr_available = False
             return
-
-        self._attr_available = True
         candidate = self._raw_to_label.get(str(raw_value))
         if candidate is None:
             candidate = str(raw_value)
@@ -113,5 +121,10 @@ class BragerSymbolSelect(SelectEntity):
     def _on_runtime_update(self, _update: ParamUpdate) -> None:
         update_key = f"{_update.pool}.{_update.chan}{_update.idx}"
         if self._refresh_keys and update_key not in self._refresh_keys:
+            return
+        self.async_schedule_update_ha_state(True)
+
+    def _on_connectivity(self, devid: str, _online: bool) -> None:
+        if devid != self._devid:
             return
         self.async_schedule_update_ha_state(True)

--- a/custom_components/habragerone/select.py
+++ b/custom_components/habragerone/select.py
@@ -124,7 +124,7 @@ class BragerSymbolSelect(SelectEntity):
             return
         self.async_schedule_update_ha_state(True)
 
-    def _on_connectivity(self, devid: str, _online: bool) -> None:
-        if devid != self._devid:
+    def _on_connectivity(self, devid: str, _online: bool, online_changed: bool = True) -> None:
+        if devid != self._devid or not online_changed:
             return
         self.async_schedule_update_ha_state(True)

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -19,6 +19,7 @@ from .entity_common import (
     descriptor_refresh_keys,
     descriptor_suggested_object_id,
     device_info_from_descriptor,
+    entity_is_available,
     get_runtime_and_descriptors,
     record_platform_entity_stats,
 )
@@ -81,17 +82,22 @@ class BragerSymbolSensor(SensorEntity):
         self._refresh_keys = descriptor_refresh_keys(descriptor)
 
         self._unsubscribe_listener: Any = None
+        self._unsubscribe_connectivity: Any = None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to push updates when entity is added to HA."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
+        self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
-        """Detach runtime listener when entity is removed from HA."""
+        """Detach runtime listeners when entity is removed from HA."""
         if callable(self._unsubscribe_listener):
             self._unsubscribe_listener()
             self._unsubscribe_listener = None
+        if callable(self._unsubscribe_connectivity):
+            self._unsubscribe_connectivity()
+            self._unsubscribe_connectivity = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -101,11 +107,13 @@ class BragerSymbolSensor(SensorEntity):
     async def async_update(self) -> None:
         """Fetch latest value from ParamStore (no heavy resolver call)."""
         raw_value = descriptor_current_raw_value(self._runtime.store, self._descriptor)
+        self._attr_available = entity_is_available(
+            self._runtime,
+            devid=self._devid,
+            has_value=raw_value is not None,
+        )
         if raw_value is None:
-            self._attr_available = False
             return
-
-        self._attr_available = True
         if self._requires_resolver_value:
             resolved_value, resolved_unit = await self._runtime.async_resolve_symbol_with_unit(self._symbol)
             normalized_dynamic_unit = self._normalize_unit(resolved_unit)
@@ -135,6 +143,11 @@ class BragerSymbolSensor(SensorEntity):
     def _on_runtime_update(self, _update: ParamUpdate) -> None:
         update_key = f"{_update.pool}.{_update.chan}{_update.idx}"
         if self._refresh_keys and update_key not in self._refresh_keys:
+            return
+        self.async_schedule_update_ha_state(True)
+
+    def _on_connectivity(self, devid: str, _online: bool) -> None:
+        if devid != self._devid:
             return
         self.async_schedule_update_ha_state(True)
 

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -146,8 +146,8 @@ class BragerSymbolSensor(SensorEntity):
             return
         self.async_schedule_update_ha_state(True)
 
-    def _on_connectivity(self, devid: str, _online: bool) -> None:
-        if devid != self._devid:
+    def _on_connectivity(self, devid: str, _online: bool, online_changed: bool = True) -> None:
+        if devid != self._devid or not online_changed:
             return
         self.async_schedule_update_ha_state(True)
 

--- a/custom_components/habragerone/switch.py
+++ b/custom_components/habragerone/switch.py
@@ -115,8 +115,8 @@ class BragerSymbolSwitch(SwitchEntity):
             return
         self.async_schedule_update_ha_state(True)
 
-    def _on_connectivity(self, devid: str, _online: bool) -> None:
-        if devid != self._devid:
+    def _on_connectivity(self, devid: str, _online: bool, online_changed: bool = True) -> None:
+        if devid != self._devid or not online_changed:
             return
         self.async_schedule_update_ha_state(True)
 

--- a/custom_components/habragerone/switch.py
+++ b/custom_components/habragerone/switch.py
@@ -18,6 +18,7 @@ from .entity_common import (
     descriptor_refresh_keys,
     descriptor_suggested_object_id,
     device_info_from_descriptor,
+    entity_is_available,
     get_runtime_and_descriptors,
     record_platform_entity_stats,
 )
@@ -64,6 +65,7 @@ class BragerSymbolSwitch(SwitchEntity):
         self._attr_available = True
         self._refresh_keys = descriptor_refresh_keys(descriptor)
         self._unsubscribe_listener: Any = None
+        self._unsubscribe_connectivity: Any = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -71,24 +73,30 @@ class BragerSymbolSwitch(SwitchEntity):
         return device_info_from_descriptor(self._descriptor, domain=DOMAIN)
 
     async def async_added_to_hass(self) -> None:
-        """Attach runtime listener when entity is added."""
+        """Attach runtime listeners when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
+        self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
-        """Detach runtime listener before entity removal."""
+        """Detach runtime listeners before entity removal."""
         if callable(self._unsubscribe_listener):
             self._unsubscribe_listener()
             self._unsubscribe_listener = None
+        if callable(self._unsubscribe_connectivity):
+            self._unsubscribe_connectivity()
+            self._unsubscribe_connectivity = None
 
     async def async_update(self) -> None:
         """Refresh switch state from ParamStore value."""
         raw_value = descriptor_current_raw_value(self._runtime.store, self._descriptor)
+        self._attr_available = entity_is_available(
+            self._runtime,
+            devid=self._devid,
+            has_value=raw_value is not None,
+        )
         if raw_value is None:
-            self._attr_available = False
             return
-
-        self._attr_available = True
         self._attr_is_on = _coerce_bool(raw_value)
 
     async def async_turn_on(self, **kwargs: Any) -> None:
@@ -104,6 +112,11 @@ class BragerSymbolSwitch(SwitchEntity):
     def _on_runtime_update(self, _update: ParamUpdate) -> None:
         update_key = f"{_update.pool}.{_update.chan}{_update.idx}"
         if self._refresh_keys and update_key not in self._refresh_keys:
+            return
+        self.async_schedule_update_ha_state(True)
+
+    def _on_connectivity(self, devid: str, _online: bool) -> None:
+        if devid != self._devid:
             return
         self.async_schedule_update_ha_state(True)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 import asyncio
 import sys
 import types
+from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
 
@@ -18,6 +19,16 @@ class _TokenStub(BaseModel):
     token_type: str = "bearer"
     expires_at: datetime | None = None
     objects: list[dict[str, Any]] = Field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class _ModuleConnectivityStub:
+    """Minimal ModuleConnectivity stand-in for offline unit tests."""
+
+    devid: str
+    online: bool
+    source: str = "derived"
+    connected_at: int | None = None
 
 
 @pytest.fixture(autouse=True)
@@ -85,6 +96,7 @@ def install_pybragerone_stubs() -> None:
 
     pybragerone_models_events_stub = types.ModuleType("pybragerone.models.events")
     pybragerone_models_events_stub.ParamUpdate = object
+    pybragerone_models_events_stub.ModuleConnectivity = _ModuleConnectivityStub
     sys.modules["pybragerone.models.events"] = pybragerone_models_events_stub
 
     pybragerone_models_catalog_stub = types.ModuleType("pybragerone.models.catalog")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -30,6 +30,8 @@ class _ModuleConnectivityStub:
     source: str = "derived"
     connected_at: int | None = None
     gateway: dict[str, object] | None = None
+    online_changed: bool = True
+    metadata_changed: bool = False
 
 
 @pytest.fixture(autouse=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,6 +29,7 @@ class _ModuleConnectivityStub:
     online: bool
     source: str = "derived"
     connected_at: int | None = None
+    gateway: dict[str, object] | None = None
 
 
 @pytest.fixture(autouse=True)

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -70,6 +70,7 @@ class FakeGateway:
         self.modules: list[str] = list(modules) if modules is not None else ["DEV1"]
         self._online: dict[str, bool] = {}
         self._connected_at: dict[str, int] = {}
+        self._gateway: dict[str, dict[str, object]] = {}
         self._connectivity_callbacks: list[Any] = []
         self._start_error = start_error
         self._start_delay = start_delay
@@ -98,6 +99,11 @@ class FakeGateway:
         """Return cached REST ``connectedAt`` epoch seconds when known."""
         return self._connected_at.get(devid)
 
+    def module_gateway(self, devid: str) -> dict[str, object] | None:
+        """Return cached gateway blob when known."""
+        gateway = self._gateway.get(devid)
+        return dict(gateway) if isinstance(gateway, dict) else None
+
     def emit_connectivity(
         self,
         devid: str,
@@ -105,16 +111,20 @@ class FakeGateway:
         *,
         connected_at: int | None = None,
         source: str = "derived",
+        gateway: dict[str, object] | None = None,
     ) -> None:
         """Update online cache and notify registered connectivity callbacks."""
         if connected_at is not None:
             self._connected_at[devid] = connected_at
+        if gateway is not None:
+            self._gateway[devid] = dict(gateway)
         self._online[devid] = online
         event = types.SimpleNamespace(
             devid=devid,
             online=online,
             source=source,
             connected_at=connected_at if connected_at is not None else self._connected_at.get(devid),
+            gateway=self._gateway.get(devid),
         )
         for callback in list(self._connectivity_callbacks):
             callback(event)

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -125,6 +125,8 @@ class FakeGateway:
             source=source,
             connected_at=connected_at if connected_at is not None else self._connected_at.get(devid),
             gateway=self._gateway.get(devid),
+            online_changed=True,
+            metadata_changed=False,
         )
         for callback in list(self._connectivity_callbacks):
             callback(event)

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import asyncio
+import types
 from collections.abc import AsyncIterator
 from dataclasses import dataclass, field
-from typing import Any, ClassVar
+from typing import Any
 
 
 @dataclass
@@ -58,10 +59,18 @@ class FakeApi:
 class FakeGateway:
     """Gateway with controllable start/stop and a fake event bus."""
 
-    modules: ClassVar[list[object]] = []
-
-    def __init__(self, *, start_error: Exception | None = None, start_delay: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        start_error: Exception | None = None,
+        start_delay: bool = False,
+        modules: list[str] | None = None,
+    ) -> None:
         self.bus = FakeBus()
+        self.modules: list[str] = list(modules) if modules is not None else ["DEV1"]
+        self._online: dict[str, bool] = {}
+        self._connected_at: dict[str, int] = {}
+        self._connectivity_callbacks: list[Any] = []
         self._start_error = start_error
         self._start_delay = start_delay
         self.started = False
@@ -76,6 +85,39 @@ class FakeGateway:
 
     async def stop(self) -> None:
         self.stopped = True
+
+    def on_module_connectivity(self, callback: Any) -> None:
+        """Register a ModuleConnectivity callback (mirrors BragerOneGateway)."""
+        self._connectivity_callbacks.append(callback)
+
+    def module_online(self, devid: str) -> bool | None:
+        """Return cached online flag, or ``None`` when unknown."""
+        return self._online.get(devid)
+
+    def module_connected_at(self, devid: str) -> int | None:
+        """Return cached REST ``connectedAt`` epoch seconds when known."""
+        return self._connected_at.get(devid)
+
+    def emit_connectivity(
+        self,
+        devid: str,
+        online: bool,
+        *,
+        connected_at: int | None = None,
+        source: str = "derived",
+    ) -> None:
+        """Update online cache and notify registered connectivity callbacks."""
+        if connected_at is not None:
+            self._connected_at[devid] = connected_at
+        self._online[devid] = online
+        event = types.SimpleNamespace(
+            devid=devid,
+            online=online,
+            source=source,
+            connected_at=connected_at if connected_at is not None else self._connected_at.get(devid),
+        )
+        for callback in list(self._connectivity_callbacks):
+            callback(event)
 
 
 class FakeStore:

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -292,6 +292,43 @@ def test_connection_label_non_dict_skips_descriptors(monkeypatch: pytest.MonkeyP
     )
     assert payload["connection_descriptors"] == []
 
+def test_connection_descriptors_skipped_quietly_without_label_api(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    with caplog.at_level(logging.DEBUG, logger=BOOTSTRAP_LOGGER):
+        payload, _calls, _web_ui = _run_bootstrap(monkeypatch, gated_groups={"Panel": ["SYM"]}, ungated_groups={})
+    assert payload["connection_descriptors"] == []
+    assert any("connection-label API unavailable" in record.getMessage() for record in caplog.records)
+
+
+def test_connection_descriptors_skipped_when_no_effective_modules(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _EmptyApi(_FakeApi):
+        async def get_modules(self, object_id: int) -> list[SimpleNamespace]:
+            _ = object_id
+            return []
+
+    class _EmptyLabels(_RecordingResolver):
+        async def resolve_module_connection_labels(self, *, lang: str | None = None) -> dict[str, str]:
+            _ = lang
+            return {}
+
+    _RecordingResolver.gated_groups = {}
+    _RecordingResolver.ungated_groups = {}
+    _RecordingResolver.calls = []
+    monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
+    monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", _EmptyLabels)
+    payload = asyncio.run(
+        async_build_bootstrap_payload(
+            api=cast(Any, _EmptyApi()),  # type: ignore[arg-type]
+            object_id=1,
+            modules=[],
+            language="en",
+        )
+    )
+    assert payload["connection_descriptors"] == []
+
+
+
 def test_failing_panel_group_build_propagates_instead_of_caching_emptiness() -> None:
     """A broken panel extraction must fail setup rather than report zero entities."""
 

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -212,8 +212,89 @@ def test_empty_panel_groups_warn_without_failing_bootstrap(
     assert "M1" in warnings[0].getMessage()
 
 
+def test_connection_descriptors_built_from_spa_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _LabeledResolver(_RecordingResolver):
+        async def resolve_module_connection_labels(self, *, lang: str | None = None) -> dict[str, str]:
+            _ = lang
+            return {
+                "serverConnection": "Server connection status",
+                "connection.status": "Connection with module status",
+                "connection.index": "Connection with module",
+            }
+
+    _RecordingResolver.gated_groups = {"Panel": ["SYM_GATED"]}
+    _RecordingResolver.ungated_groups = {}
+    _RecordingResolver.calls = []
+    monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
+    monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", _LabeledResolver)
+
+    payload = asyncio.run(
+        async_build_bootstrap_payload(
+            api=cast(Any, _FakeApi()),  # type: ignore[arg-type]
+            object_id=1,
+            modules=["M1"],
+            language="en",
+        )
+    )
+    descriptors = payload["connection_descriptors"]
+    assert len(descriptors) == 1
+    assert descriptors[0]["menu_key"] == "module.connection"
+    assert descriptors[0]["label"] == "Connection with module status"
+    assert "Connection with module" in descriptors[0]["device_name"]
+
+
+def test_connection_label_resolve_failure_warns_when_api_supported(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    class _BrokenLabels(_RecordingResolver):
+        async def resolve_module_connection_labels(self, *, lang: str | None = None) -> dict[str, str]:
+            _ = lang
+            raise RuntimeError("i18n down")
+
+    _RecordingResolver.gated_groups = {"Panel": ["SYM_GATED"]}
+    _RecordingResolver.ungated_groups = {}
+    _RecordingResolver.calls = []
+    monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
+    monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", _BrokenLabels)
+
+    with caplog.at_level(logging.WARNING, logger=BOOTSTRAP_LOGGER):
+        payload = asyncio.run(
+            async_build_bootstrap_payload(
+                api=cast(Any, _FakeApi()),  # type: ignore[arg-type]
+                object_id=1,
+                modules=["M1"],
+                language="en",
+            )
+        )
+    assert payload["connection_descriptors"] == []
+    assert any("Skipping connection_descriptors" in record.getMessage() for record in caplog.records)
+
+
+def test_connection_label_non_dict_skips_descriptors(monkeypatch: pytest.MonkeyPatch) -> None:
+    class _NonDictLabels(_RecordingResolver):
+        async def resolve_module_connection_labels(self, *, lang: str | None = None) -> object:
+            _ = lang
+            return ["not", "a", "dict"]
+
+    _RecordingResolver.gated_groups = {"Panel": ["SYM_GATED"]}
+    _RecordingResolver.ungated_groups = {}
+    _RecordingResolver.calls = []
+    monkeypatch.setattr(sys.modules["pybragerone.models.param"], "ParamStore", _FakeParamStore)
+    monkeypatch.setattr(sys.modules["pybragerone.models.param_resolver"], "ParamResolver", _NonDictLabels)
+
+    payload = asyncio.run(
+        async_build_bootstrap_payload(
+            api=cast(Any, _FakeApi()),  # type: ignore[arg-type]
+            object_id=1,
+            modules=["M1"],
+            language="en",
+        )
+    )
+    assert payload["connection_descriptors"] == []
+
 def test_failing_panel_group_build_propagates_instead_of_caching_emptiness() -> None:
     """A broken panel extraction must fail setup rather than report zero entities."""
+
 
     class _AlwaysFailingResolver:
         async def build_panel_groups(

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -292,6 +292,7 @@ def test_connection_label_non_dict_skips_descriptors(monkeypatch: pytest.MonkeyP
     )
     assert payload["connection_descriptors"] == []
 
+
 def test_connection_descriptors_skipped_quietly_without_label_api(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
@@ -328,10 +329,8 @@ def test_connection_descriptors_skipped_when_no_effective_modules(monkeypatch: p
     assert payload["connection_descriptors"] == []
 
 
-
 def test_failing_panel_group_build_propagates_instead_of_caching_emptiness() -> None:
     """A broken panel extraction must fail setup rather than report zero entities."""
-
 
     class _AlwaysFailingResolver:
         async def build_panel_groups(

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -146,6 +146,24 @@ async def test_diagnostics_connectivity_without_gateway_modules_list(hass: HomeA
 
 
 @pytest.mark.asyncio
+async def test_diagnostics_skips_blank_devid_connectivity(hass: HomeAssistant) -> None:
+    from custom_components.habragerone.const import DATA_RUNTIME
+    from tests.helpers.fakes import make_runtime
+
+    runtime, _api, gateway, _store = make_runtime(
+        modules_meta={"": {"name": "bad"}, "DEV1": {"name": "Boiler", "connectedAt": 1}}
+    )
+    gateway.modules = ["", "DEV1"]
+    runtime._module_online["DEV1"] = True
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.data[DOMAIN][entry.entry_id][DATA_RUNTIME] = runtime
+
+    payload = await async_get_config_entry_diagnostics(hass, entry)
+    assert "" not in payload["connectivity"]
+    assert payload["connectivity"]["DEV1"]["online"] is True
+
+
+@pytest.mark.asyncio
 async def test_diagnostics_skips_connectivity_when_entry_data_not_dict(hass: HomeAssistant) -> None:
     entry = register_config_entry(hass, runtime=object(), descriptors=[])
     hass.data[DOMAIN][entry.entry_id] = "not-a-dict"  # type: ignore[assignment]

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -129,3 +129,25 @@ async def test_diagnostics_includes_module_connectivity(hass: HomeAssistant) -> 
     assert connectivity["DEV1"]["online"] is True
     assert connectivity["DEV1"]["connectedAt"] == 99
     assert "DEV2" in connectivity
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_connectivity_without_gateway_modules_list(hass: HomeAssistant) -> None:
+    from custom_components.habragerone.const import DATA_RUNTIME
+    from tests.helpers.fakes import make_runtime
+
+    runtime, _api, gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    gateway.modules = "not-a-list"  # type: ignore[assignment]
+    runtime._module_online["DEV1"] = False
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.data[DOMAIN][entry.entry_id][DATA_RUNTIME] = runtime
+    payload = await async_get_config_entry_diagnostics(hass, entry)
+    assert payload["connectivity"]["DEV1"]["online"] is False
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_skips_connectivity_when_entry_data_not_dict(hass: HomeAssistant) -> None:
+    entry = register_config_entry(hass, runtime=object(), descriptors=[])
+    hass.data[DOMAIN][entry.entry_id] = "not-a-dict"  # type: ignore[assignment]
+    payload = await async_get_config_entry_diagnostics(hass, entry)
+    assert payload["connectivity"] == {}

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -109,3 +109,23 @@ async def test_diagnostics_reports_unknown_platforms(hass: HomeAssistant) -> Non
 
     assert summary["unknown_platforms"] == {"climate": 1}
     assert "climate" not in summary["platform_breakdown"]
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_includes_module_connectivity(hass: HomeAssistant) -> None:
+    from custom_components.habragerone.const import DATA_RUNTIME
+    from tests.helpers.fakes import make_runtime
+
+    runtime, _api, gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler", "connectedAt": 99}})
+    gateway.modules = ["DEV1", "DEV2"]
+    gateway._online["DEV1"] = True
+    gateway._connected_at["DEV1"] = 99
+    runtime._module_online["DEV1"] = True
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[{"platform": "sensor", "symbol": "TEMP"}])
+    hass.data[DOMAIN][entry.entry_id][DATA_RUNTIME] = runtime
+
+    payload = await async_get_config_entry_diagnostics(hass, entry)
+    connectivity = payload["connectivity"]
+    assert connectivity["DEV1"]["online"] is True
+    assert connectivity["DEV1"]["connectedAt"] == 99
+    assert "DEV2" in connectivity

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -1,0 +1,106 @@
+"""Tests for module connectivity runtime cache and diagnostic binary sensor."""
+
+from __future__ import annotations
+
+import pytest
+from homeassistant.components.binary_sensor import BinarySensorDeviceClass
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.binary_sensor import (  # noqa: E402
+    BragerModuleConnectivityBinarySensor,
+    async_setup_entry,
+)
+from custom_components.habragerone.const import (  # noqa: E402
+    CONF_MODULES_META,
+    DATA_ENTITY_STATS,
+    DOMAIN,
+)
+from custom_components.habragerone.entity_common import entity_is_available, module_is_reachable  # noqa: E402
+from tests.helpers.descriptors import binary_sensor_descriptor  # noqa: E402
+from tests.helpers.fakes import make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+def test_module_is_reachable_unknown_defaults_true() -> None:
+    runtime, *_rest = make_runtime()
+    assert module_is_reachable(runtime, "DEV1") is True
+    runtime._module_online["DEV1"] = False
+    assert module_is_reachable(runtime, "DEV1") is False
+    assert entity_is_available(runtime, devid="DEV1", has_value=True) is False
+    assert entity_is_available(runtime, devid="DEV1", has_value=False) is False
+
+
+@pytest.mark.asyncio
+async def test_runtime_seeds_and_fans_out_connectivity() -> None:
+    runtime, _api, gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    gateway._online["DEV1"] = True
+    gateway._connected_at["DEV1"] = 1_700_000_000
+    seen: list[tuple[str, bool]] = []
+    runtime.add_connectivity_listener(lambda devid, online: seen.append((devid, online)))
+
+    await runtime.start()
+    assert runtime.module_online("DEV1") is True
+    assert runtime.modules_meta["DEV1"]["connectedAt"] == 1_700_000_000
+    assert ("DEV1", True) in seen
+
+    seen.clear()
+    gateway.emit_connectivity("DEV1", False, connected_at=0)
+    assert runtime.module_online("DEV1") is False
+    assert runtime.modules_meta["DEV1"]["connectedAt"] == 0
+    assert seen == [("DEV1", False)]
+    await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_async_setup_adds_connectivity_sensor(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(
+        flat_values={"P5.s0": 1},
+        modules_meta={"DEV1": {"name": "Boiler", "title": "DasPell", "version": "V2"}},
+    )
+    descriptors = [binary_sensor_descriptor(symbol="BIN1")]
+    entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
+    # register_config_entry may not persist modules_meta on entry.data — set explicitly.
+    hass.config_entries.async_update_entry(entry, data={**entry.data, CONF_MODULES_META: {"DEV1": {"name": "Boiler"}}})
+    entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
+
+    added: list[object] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    connectivity = [entity for entity in added if isinstance(entity, BragerModuleConnectivityBinarySensor)]
+    assert len(connectivity) == 1
+    entity = connectivity[0]
+    assert entity._attr_device_class == BinarySensorDeviceClass.CONNECTIVITY
+    assert entity._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert entity._attr_unique_id.endswith("_dev1_connectivity_binary")
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["binary_sensor"]
+    assert stats["created_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_connectivity_sensor_tracks_runtime(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    entity = BragerModuleConnectivityBinarySensor(
+        entry=entry,
+        runtime=runtime,
+        devid="DEV1",
+        module_meta={"name": "Boiler"},
+    )
+    entity.hass = hass
+    entity.async_write_ha_state = lambda: None  # type: ignore[method-assign]
+    entity.schedule_update_ha_state = lambda *a, **k: None  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = lambda *a, **k: None  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+    runtime._apply_module_online("DEV1", True, connected_at=99)
+    await entity.async_update()
+    assert entity._attr_is_on is True
+
+    runtime._apply_module_online("DEV1", False, connected_at=0)
+    await entity.async_update()
+    assert entity._attr_is_on is False

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -6,6 +6,7 @@ import pytest
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 
 from tests.conftest import install_pybragerone_stubs
 
@@ -26,6 +27,24 @@ from tests.helpers.descriptors import binary_sensor_descriptor  # noqa: E402
 from tests.helpers.fakes import make_runtime  # noqa: E402
 from tests.helpers.hass import register_config_entry  # noqa: E402
 
+CONNECTION_DESCRIPTOR = {
+    "kind": "module_connection",
+    "source": "module_i18n",
+    "menu_key": "module.connection",
+    "devid": "DEV1",
+    "module_name": "Boiler",
+    "label": "Connection with module status",
+    "device_name": "Boiler — Connection with module",
+    "labels": {
+        "connection.status": "Connection with module status",
+        "connection.index": "Connection with module",
+        "connection.connected": "Connected",
+        "connection.notConnected": "Disconnected",
+        "serverConnection": "Server connection status",
+    },
+    "platform": "binary_sensor",
+}
+
 
 def test_module_is_reachable_unknown_defaults_true() -> None:
     runtime, *_rest = make_runtime()
@@ -41,20 +60,32 @@ async def test_runtime_seeds_and_fans_out_connectivity() -> None:
     runtime, _api, gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
     gateway._online["DEV1"] = True
     gateway._connected_at["DEV1"] = 1_700_000_000
-    seen: list[tuple[str, bool]] = []
-    runtime.add_connectivity_listener(lambda devid, online: seen.append((devid, online)))
+    seen: list[tuple[str, bool, bool]] = []
+    runtime.add_connectivity_listener(lambda devid, online, flipped: seen.append((devid, online, flipped)))
 
     await runtime.start()
+    assert runtime.supports_module_connectivity is True
     assert runtime.module_online("DEV1") is True
     assert runtime.modules_meta["DEV1"]["connectedAt"] == 1_700_000_000
-    assert ("DEV1", True) in seen
+    assert ("DEV1", True, True) in seen
 
     seen.clear()
     gateway.emit_connectivity("DEV1", False, connected_at=0)
     assert runtime.module_online("DEV1") is False
     assert runtime.modules_meta["DEV1"]["connectedAt"] == 0
-    assert seen == [("DEV1", False)]
+    assert seen == [("DEV1", False, True)]
     await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_async_write_refuses_when_offline() -> None:
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    runtime._module_online["DEV1"] = False
+    with pytest.raises(HomeAssistantError, match="offline"):
+        await runtime.async_write(
+            descriptor={"symbol": "PARAM_X", "devid": "DEV1", "pool": "P1", "chan": "v", "idx": 1},
+            input_display_value=1,
+        )
 
 
 @pytest.mark.asyncio
@@ -64,31 +95,13 @@ async def test_async_setup_adds_connectivity_sensor(hass: HomeAssistant) -> None
         modules_meta={"DEV1": {"name": "Boiler", "title": "DasPell", "version": "V2"}},
     )
     descriptors = [binary_sensor_descriptor(symbol="BIN1")]
-    connection_descriptors = [
-        {
-            "kind": "module_connection",
-            "source": "module_i18n",
-            "menu_key": "module.connection",
-            "devid": "DEV1",
-            "label": "Connection with module status",
-            "device_name": "Connection with module",
-            "labels": {
-                "connection.status": "Connection with module status",
-                "connection.index": "Connection with module",
-                "connection.connected": "Connected",
-                "connection.notConnected": "Disconnected",
-                "serverConnection": "Server connection status",
-            },
-            "platform": "binary_sensor",
-        }
-    ]
     entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
     hass.config_entries.async_update_entry(
         entry,
         data={
             **entry.data,
             CONF_MODULES_META: {"DEV1": {"name": "Boiler", "title": "DasPell", "version": "V2"}},
-            CONF_CONNECTION_DESCRIPTORS: connection_descriptors,
+            CONF_CONNECTION_DESCRIPTORS: [CONNECTION_DESCRIPTOR],
         },
     )
     entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
@@ -107,8 +120,24 @@ async def test_async_setup_adds_connectivity_sensor(hass: HomeAssistant) -> None
     assert info is not None
     assert (DOMAIN, "DEV1:module.connection") in info["identifiers"]
     assert info.get("via_device") == (DOMAIN, "DEV1")
+    assert info.get("name") == "Boiler — Connection with module"
     stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["binary_sensor"]
     assert stats["created_count"] == 2
+    assert stats["descriptor_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_async_setup_skips_connectivity_without_descriptor(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_MODULES_META: {"DEV1": {"name": "Boiler"}}, CONF_CONNECTION_DESCRIPTORS: []},
+    )
+    entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
+    added: list[object] = []
+    await async_setup_entry(hass, entry, added.extend)
+    assert not any(isinstance(entity, BragerModuleConnectivityBinarySensor) for entity in added)
 
 
 @pytest.mark.asyncio
@@ -122,9 +151,10 @@ async def test_connectivity_sensor_tracks_runtime(hass: HomeAssistant) -> None:
         module_meta={"name": "Boiler"},
         connection_descriptor={
             "label": "Status połączenia z modułem",
-            "device_name": "Połączenie z modułem",
+            "device_name": "Boiler — Połączenie z modułem",
             "menu_key": "module.connection",
             "labels": {
+                "connection.index": "Połączenie z modułem",
                 "connection.connected": "Połączono",
                 "connection.notConnected": "Rozłączono",
             },
@@ -136,6 +166,10 @@ async def test_connectivity_sensor_tracks_runtime(hass: HomeAssistant) -> None:
     entity.async_schedule_update_ha_state = lambda *a, **k: None  # type: ignore[method-assign]
 
     await entity.async_added_to_hass()
+    await entity.async_update()
+    assert entity._attr_is_on is None
+    assert entity._attr_available is False
+
     runtime._apply_module_online(
         "DEV1",
         True,
@@ -144,6 +178,7 @@ async def test_connectivity_sensor_tracks_runtime(hass: HomeAssistant) -> None:
     )
     await entity.async_update()
     assert entity._attr_is_on is True
+    assert entity._attr_available is True
     assert entity._attr_name == "Status połączenia z modułem"
     attrs = entity.extra_state_attributes
     assert attrs["connected_at"] == 99

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import types
+
 import pytest
 from homeassistant.components.binary_sensor import BinarySensorDeviceClass
 from homeassistant.const import EntityCategory
@@ -188,3 +190,138 @@ async def test_connectivity_sensor_tracks_runtime(hass: HomeAssistant) -> None:
     runtime._apply_module_online("DEV1", False, connected_at=0)
     await entity.async_update()
     assert entity._attr_is_on is False
+
+    entity._on_connectivity("OTHER", True)
+    entity._on_connectivity("DEV1", False)
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_connectivity is None
+
+
+@pytest.mark.asyncio
+async def test_async_setup_skips_non_dict_connection_rows(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}, "": {"name": "bad"}})
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            CONF_MODULES_META: {"DEV1": "not-a-dict", "": {"name": "bad"}},
+            CONF_CONNECTION_DESCRIPTORS: ["bad", {"devid": ""}, CONNECTION_DESCRIPTOR],
+        },
+    )
+    entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
+    added: list[object] = []
+    await async_setup_entry(hass, entry, added.extend)
+    connectivity = [entity for entity in added if isinstance(entity, BragerModuleConnectivityBinarySensor)]
+    assert len(connectivity) == 1
+
+
+@pytest.mark.asyncio
+async def test_connectivity_sensor_requires_spa_label(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    with pytest.raises(ValueError, match="missing SPA i18n label"):
+        BragerModuleConnectivityBinarySensor(
+            entry=entry,
+            runtime=runtime,
+            devid="DEV1",
+            module_meta={"name": "Boiler"},
+            connection_descriptor={"labels": {}},
+        )
+
+
+@pytest.mark.asyncio
+async def test_runtime_connectivity_listener_compat_and_seed_edges() -> None:
+    from typing import ClassVar
+
+    from custom_components.habragerone.runtime import BragerRuntime
+
+    runtime, _api, _gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    two_arg: list[tuple[str, bool]] = []
+    runtime.add_connectivity_listener(lambda devid, online: two_arg.append((devid, online)))
+    boom_calls = 0
+
+    def _boom(_devid: str, _online: bool, _flipped: bool = True) -> None:
+        nonlocal boom_calls
+        boom_calls += 1
+        raise RuntimeError("listener boom")
+
+    runtime.add_connectivity_listener(_boom)
+    runtime._apply_module_online("DEV1", True, connected_at=1)
+    assert two_arg == [("DEV1", True)]
+    assert boom_calls == 1
+
+    # Bad gateway events are ignored.
+    runtime._on_gateway_connectivity(object())
+    runtime._on_gateway_connectivity(types.SimpleNamespace(devid="", online=True))
+    runtime._on_gateway_connectivity(
+        types.SimpleNamespace(devid="DEV1", online=False, online_changed="yes", connected_at=0, gateway=None)
+    )
+    assert runtime.module_online("DEV1") is False
+
+    # Seed skips when gateway has no modules list / no online getter.
+    class _NoModules:
+        def on_module_connectivity(self, _cb: object) -> None:
+            return None
+
+        def module_online(self, _devid: str) -> bool | None:
+            return True
+
+    runtime.gateway = _NoModules()  # type: ignore[assignment]
+    runtime._seed_module_online_from_gateway()
+
+    class _BadModules:
+        modules: ClassVar[object] = "nope"
+
+        def on_module_connectivity(self, _cb: object) -> None:
+            return None
+
+        def module_online(self, _devid: str) -> bool | None:
+            return True
+
+    runtime.gateway = _BadModules()  # type: ignore[assignment]
+    runtime._seed_module_online_from_gateway()
+
+    class _NoOnlineGetter:
+        modules: ClassVar[list[str]] = ["DEV1"]
+
+        def on_module_connectivity(self, _cb: object) -> None:
+            return None
+
+    runtime.gateway = _NoOnlineGetter()  # type: ignore[assignment]
+    assert runtime.supports_module_connectivity is False
+    runtime._seed_module_online_from_gateway()
+
+    class _SupportsButNoGetter:
+        modules: ClassVar[list[str]] = ["DEV1"]
+        module_online = None
+
+        def on_module_connectivity(self, _cb: object) -> None:
+            return None
+
+    class _NonBoolOnline:
+        modules: ClassVar[list[str]] = ["DEV1"]
+
+        def on_module_connectivity(self, _cb: object) -> None:
+            return None
+
+        def module_online(self, _devid: str) -> object:
+            return "yes"
+
+        def module_connected_at(self, _devid: str) -> None:
+            return None
+
+        def module_gateway(self, _devid: str) -> None:
+            return None
+
+    original_supports = BragerRuntime.supports_module_connectivity
+    try:
+        BragerRuntime.supports_module_connectivity = property(lambda self: True)  # type: ignore[assignment,method-assign]
+        runtime.gateway = _SupportsButNoGetter()  # type: ignore[assignment]
+        runtime._seed_module_online_from_gateway()
+    finally:
+        BragerRuntime.supports_module_connectivity = original_supports  # type: ignore[assignment]
+
+    runtime.gateway = _NonBoolOnline()  # type: ignore[assignment]
+    runtime._seed_module_online_from_gateway()
+    assert runtime.module_online("DEV1") is False

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -313,6 +313,25 @@ async def test_runtime_connectivity_listener_compat_and_seed_edges() -> None:
     assert boom_calls == 1
     assert type_error_calls == 1
 
+    # When signature inspection fails, fall back to the modern 3-arg call.
+    uninspectable_calls: list[tuple[str, bool, bool]] = []
+
+    class _Uninspectable:
+        def __call__(self, devid: str, online: bool, flipped: bool = True) -> None:
+            uninspectable_calls.append((devid, online, flipped))
+
+    runtime._connectivity_listeners.clear()
+    with pytest.MonkeyPatch.context() as monkeypatch:
+        runtime_module = __import__("custom_components.habragerone.runtime", fromlist=["inspect"])
+        monkeypatch.setattr(
+            runtime_module.inspect,
+            "signature",
+            lambda _cb: (_ for _ in ()).throw(ValueError("no sig")),
+        )
+        runtime.add_connectivity_listener(_Uninspectable())  # type: ignore[arg-type]
+        runtime._apply_module_online("DEV1", False, connected_at=0)
+    assert uninspectable_calls == [("DEV1", False, True)]
+
     # Bad gateway events are ignored.
     runtime._on_gateway_connectivity(object())
     runtime._on_gateway_connectivity(types.SimpleNamespace(devid="", online=True))

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -16,6 +16,7 @@ from custom_components.habragerone.binary_sensor import (  # noqa: E402
     async_setup_entry,
 )
 from custom_components.habragerone.const import (  # noqa: E402
+    CONF_CONNECTION_DESCRIPTORS,
     CONF_MODULES_META,
     DATA_ENTITY_STATS,
     DOMAIN,
@@ -63,9 +64,33 @@ async def test_async_setup_adds_connectivity_sensor(hass: HomeAssistant) -> None
         modules_meta={"DEV1": {"name": "Boiler", "title": "DasPell", "version": "V2"}},
     )
     descriptors = [binary_sensor_descriptor(symbol="BIN1")]
+    connection_descriptors = [
+        {
+            "kind": "module_connection",
+            "source": "module_i18n",
+            "menu_key": "module.connection",
+            "devid": "DEV1",
+            "label": "Connection with module status",
+            "device_name": "Connection with module",
+            "labels": {
+                "connection.status": "Connection with module status",
+                "connection.index": "Connection with module",
+                "connection.connected": "Connected",
+                "connection.notConnected": "Disconnected",
+                "serverConnection": "Server connection status",
+            },
+            "platform": "binary_sensor",
+        }
+    ]
     entry = register_config_entry(hass, runtime=runtime, descriptors=descriptors)
-    # register_config_entry may not persist modules_meta on entry.data — set explicitly.
-    hass.config_entries.async_update_entry(entry, data={**entry.data, CONF_MODULES_META: {"DEV1": {"name": "Boiler"}}})
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            CONF_MODULES_META: {"DEV1": {"name": "Boiler", "title": "DasPell", "version": "V2"}},
+            CONF_CONNECTION_DESCRIPTORS: connection_descriptors,
+        },
+    )
     entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
 
     added: list[object] = []
@@ -76,7 +101,12 @@ async def test_async_setup_adds_connectivity_sensor(hass: HomeAssistant) -> None
     entity = connectivity[0]
     assert entity._attr_device_class == BinarySensorDeviceClass.CONNECTIVITY
     assert entity._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert entity._attr_name == "Connection with module status"
     assert entity._attr_unique_id.endswith("_dev1_connectivity_binary")
+    info = entity.device_info
+    assert info is not None
+    assert (DOMAIN, "DEV1:module.connection") in info["identifiers"]
+    assert info.get("via_device") == (DOMAIN, "DEV1")
     stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["binary_sensor"]
     assert stats["created_count"] == 2
 
@@ -90,6 +120,15 @@ async def test_connectivity_sensor_tracks_runtime(hass: HomeAssistant) -> None:
         runtime=runtime,
         devid="DEV1",
         module_meta={"name": "Boiler"},
+        connection_descriptor={
+            "label": "Status połączenia z modułem",
+            "device_name": "Połączenie z modułem",
+            "menu_key": "module.connection",
+            "labels": {
+                "connection.connected": "Połączono",
+                "connection.notConnected": "Rozłączono",
+            },
+        },
     )
     entity.hass = hass
     entity.async_write_ha_state = lambda: None  # type: ignore[method-assign]
@@ -97,9 +136,19 @@ async def test_connectivity_sensor_tracks_runtime(hass: HomeAssistant) -> None:
     entity.async_schedule_update_ha_state = lambda *a, **k: None  # type: ignore[method-assign]
 
     await entity.async_added_to_hass()
-    runtime._apply_module_online("DEV1", True, connected_at=99)
+    runtime._apply_module_online(
+        "DEV1",
+        True,
+        connected_at=99,
+        gateway={"address": "10.0.0.1", "interface": "wifi", "version": "V2"},
+    )
     await entity.async_update()
     assert entity._attr_is_on is True
+    assert entity._attr_name == "Status połączenia z modułem"
+    attrs = entity.extra_state_attributes
+    assert attrs["connected_at"] == 99
+    assert attrs["gateway_interface"] == "wifi"
+    assert attrs["state_label_on"] == "Połączono"
 
     runtime._apply_module_online("DEV1", False, connected_at=0)
     await entity.async_update()

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -217,6 +217,58 @@ async def test_async_setup_skips_non_dict_connection_rows(hass: HomeAssistant) -
 
 
 @pytest.mark.asyncio
+async def test_async_setup_skips_non_list_connection_descriptors(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            CONF_MODULES_META: {"DEV1": {"name": "Boiler"}},
+            CONF_CONNECTION_DESCRIPTORS: "not-a-list",
+        },
+    )
+    entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
+    added: list[object] = []
+    await async_setup_entry(hass, entry, added.extend)
+    assert not any(isinstance(entity, BragerModuleConnectivityBinarySensor) for entity in added)
+
+
+@pytest.mark.asyncio
+async def test_connectivity_sensor_attrs_without_optional_fields(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    runtime.modules_meta["DEV1"] = {
+        "name": "Boiler",
+        "connectedAt": "bad",
+        "gateway": {"address": None, "interface": "", "version": None},
+    }
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    entity = BragerModuleConnectivityBinarySensor(
+        entry=entry,
+        runtime=runtime,
+        devid="DEV1",
+        module_meta=runtime.modules_meta["DEV1"],
+        connection_descriptor={
+            "label": "Status",
+            "labels": {"connection.connected": 1, "connection.notConnected": None},
+            "menu_key": "module.connection",
+        },
+    )
+    attrs = entity.extra_state_attributes
+    assert "connected_at" not in attrs
+    assert "gateway_address" not in attrs
+    assert "gateway_interface" not in attrs
+    assert "gateway_version" not in attrs
+    assert "state_label_on" not in attrs
+
+    runtime.modules_meta["DEV1"] = {"name": "Boiler", "gateway": "not-a-dict"}
+    assert "gateway_address" not in entity.extra_state_attributes
+
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_connectivity is None
+
+
+@pytest.mark.asyncio
 async def test_connectivity_sensor_requires_spa_label(hass: HomeAssistant) -> None:
     runtime, *_rest = make_runtime()
     entry = register_config_entry(hass, runtime=runtime, descriptors=[])
@@ -325,3 +377,25 @@ async def test_runtime_connectivity_listener_compat_and_seed_edges() -> None:
     runtime.gateway = _NonBoolOnline()  # type: ignore[assignment]
     runtime._seed_module_online_from_gateway()
     assert runtime.module_online("DEV1") is False
+
+    # Metadata-only apply (no connected_at) and start without connectivity API.
+    runtime._apply_module_online("DEV1", True, connected_at=None, gateway={"address": ""})
+    assert runtime.modules_meta["DEV1"].get("gateway") == {"address": ""}
+
+    class _NoConnectivityApi:
+        modules: ClassVar[list[str]] = ["DEV1"]
+
+        def __init__(self) -> None:
+            from tests.helpers.fakes import FakeBus
+
+            self.bus = FakeBus()
+
+        async def start(self) -> None:
+            return None
+
+        async def stop(self) -> None:
+            return None
+
+    runtime.gateway = _NoConnectivityApi()  # type: ignore[assignment]
+    await runtime.start()
+    await runtime.stop()

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -299,9 +299,19 @@ async def test_runtime_connectivity_listener_compat_and_seed_edges() -> None:
         raise RuntimeError("listener boom")
 
     runtime.add_connectivity_listener(_boom)
+
+    type_error_calls = 0
+
+    def _type_error_inside(_devid: str, _online: bool, _flipped: bool = True) -> None:
+        nonlocal type_error_calls
+        type_error_calls += 1
+        raise TypeError("raised inside a 3-arg listener")
+
+    runtime.add_connectivity_listener(_type_error_inside)
     runtime._apply_module_online("DEV1", True, connected_at=1)
     assert two_arg == [("DEV1", True)]
     assert boom_calls == 1
+    assert type_error_calls == 1
 
     # Bad gateway events are ignored.
     runtime._on_gateway_connectivity(object())

--- a/tests/test_platform_binary_sensor.py
+++ b/tests/test_platform_binary_sensor.py
@@ -148,3 +148,11 @@ async def test_binary_sensor_runtime_update_schedules_refresh_for_matching_key(h
     entity.async_schedule_update_ha_state.reset_mock()
     entity._on_runtime_update(FakeParamUpdate(pool="P9", chan="v", idx=1))
     entity.async_schedule_update_ha_state.assert_not_called()
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_connectivity("OTHER", False)
+    entity.async_schedule_update_ha_state.assert_not_called()
+    entity._on_connectivity("DEV1", False, online_changed=False)
+    entity.async_schedule_update_ha_state.assert_not_called()
+    entity._on_connectivity("DEV1", False)
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)

--- a/tests/test_platform_binary_sensor.py
+++ b/tests/test_platform_binary_sensor.py
@@ -156,3 +156,7 @@ async def test_binary_sensor_runtime_update_schedules_refresh_for_matching_key(h
     entity.async_schedule_update_ha_state.assert_not_called()
     entity._on_connectivity("DEV1", False)
     entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    bare = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    await bare.async_will_remove_from_hass()
+    assert bare._unsubscribe_connectivity is None

--- a/tests/test_platform_button.py
+++ b/tests/test_platform_button.py
@@ -99,6 +99,10 @@ async def test_button_connectivity_listener_lifecycle(hass: HomeAssistant) -> No
     await entity.async_will_remove_from_hass()
     assert entity._unsubscribe_connectivity is None
 
+    bare = BragerActionButton(entry=entry, runtime=runtime, descriptor=descriptor)
+    await bare.async_will_remove_from_hass()
+    assert bare._unsubscribe_connectivity is None
+
 
 @pytest.mark.asyncio
 async def test_button_press_defaults_value_when_rule_missing(hass: HomeAssistant) -> None:

--- a/tests/test_platform_button.py
+++ b/tests/test_platform_button.py
@@ -74,6 +74,33 @@ async def test_button_press_dispatches_first_rule_value(hass: HomeAssistant) -> 
 
 
 @pytest.mark.asyncio
+async def test_button_connectivity_listener_lifecycle(hass: HomeAssistant) -> None:
+    from unittest.mock import MagicMock
+
+    runtime, *_rest = make_runtime()
+    descriptor = button_descriptor(symbol="RESET_ALARM")
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerActionButton(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "button.test_reset"
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+    assert callable(entity._unsubscribe_connectivity)
+    await entity.async_update()
+    assert entity.available is True
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_connectivity("OTHER", False)
+    entity.async_schedule_update_ha_state.assert_not_called()
+    entity._on_connectivity("DEV1", False)
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_connectivity is None
+
+
+@pytest.mark.asyncio
 async def test_button_press_defaults_value_when_rule_missing(hass: HomeAssistant) -> None:
     runtime, api, _gateway, _store = make_runtime()
     descriptor = button_descriptor(command_rules=[{"command": "PING"}])

--- a/tests/test_platform_number.py
+++ b/tests/test_platform_number.py
@@ -130,3 +130,9 @@ async def test_number_runtime_update_schedules_refresh_for_matching_key(hass: Ho
     entity.async_schedule_update_ha_state.reset_mock()
     entity._on_runtime_update(FakeParamUpdate(pool="P1", chan="s", idx=9))
     entity.async_schedule_update_ha_state.assert_not_called()
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_connectivity("OTHER", False)
+    entity.async_schedule_update_ha_state.assert_not_called()
+    entity._on_connectivity("DEV1", False)
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)

--- a/tests/test_platform_number.py
+++ b/tests/test_platform_number.py
@@ -136,3 +136,7 @@ async def test_number_runtime_update_schedules_refresh_for_matching_key(hass: Ho
     entity.async_schedule_update_ha_state.assert_not_called()
     entity._on_connectivity("DEV1", False)
     entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    bare = BragerSymbolNumber(entry=entry, runtime=runtime, descriptor=descriptor)
+    await bare.async_will_remove_from_hass()
+    assert bare._unsubscribe_connectivity is None

--- a/tests/test_platform_select.py
+++ b/tests/test_platform_select.py
@@ -115,3 +115,9 @@ async def test_select_runtime_update_schedules_refresh_for_matching_key(hass: Ho
     entity.async_schedule_update_ha_state.reset_mock()
     entity._on_runtime_update(FakeParamUpdate(pool="P1", chan="s", idx=9))
     entity.async_schedule_update_ha_state.assert_not_called()
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_connectivity("OTHER", False)
+    entity.async_schedule_update_ha_state.assert_not_called()
+    entity._on_connectivity("DEV1", False)
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)

--- a/tests/test_platform_select.py
+++ b/tests/test_platform_select.py
@@ -121,3 +121,7 @@ async def test_select_runtime_update_schedules_refresh_for_matching_key(hass: Ho
     entity.async_schedule_update_ha_state.assert_not_called()
     entity._on_connectivity("DEV1", False)
     entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    bare = BragerSymbolSelect(entry=entry, runtime=runtime, descriptor=descriptor)
+    await bare.async_will_remove_from_hass()
+    assert bare._unsubscribe_connectivity is None

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -196,3 +196,15 @@ async def test_sensor_runtime_update_schedules_refresh_for_matching_key(hass: Ho
     entity.async_schedule_update_ha_state.reset_mock()
     entity._on_runtime_update(FakeParamUpdate(pool="P9", chan="v", idx=1))
     entity.async_schedule_update_ha_state.assert_not_called()
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_connectivity("OTHER", False)
+    entity.async_schedule_update_ha_state.assert_not_called()
+    entity._on_connectivity("DEV1", False, online_changed=False)
+    entity.async_schedule_update_ha_state.assert_not_called()
+    entity._on_connectivity("DEV1", False)
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    bare = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    await bare.async_will_remove_from_hass()
+    assert bare._unsubscribe_connectivity is None

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -105,6 +105,7 @@ async def test_sensor_update_uses_status_resolver_for_status_symbols(hass: HomeA
     runtime = SimpleNamespace(
         store=store,
         add_listener=lambda _cb: lambda: None,
+        module_online=lambda _devid: None,
         async_resolve_status_label=resolve_status,
     )
     descriptor = sensor_descriptor(symbol="STATUS_BOILER", pool="P5", chan="s", idx=5, unit=None)
@@ -126,6 +127,7 @@ async def test_sensor_update_uses_dynamic_unit_resolver(hass: HomeAssistant) -> 
     runtime = SimpleNamespace(
         store=store,
         add_listener=lambda _cb: lambda: None,
+        module_online=lambda _devid: None,
         async_resolve_symbol_with_unit=resolve_with_unit,
     )
     descriptor = sensor_descriptor(

--- a/tests/test_platform_switch.py
+++ b/tests/test_platform_switch.py
@@ -166,3 +166,7 @@ async def test_switch_runtime_update_schedules_refresh_for_matching_key(hass: Ho
     entity.async_schedule_update_ha_state.assert_not_called()
     entity._on_connectivity("DEV1", False)
     entity.async_schedule_update_ha_state.assert_called_once_with(True)
+
+    bare = BragerSymbolSwitch(entry=entry, runtime=runtime, descriptor=descriptor)
+    await bare.async_will_remove_from_hass()
+    assert bare._unsubscribe_connectivity is None

--- a/tests/test_platform_switch.py
+++ b/tests/test_platform_switch.py
@@ -160,3 +160,9 @@ async def test_switch_runtime_update_schedules_refresh_for_matching_key(hass: Ho
     entity.async_schedule_update_ha_state.reset_mock()
     entity._on_runtime_update(FakeParamUpdate(pool="P9", chan="v", idx=1))
     entity.async_schedule_update_ha_state.assert_not_called()
+
+    entity.async_schedule_update_ha_state.reset_mock()
+    entity._on_connectivity("OTHER", False)
+    entity.async_schedule_update_ha_state.assert_not_called()
+    entity._on_connectivity("DEV1", False)
+    entity.async_schedule_update_ha_state.assert_called_once_with(True)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses #154 on top of py-bragerone **2026.8.7** (#312):

- SPA i18n labels via `connection_descriptors`
- Child device `{devid}:module.connection` + `via_device`
- Availability gated on SPA `connectedAt`; writes refused when offline
- Connectivity listener arity via `inspect.signature` (no bare TypeError→2-arg retry)
- Diagnostics skips blank devids
- Pin `py-bragerone==2026.8.7`; HACS manifest version **2026.8.4**
- `BOOTSTRAP_VERSION = 7`

## Test plan

```bash
uv run pytest tests/test_module_connectivity.py tests/test_diagnostics.py -q
uv run --group dev mypy
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

