### PR TITLE
docs: HACS beta/rc before stable release checklist (#175)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -50,16 +50,40 @@ Issue and PR templates live under `.github/ISSUE_TEMPLATE/` and `.github/PULL_RE
 
 ### Publishing Releases
 
-The project publishes releases through GitHub Actions:
+Do **not** cut a stable HACS tag until the same version has been smoke-tested as a HACS **pre-release** on a live Home Assistant install. Tooling already supports this (`scripts/release.sh` + `.github/workflows/release.yml`); skipping the beta/rc step is a process failure, not a tooling gap.
+
+#### Release checklist (maintainers)
+
+1. Land the release candidates on `main` (CI green).
+2. Tag a **pre-release** (prefer `beta`, then `rc` if needed):
+
+   ```bash
+   ./scripts/release.sh 2026.x.y beta   # pushes v2026.x.yb1 → GitHub pre-release
+   ```
+
+3. In HACS, enable **Show beta versions** (or equivalent) and install/update the pre-release on a **live** HA instance.
+4. Smoke-test at least: config flow / reconfigure, entity count and naming, a few writes, reconnect / module connectivity.
+5. Fix blockers on `main` and retag another `beta`/`rc` if needed.
+6. Only then cut **stable**:
+
+   ```bash
+   ./scripts/release.sh 2026.x.y stable # pushes v2026.x.y → GitHub release (HACS default)
+   ```
+
+Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release`) sets `prerelease=true` when the tag matches `(a|b|rc)[0-9]+$` (`v2026.x.ya1`, `…b1`, `…rc1`). HACS surfaces those as opt-in pre-releases; unsuffixed `v2026.x.y` is the stable channel.
+
+#### Commands
 
 ```bash
-# Create stable release
-./scripts/release.sh 2025.1.0
+# Pre-release (alpha / beta / rc) — always before the matching stable
+./scripts/release.sh 2026.x.y beta
 
-# Create pre-release
-./scripts/release.sh 2025.1.0 alpha  # or beta, rc
+# Stable — only after live smoke on the pre-release
+./scripts/release.sh 2026.x.y
+# or explicitly:
+./scripts/release.sh 2026.x.y stable
 ```
 
-Releases are automatically built and published on GitHub:
-- **GitHub Releases** for stable tags (`v2025.1.0`)
-- **GitHub pre-releases** for pre-release tags (`v2025.1.0a1`, `v2025.1.0b1`, `v2025.1.0rc1`)
+GitHub Actions then builds the package and publishes:
+- **GitHub Releases** for stable tags (`v2026.x.y`)
+- **GitHub pre-releases** for suffixed tags (`v2026.x.ya1`, `v2026.x.yb1`, `v2026.x.yrc1`)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ This custom component provides integration between Home Assistant and the Brager
 3. Restart Home Assistant
 4. Configure the integration
 
+Testers: enable HACS **Show beta versions** to install `alpha` / `beta` / `rc` tags before they hit the default (stable) channel. Maintainers always smoke-test a pre-release on a live HA instance before cutting the matching stable tag — see [DEVELOPMENT.md](DEVELOPMENT.md#publishing-releases).
+
 ## Configuration
 
 The integration can be configured through the Home Assistant UI. You will need:

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -3,11 +3,16 @@
 # Release script for ha-bragerone
 # Usage: ./scripts/release.sh [version] [type]
 #
+# Process (do not skip): beta/rc pre-release → live HACS smoke → stable.
+# Full checklist: DEVELOPMENT.md → "Publishing Releases".
+# Tag suffix drives GitHub/HACS channel via .github/workflows/release.yml
+# (tags matching (a|b|rc)[0-9]+$ are marked prerelease=true).
+#
 # Examples:
-#   ./scripts/release.sh 2025.1.0        # Stable release
-#   ./scripts/release.sh 2025.1.0 alpha  # Alpha release (2025.1.0a1)
-#   ./scripts/release.sh 2025.1.0 beta   # Beta release (2025.1.0b1)
-#   ./scripts/release.sh 2025.1.0 rc     # Release candidate (2025.1.0rc1)
+#   ./scripts/release.sh 2026.8.5 beta   # Pre-release first (v2026.8.5b1)
+#   ./scripts/release.sh 2026.8.5 rc     # Optional RC after beta
+#   ./scripts/release.sh 2026.8.5        # Stable only after live smoke
+#   ./scripts/release.sh 2026.8.5 alpha  # Early alpha if needed
 
 set -e
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes #175 — document the mandatory **pre-release → live HACS smoke → stable** process so we do not ship another stable tag (like 2026.8.4) without a beta/rc cycle first.

Tooling already exists (`scripts/release.sh`, `release.yml` tag-suffix → `prerelease=true`); this PR is process documentation only.

## Type of change

- [x] Docs only

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] Docs / translations updated when user-facing behavior changes (`README.md`, `DEVELOPMENT.md`, `scripts/release.sh` header)
- [x] Version pins unchanged
- [x] No secrets committed

## Test plan

Docs-only; CI gates still run.

```bash
uv run poe lint
uv run poe test
```

## Notes for reviewers

- `DEVELOPMENT.md`: full maintainer checklist + why tag suffixes matter for HACS.
- `README.md`: short pointer for HACS testers (`Show beta versions`).
- `scripts/release.sh`: header cross-links the checklist.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

