### PR TITLE
fix: group-by-menu leading dashes and Polish status on/off tokens

### DIFF
--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -109,7 +109,7 @@ class BragerStatusBinarySensor(BinarySensorEntity):
         self._symbol = str(descriptor.get("symbol") or "")
         self._devid = str(descriptor.get("devid") or "")
 
-        label = descriptor_display_name(descriptor)
+        label = descriptor_display_name(descriptor, grouping=device_grouping_mode(entry))
         self._attr_name = label
         self._attr_suggested_object_id = descriptor_suggested_object_id(descriptor)
         self._attr_unique_id = f"{entry.entry_id}_{self._devid}_{self._symbol}_binary".lower().replace(" ", "_")
@@ -289,8 +289,38 @@ def _to_bool(value: Any) -> bool:
         return bool(int(value))
     if isinstance(value, str):
         norm = value.strip().casefold()
-        if norm in {"1", "true", "on", "enabled", "yes"}:
+        if norm in {
+            "1",
+            "true",
+            "on",
+            "enabled",
+            "yes",
+            "tak",
+            "włączony",
+            "wlaczony",
+            "włączone",
+            "wlaczone",
+            "włączono",
+            "wlaczono",
+            "załączony",
+            "zalaczony",
+            "załączone",
+            "zalaczone",
+        }:
             return True
-        if norm in {"0", "false", "off", "disabled", "no"}:
+        if norm in {
+            "0",
+            "false",
+            "off",
+            "disabled",
+            "no",
+            "nie",
+            "wyłączony",
+            "wylaczony",
+            "wyłączone",
+            "wylaczone",
+            "wyłączono",
+            "wylaczono",
+        }:
             return False
     return False

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -306,6 +306,8 @@ def _to_bool(value: Any) -> bool:
             "zalaczony",
             "załączone",
             "zalaczone",
