### PR TITLE
chore: prepare 2026.8.5rc1 release candidate

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -58,7 +58,7 @@ Do **not** cut a stable HACS tag until the same version has been smoke-tested as
 2. Tag a **pre-release** (prefer `beta`, then `rc` if needed):
 
    ```bash
-   ./scripts/release.sh 2026.x.y beta   # pushes v2026.x.yb1 → GitHub pre-release
+   ./scripts/release.sh 2026.x.y beta   # pushes 2026.x.yb1 → GitHub pre-release
    ```
 
 3. In HACS, enable **Show beta versions** (or equivalent) and install/update the pre-release on a **live** HA instance.
@@ -67,10 +67,12 @@ Do **not** cut a stable HACS tag until the same version has been smoke-tested as
 6. Only then cut **stable**:
 
    ```bash
-   ./scripts/release.sh 2026.x.y stable # pushes v2026.x.y → GitHub release (HACS default)
+   ./scripts/release.sh 2026.x.y stable # pushes 2026.x.y → GitHub release (HACS default)
    ```
 
-Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release`) sets `prerelease=true` when the tag matches `(a|b|rc)[0-9]+$` (`v2026.x.ya1`, `…b1`, `…rc1`). HACS surfaces those as opt-in pre-releases; unsuffixed `v2026.x.y` is the stable channel.
+Bump `custom_components/habragerone/manifest.json` `"version"` to the **exact** tag string before tagging (the HACS zip embeds that file).
+
+Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release`) sets `prerelease=true` when the tag matches `(a|b|rc)[0-9]+$` (`2026.x.ya1`, `…b1`, `…rc1`). HACS surfaces those as opt-in pre-releases; unsuffixed `2026.x.y` is the stable channel. Tags do **not** use a `v` prefix (match existing releases such as `2026.8.4`).
 
 #### Commands
 
@@ -85,5 +87,5 @@ Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release
 ```
 
 GitHub Actions then builds the package and publishes:
-- **GitHub Releases** for stable tags (`v2026.x.y`)
-- **GitHub pre-releases** for suffixed tags (`v2026.x.ya1`, `v2026.x.yb1`, `v2026.x.yrc1`)
+- **GitHub Releases** for stable tags (`2026.x.y`)
+- **GitHub pre-releases** for suffixed tags (`2026.x.ya1`, `2026.x.yb1`, `2026.x.yrc1`)

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -19,5 +19,5 @@
     "py-bragerone==2026.8.7",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.4"
+  "version": "2026.8.5rc1"
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -45,10 +45,10 @@ Main development workflow helper with various commands:
 Release helper that creates and pushes version tags used by the GitHub release workflow.
 
 ```bash
-# Stable release tag (v2025.1.0)
+# Stable release tag (2025.1.0)
 ./scripts/release.sh 2025.1.0
 
-# Pre-release tags (v2025.1.0a1 / v2025.1.0b1 / v2025.1.0rc1)
+# Pre-release tags (2025.1.0a1 / 2025.1.0b1 / 2025.1.0rc1)
 ./scripts/release.sh 2025.1.0 alpha
 ./scripts/release.sh 2025.1.0 beta
 ./scripts/release.sh 2025.1.0 rc

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -5,13 +5,17 @@
 #
 # Process (do not skip): beta/rc pre-release → live HACS smoke → stable.
 # Full checklist: DEVELOPMENT.md → "Publishing Releases".
+# Tags match historical CalVer without a "v" prefix (e.g. 2026.8.5rc1).
 # Tag suffix drives GitHub/HACS channel via .github/workflows/release.yml
 # (tags matching (a|b|rc)[0-9]+$ are marked prerelease=true).
 #
+# Before tagging a pre-release/stable, bump custom_components/habragerone/manifest.json
+# "version" to the same string as the tag (HACS zip embeds that file).
+#
 # Examples:
-#   ./scripts/release.sh 2026.8.5 beta   # Pre-release first (v2026.8.5b1)
-#   ./scripts/release.sh 2026.8.5 rc     # Optional RC after beta
-#   ./scripts/release.sh 2026.8.5        # Stable only after live smoke
+#   ./scripts/release.sh 2026.8.5 beta   # Pre-release first (2026.8.5b1)
+#   ./scripts/release.sh 2026.8.5 rc     # Optional RC after beta (2026.8.5rc1)
+#   ./scripts/release.sh 2026.8.5        # Stable only after live smoke (2026.8.5)
 #   ./scripts/release.sh 2026.8.5 alpha  # Early alpha if needed
 
 set -e
@@ -58,34 +62,34 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
-# Construct tag name based on release type
+# Construct tag name based on release type (no "v" prefix — matches existing tags)
 case $RELEASE_TYPE in
     stable)
-        TAG="v$VERSION"
+        TAG="$VERSION"
         ;;
     alpha)
         # Find next alpha number
         ALPHA_NUM=1
-        while git tag | grep -q "v${VERSION}a${ALPHA_NUM}"; do
+        while git tag | grep -q "${VERSION}a${ALPHA_NUM}"; do
             ((ALPHA_NUM++))
         done
-        TAG="v${VERSION}a${ALPHA_NUM}"
+        TAG="${VERSION}a${ALPHA_NUM}"
         ;;
     beta)
         # Find next beta number
         BETA_NUM=1
-        while git tag | grep -q "v${VERSION}b${BETA_NUM}"; do
+        while git tag | grep -q "${VERSION}b${BETA_NUM}"; do
             ((BETA_NUM++))
         done
-        TAG="v${VERSION}b${BETA_NUM}"
+        TAG="${VERSION}b${BETA_NUM}"
         ;;
     rc)
         # Find next rc number
         RC_NUM=1
-        while git tag | grep -q "v${VERSION}rc${RC_NUM}"; do
+        while git tag | grep -q "${VERSION}rc${RC_NUM}"; do
             ((RC_NUM++))
         done
-        TAG="v${VERSION}rc${RC_NUM}"
+        TAG="${VERSION}rc${RC_NUM}"
         ;;
     *)
         log_error "Invalid release type: $RELEASE_TYPE"
@@ -101,6 +105,17 @@ if git tag | grep -q "^$TAG$"; then
 fi
 
 log_info "Preparing release $TAG ($RELEASE_TYPE)"
+
+# HACS zip embeds manifest.json — version must match the tag.
+MANIFEST_VERSION="$(python3 -c "import json; print(json.load(open(\"custom_components/habragerone/manifest.json\"))[\"version\"])" 2>/dev/null || true)"
+if [ -z "$MANIFEST_VERSION" ]; then
+    log_error "Could not read custom_components/habragerone/manifest.json version"
+    exit 1
+fi
+if [ "$MANIFEST_VERSION" != "$TAG" ]; then
+    log_error "manifest.json version ($MANIFEST_VERSION) != tag ($TAG). Bump manifest first."
+    exit 1
+fi
 
 # Show what will be published
 if [ "$RELEASE_TYPE" = "stable" ]; then

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -62,6 +62,11 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+# Exact tag existence (avoid grep regex false positives on CalVer dots).
+tag_exists() {
+    git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1
+}
+
 # Construct tag name based on release type (no "v" prefix — matches existing tags)
 case $RELEASE_TYPE in
     stable)
@@ -70,7 +75,7 @@ case $RELEASE_TYPE in
     alpha)
         # Find next alpha number
         ALPHA_NUM=1
-        while git tag | grep -q "${VERSION}a${ALPHA_NUM}"; do
+        while tag_exists "${VERSION}a${ALPHA_NUM}"; do
             ((ALPHA_NUM++))
         done
         TAG="${VERSION}a${ALPHA_NUM}"
@@ -78,7 +83,7 @@ case $RELEASE_TYPE in
     beta)
         # Find next beta number
         BETA_NUM=1
-        while git tag | grep -q "${VERSION}b${BETA_NUM}"; do
+        while tag_exists "${VERSION}b${BETA_NUM}"; do
             ((BETA_NUM++))
         done
         TAG="${VERSION}b${BETA_NUM}"
@@ -86,7 +91,7 @@ case $RELEASE_TYPE in
     rc)
         # Find next rc number
         RC_NUM=1
-        while git tag | grep -q "${VERSION}rc${RC_NUM}"; do
+        while tag_exists "${VERSION}rc${RC_NUM}"; do
             ((RC_NUM++))
         done
         TAG="${VERSION}rc${RC_NUM}"
@@ -99,7 +104,7 @@ case $RELEASE_TYPE in
 esac
 
 # Check if tag already exists
-if git tag | grep -q "^$TAG$"; then
+if tag_exists "$TAG"; then
     log_error "Tag $TAG already exists"
     exit 1
 fi
@@ -107,9 +112,11 @@ fi
 log_info "Preparing release $TAG ($RELEASE_TYPE)"
 
 # HACS zip embeds manifest.json — version must match the tag.
-MANIFEST_VERSION="$(python3 -c "import json; print(json.load(open(\"custom_components/habragerone/manifest.json\"))[\"version\"])" 2>/dev/null || true)"
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+MANIFEST_PATH="$REPO_ROOT/custom_components/habragerone/manifest.json"
+MANIFEST_VERSION="$(python3 -c "import json; print(json.load(open(\"$MANIFEST_PATH\"))[\"version\"])" 2>/dev/null || true)"
 if [ -z "$MANIFEST_VERSION" ]; then
-    log_error "Could not read custom_components/habragerone/manifest.json version"
+    log_error "Could not read $MANIFEST_PATH version"
     exit 1
 fi
 if [ "$MANIFEST_VERSION" != "$TAG" ]; then


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Prepare **2026.8.5rc1** pre-release:

- Bump `manifest.json` version to `2026.8.5rc1` (HACS zip embeds this).
- Align `scripts/release.sh` / docs with real tag format (**no `v` prefix**, matching `2026.8.4`).
- Fail release if manifest version ≠ tag.

After merge, tag with `./scripts/release.sh 2026.8.5 rc` to publish the GitHub/HACS pre-release.

## Type of change

- [x] Docs only / tooling / chore

## Checklist

- [x] English only in code, comments, and docs
- [x] Version pins unchanged (py-bragerone still 2026.8.7)
- [x] No secrets committed

## Test plan

```bash
uv run poe lint
uv run poe test
# after merge:
./scripts/release.sh 2026.8.5 rc
```

## Notes for reviewers

Includes #177 naming, #176 parent menu grouping, #175 release checklist docs, #178 connectivity docs since 2026.8.4.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