+            "załączono",
+            "zalaczono",
         }:
             return True
         if norm in {

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -583,8 +583,8 @@ def _menu_keys_by_panel_path(
     panel groups with a ``panel_path`` but never in the HA menu-route walk, so
     they lack route meta. Inherit the ``menu_key`` of any other symbol that
     shares the same ``panel_path`` (or the same root segment) and does have
-    route meta — so group-by-menu keeps them under the Podajnik / Dmuchawa
-    device instead of the bare module.
+    route meta — so group-by-menu keeps them under the matching menu child
+    device (e.g. feeder / fan panels) instead of the bare module.
     """
     by_exact: dict[str, str] = {}
     by_group: dict[str, str] = {}

--- a/custom_components/habragerone/button.py
+++ b/custom_components/habragerone/button.py
@@ -55,7 +55,7 @@ class BragerActionButton(ButtonEntity):
         self._symbol = str(descriptor.get("symbol") or "")
         self._devid = str(descriptor.get("devid") or "")
 
-        label = descriptor_display_name(descriptor)
+        label = descriptor_display_name(descriptor, grouping=device_grouping_mode(entry))
         self._attr_name = label
         self._attr_suggested_object_id = descriptor_suggested_object_id(descriptor)
         self._attr_unique_id = f"{entry.entry_id}_{self._devid}_{self._symbol}_button".lower().replace(" ", "_")

--- a/custom_components/habragerone/entity_common.py
+++ b/custom_components/habragerone/entity_common.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Mapping
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -29,7 +30,11 @@ from .runtime import BragerRuntime
 
 def device_grouping_mode(entry: ConfigEntry) -> str:
     """Return the configured device grouping mode for *entry* (flat default)."""
-    raw = entry.options.get(CONF_DEVICE_GROUPING, entry.data.get(CONF_DEVICE_GROUPING, DEFAULT_DEVICE_GROUPING))
+    options = getattr(entry, "options", None)
+    data = getattr(entry, "data", None)
+    options_map = options if isinstance(options, Mapping) else {}
+    data_map = data if isinstance(data, Mapping) else {}
+    raw = options_map.get(CONF_DEVICE_GROUPING, data_map.get(CONF_DEVICE_GROUPING, DEFAULT_DEVICE_GROUPING))
     mode = str(raw or "").strip().lower()
     if mode in DEVICE_GROUPING_MODES:
         return mode
@@ -252,19 +257,32 @@ def descriptor_raw_to_label(descriptor: dict[str, Any]) -> dict[str, str]:
     return {str(key): str(value) for key, value in raw_to_label.items()}
 
 
-def descriptor_display_name(descriptor: dict[str, Any]) -> str:
-    """Build entity display label as ``LeafPanel - Label`` when available.
+def descriptor_display_name(
+    descriptor: dict[str, Any],
+    *,
+    grouping: str = DEFAULT_DEVICE_GROUPING,
+) -> str:
+    """Build entity display label as ``LeafPanel - Label`` when useful.
 
     Uses the menu leaf (``menu_title`` / last ``panel_path`` segment), not the
     full parent-to-child chain — the parent segment belongs on the HA device once
     group-by-menu uses parent menus (#176). Empty or slash-only paths yield the
     bare label (no leading dash).
+
+    In group-by-menu mode, when the leaf prefix equals ``menu_group_title`` (the
+    child device name), return the bare label so HA does not show a redundant
+    ``Device - …`` name that renders as a leading dash under that device.
     """
     label = str(descriptor.get("label") or descriptor.get("symbol") or "").strip()
     prefix = _display_name_panel_prefix(descriptor)
-    if prefix:
-        return f"{prefix} - {label}"
-    return label
+    if not prefix:
+        return label
+    mode = str(grouping or "").strip().lower()
+    if mode == DEVICE_GROUPING_BY_MENU:
+        group = str(descriptor.get("menu_group_title") or "").strip()
+        if group and prefix == group:
+            return label
+    return f"{prefix} - {label}"
 
 
 def descriptor_suggested_object_id(descriptor: dict[str, Any]) -> str:

--- a/custom_components/habragerone/number.py
+++ b/custom_components/habragerone/number.py
@@ -60,7 +60,7 @@ class BragerSymbolNumber(NumberEntity):
         self._symbol = str(descriptor.get("symbol") or "")
         self._devid = str(descriptor.get("devid") or "")
 
-        label = descriptor_display_name(descriptor)
+        label = descriptor_display_name(descriptor, grouping=device_grouping_mode(entry))
         self._attr_name = label
         self._attr_suggested_object_id = descriptor_suggested_object_id(descriptor)
         self._attr_unique_id = f"{entry.entry_id}_{self._devid}_{self._symbol}_number".lower().replace(" ", "_")

--- a/custom_components/habragerone/select.py
+++ b/custom_components/habragerone/select.py
@@ -61,7 +61,7 @@ class BragerSymbolSelect(SelectEntity):
         self._symbol = str(descriptor.get("symbol") or "")
         self._devid = str(descriptor.get("devid") or "")
 
-        label = descriptor_display_name(descriptor)
+        label = descriptor_display_name(descriptor, grouping=device_grouping_mode(entry))
         self._attr_name = label
         self._attr_suggested_object_id = descriptor_suggested_object_id(descriptor)
         self._attr_unique_id = f"{entry.entry_id}_{self._devid}_{self._symbol}_select".lower().replace(" ", "_")

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -71,7 +71,7 @@ class BragerSymbolSensor(SensorEntity):
 
         symbol = str(descriptor.get("symbol", ""))
         devid = str(descriptor.get("devid", ""))
-        label = descriptor_display_name(descriptor)
+        label = descriptor_display_name(descriptor, grouping=device_grouping_mode(entry))
 
         self._symbol = symbol
         self._devid = devid

--- a/custom_components/habragerone/status_rules.py
+++ b/custom_components/habragerone/status_rules.py
@@ -43,11 +43,53 @@ def resolve_rule_bool(
     if not isinstance(display, str):
         return None
     norm = display.strip().casefold()
-    if norm in {"on", "on manual", "enabled", "true", "yes"}:
+    if norm in _BOOL_TRUE_TOKENS:
         return True
-    if norm in {"off", "off manual", "disabled", "false", "no"}:
+    if norm in _BOOL_FALSE_TOKENS:
         return False
     return None
+
+
+_BOOL_TRUE_TOKENS = frozenset(
+    {
+        "on",
+        "on manual",
+        "enabled",
+        "true",
+        "yes",
+        "1",
+        "tak",
+        "włączony",
+        "wlaczony",
+        "włączone",
+        "wlaczone",
+        "włączono",
+        "wlaczono",
+        "załączony",
+        "zalaczony",
+        "załączone",
+        "zalaczone",
+        "załączono",
+        "zalaczono",
+    }
+)
+_BOOL_FALSE_TOKENS = frozenset(
+    {
+        "off",
+        "off manual",
+        "disabled",
+        "false",
+        "no",
+        "0",
+        "nie",
+        "wyłączony",
+        "wylaczony",
+        "wyłączone",
+        "wylaczone",
+        "wyłączono",
+        "wylaczono",
+    }
+)
 
 
 def rule_matches(rule: Mapping[str, Any], *, flat_values: Mapping[str, Any], default_actual: Any) -> bool:

--- a/custom_components/habragerone/switch.py
+++ b/custom_components/habragerone/switch.py
@@ -58,7 +58,7 @@ class BragerSymbolSwitch(SwitchEntity):
         self._symbol = str(descriptor.get("symbol") or "")
         self._devid = str(descriptor.get("devid") or "")
 
-        label = descriptor_display_name(descriptor)
+        label = descriptor_display_name(descriptor, grouping=device_grouping_mode(entry))
         self._attr_name = label
         self._attr_suggested_object_id = descriptor_suggested_object_id(descriptor)
         self._attr_unique_id = f"{entry.entry_id}_{self._devid}_{self._symbol}_switch".lower().replace(" ", "_")

--- a/tests/test_entity_naming.py
+++ b/tests/test_entity_naming.py
@@ -64,6 +64,31 @@ def test_descriptor_display_name_prefers_menu_title_over_path() -> None:
     assert descriptor_display_name(descriptor) == "Zawór 1 - Status"
 
 
+def test_descriptor_display_name_omits_prefix_when_it_matches_group_device() -> None:
+    from custom_components.habragerone.const import DEVICE_GROUPING_BY_MENU, DEVICE_GROUPING_FLAT
+
+    descriptor = {
+        "panel_path": "Dmuchawa",
+        "menu_title": "Dmuchawa",
+        "menu_group_title": "Dmuchawa",
+        "label": "Wydajność dmuchawy",
+    }
+    assert descriptor_display_name(descriptor, grouping=DEVICE_GROUPING_BY_MENU) == "Wydajność dmuchawy"
+    assert descriptor_display_name(descriptor, grouping=DEVICE_GROUPING_FLAT) == "Dmuchawa - Wydajność dmuchawy"
+
+
+def test_descriptor_display_name_keeps_leaf_under_parent_group_device() -> None:
+    from custom_components.habragerone.const import DEVICE_GROUPING_BY_MENU
+
+    descriptor = {
+        "panel_path": "Menu termostatów/Zawór 1",
+        "menu_title": "Zawór 1",
+        "menu_group_title": "Menu termostatów",
+        "label": "Status",
+    }
+    assert descriptor_display_name(descriptor, grouping=DEVICE_GROUPING_BY_MENU) == "Zawór 1 - Status"
+
+
 def test_descriptor_suggested_object_id_uses_devid_and_symbol() -> None:
     descriptor = {
         "devid": "MODABC123",

--- a/tests/test_status_rules.py
+++ b/tests/test_status_rules.py
@@ -64,6 +64,13 @@ def test_resolve_rule_bool_maps_on_off_tokens() -> None:
     descriptor["mapping"]["command_rules"][0]["value"] = "maybe"
     assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=1) is None
 
+    descriptor["mapping"]["command_rules"][0]["value"] = "Włączono"
+    assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=1) is True
+    descriptor["mapping"]["command_rules"][0]["value"] = "Wyłączony"
+    assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=1) is False
+    descriptor["mapping"]["command_rules"][0]["value"] = "Załączony"
+    assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=1) is True
+
 
 def test_resolve_rule_bool_returns_none_for_non_string_display() -> None:
     descriptor = {"mapping": {"command_rules": [{"conditions": [], "value": 42}]}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

RC smoke follow-ups after #184:

1. **Leading dashes** under group-by-menu devices (e.g. Dmuchawa): when leaf prefix equals `menu_group_title`, use the bare label so HA does not render `Device - Label` as a leading dash under that device.
2. **Circulation pump status**: recognize Polish on/off tokens (`włączony` / `wyłączony` / `załączony`, …) in `resolve_rule_bool` and `_to_bool` so status rules do not fall through to raw bitmask coercion.
3. Docstring English-only leftover from #184 Copilot note.

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] English only; Google-style docstrings
- [x] `uv run poe lint` / `typecheck` / `test` pass locally
- [x] Tests added / updated
- [x] No secrets committed

## Test plan

```bash
uv run poe lint
uv run poe typecheck
uv run poe test
```

On live HA (group-by-menu): reload, confirm no leading `-` under single-segment menus; check Menu cyrkulacji pump status vs app.

## Notes for reviewers

Still deferred: missing **Strefy czasowe** menu (heavier catalog/filter topic).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

