### PR TITLE
fix: resolve STATUS binary diodes via SPA status label path

### DIFF
--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -31,7 +31,7 @@ from .entity_common import (
     record_platform_entity_stats,
 )
 from .runtime import BragerRuntime
-from .status_rules import coerce_status_bool, resolve_entity_bool
+from .status_rules import coerce_status_bool, resolve_entity_bool, status_label_to_bool
 
 
 def _descriptor_labels(descriptor: dict[str, Any]) -> dict[str, Any]:
@@ -144,7 +144,7 @@ class BragerStatusBinarySensor(BinarySensorEntity):
             self._unsubscribe_connectivity = None
 
     async def async_update(self) -> None:
-        """Refresh state from ParamStore value."""
+        """Refresh state from ParamStore / SPA status resolver."""
         raw_value = descriptor_current_raw_value(self._runtime.store, self._descriptor)
         self._attr_available = entity_is_available(
             self._runtime,
@@ -153,6 +153,16 @@ class BragerStatusBinarySensor(BinarySensorEntity):
         )
         if raw_value is None:
             return
+
+        # STATUS_* diodes (e.g. PumpState) must follow the same ComputedValueEvaluator
+        # path as text sensors — cached command_rules alone miss ``value:`` maps and
+        # dual-bit PumpState inputs (bit 1 ON/OFF + bit 3 manual).
+        if self._symbol.startswith("STATUS_"):
+            resolved = await self._runtime.async_resolve_status_label(self._symbol)
+            resolved_bool = status_label_to_bool(resolved)
+            if resolved_bool is not None:
+                self._attr_is_on = resolved_bool
+                return
 
         self._attr_is_on = resolve_entity_bool(
             descriptor=self._descriptor,

--- a/custom_components/habragerone/status_rules.py
+++ b/custom_components/habragerone/status_rules.py
@@ -44,15 +44,46 @@ def resolve_rule_bool(
 
 
 def status_label_to_bool(value: Any) -> bool | None:
-    """Map a STATUS display label/token to on/off, or None when unknown."""
+    """Map a STATUS display label/token to on/off, or None when unknown.
+
+    Accepts SPA enum tags (``e.ON_MANUAL``), English diode tokens (``On Manual``),
+    and translated labels including parenthetical manual notes
+    (``Włączone (ręcznie)`` / ``Wyłączony (ręcznie)``).
+    """
     if not isinstance(value, str):
         return None
-    norm = value.strip().casefold()
+    norm = _normalize_status_label_token(value)
+    if not norm:
+        return None
     if norm in _BOOL_TRUE_TOKENS:
         return True
     if norm in _BOOL_FALSE_TOKENS:
         return False
+    # Prefix fallback covers ON_MANUAL / OFF_MANUAL after underscore→space.
+    if norm.startswith("on"):
+        return True
+    if norm.startswith("off"):
+        return False
     return None
+
+
+def _normalize_status_label_token(value: str) -> str:
+    """Normalize STATUS labels/tokens for boolean mapping."""
+    norm = value.strip().casefold()
+    if not norm:
+        return ""
+    # Drop manual/context notes: "wyłączony (ręcznie)" → "wyłączony".
+    if "(" in norm:
+        norm = norm.split("(", 1)[0].rstrip()
+    # Strip enum/path prefixes: "e.on_manual", "diodestate['off']" leftovers.
+    if "." in norm:
+        norm = norm.rsplit(".", 1)[-1]
+    if "'" in norm:
+        # DiodeState['OFF'] → off
+        parts = [part for part in norm.replace("]", "").split("'") if part and part not in {"[", " "}]
+        if parts:
+            norm = parts[-1]
+    return norm.replace("_", " ").strip()
 
 
 def resolve_entity_bool(

--- a/custom_components/habragerone/status_rules.py
+++ b/custom_components/habragerone/status_rules.py
@@ -40,9 +40,14 @@ def resolve_rule_bool(
 ) -> bool | None:
     """Resolve rule output to boolean for binary-state entities."""
     display = resolve_rule_display_value(descriptor=descriptor, flat_values=flat_values, default_actual=default_actual)
-    if not isinstance(display, str):
+    return status_label_to_bool(display)
+
+
+def status_label_to_bool(value: Any) -> bool | None:
+    """Map a STATUS display label/token to on/off, or None when unknown."""
+    if not isinstance(value, str):
         return None
-    norm = display.strip().casefold()
+    norm = value.strip().casefold()
     if norm in _BOOL_TRUE_TOKENS:
         return True
     if norm in _BOOL_FALSE_TOKENS:
@@ -58,8 +63,10 @@ def resolve_entity_bool(
 ) -> bool:
     """Resolve on/off for switches and binary sensors.
 
-    Prefer command-rule labels, then a single bit/mask input from the mapping, and
-    finally a conservative raw coercion that refuses multi-bit status words.
+    Prefer command-rule labels, then bit/mask inputs from the mapping (when several
+    bits share one address, use the lowest bit — e.g. PumpState ON/OFF on bit 1
+    before manual bit 3), and finally a conservative raw coercion that refuses
+    multi-bit status words.
     """
     rule_value = resolve_rule_bool(descriptor=descriptor, flat_values=flat_values, default_actual=default_actual)
     if rule_value is not None:
@@ -74,12 +81,30 @@ def resolve_entity_bool(
                 for entry in inputs
                 if isinstance(entry, Mapping) and (isinstance(entry.get("bit"), int) or isinstance(entry.get("mask"), int))
             ]
-            if len(bit_inputs) == 1:
-                actual = read_target_actual(bit_inputs[0], flat_values=flat_values)
+            preferred = _preferred_bit_input(bit_inputs)
+            if preferred is not None:
+                actual = read_target_actual(preferred, flat_values=flat_values)
                 if isinstance(actual, int | float) and not isinstance(actual, bool):
                     return bool(int(actual))
 
     return coerce_status_bool(default_actual)
+
+
+def _preferred_bit_input(bit_inputs: list[Mapping[str, Any]]) -> Mapping[str, Any] | None:
+    """Pick the best bit/mask input when command rules did not resolve."""
+    if not bit_inputs:
+        return None
+    if len(bit_inputs) == 1:
+        return bit_inputs[0]
+
+    addresses = {str(entry.get("address") or "") for entry in bit_inputs}
+    if len(addresses) != 1:
+        return None
+
+    numbered = [entry for entry in bit_inputs if isinstance(entry.get("bit"), int)]
+    if not numbered:
+        return None
+    return min(numbered, key=lambda entry: int(entry["bit"]))
 
 
 _BOOL_TRUE_TOKENS = frozenset(

--- a/tests/helpers/descriptors.py
+++ b/tests/helpers/descriptors.py
@@ -132,8 +132,12 @@ def binary_sensor_descriptor(
     chan: str = "s",
     idx: int = 0,
     command_rules: list[dict[str, Any]] | None = None,
+    mapping_inputs: list[dict[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build a binary_sensor-platform descriptor."""
+    mapping: dict[str, Any] = {"command_rules": command_rules if command_rules is not None else []}
+    if mapping_inputs:
+        mapping["inputs"] = mapping_inputs
     return {
         "symbol": symbol,
         "devid": devid,
@@ -143,7 +147,7 @@ def binary_sensor_descriptor(
         "platform": "binary_sensor",
         "label": "Pump active",
         "module_name": "module_a",
-        "mapping": {"command_rules": command_rules if command_rules is not None else []},
+        "mapping": mapping,
     }
 
 

--- a/tests/test_platform_binary_sensor.py
+++ b/tests/test_platform_binary_sensor.py
@@ -145,6 +145,27 @@ async def test_binary_sensor_status_symbol_uses_resolver_label(hass: HomeAssista
         await entity.async_update()
     assert entity.is_on is False
 
+    # Unrecognized resolver label → fall through to resolve_entity_bool (inputs).
+    descriptor_with_bit = binary_sensor_descriptor(
+        symbol="STATUS_P5_11",
+        pool="P5",
+        chan="s",
+        idx=11,
+        command_rules=[],
+        mapping_inputs=[{"address": "P5.s11", "bit": 1}],
+    )
+    entity_fallback = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor_with_bit)
+    entity_fallback.hass = hass
+    entity_fallback.entity_id = "binary_sensor.pump_status_fallback"
+    with patch.object(BragerRuntime, "async_resolve_status_label", new=AsyncMock(return_value="unknown-state")):
+        await entity_fallback.async_update()
+    assert entity_fallback.is_on is False  # bit 1 clear in 64.0
+
+    runtime.store._flat["P5.s11"] = 66.0  # bit 1 set
+    with patch.object(BragerRuntime, "async_resolve_status_label", new=AsyncMock(return_value=None)):
+        await entity_fallback.async_update()
+    assert entity_fallback.is_on is True
+
 
 @pytest.mark.asyncio
 async def test_binary_sensor_uses_rule_mapping_when_configured(hass: HomeAssistant) -> None:

--- a/tests/test_platform_binary_sensor.py
+++ b/tests/test_platform_binary_sensor.py
@@ -133,6 +133,18 @@ async def test_binary_sensor_status_symbol_uses_resolver_label(hass: HomeAssista
         await entity.async_update()
     assert entity.is_on is False
 
+    with patch.object(
+        BragerRuntime,
+        "async_resolve_status_label",
+        new=AsyncMock(return_value="Włączone (ręcznie)"),
+    ):
+        await entity.async_update()
+    assert entity.is_on is True
+
+    with patch.object(BragerRuntime, "async_resolve_status_label", new=AsyncMock(return_value="e.OFF_MANUAL")):
+        await entity.async_update()
+    assert entity.is_on is False
+
 
 @pytest.mark.asyncio
 async def test_binary_sensor_uses_rule_mapping_when_configured(hass: HomeAssistant) -> None:

--- a/tests/test_platform_binary_sensor.py
+++ b/tests/test_platform_binary_sensor.py
@@ -107,6 +107,34 @@ async def test_binary_sensor_listener_lifecycle_and_raw_bool_state(hass: HomeAss
 
 
 @pytest.mark.asyncio
+async def test_binary_sensor_status_symbol_uses_resolver_label(hass: HomeAssistant) -> None:
+    from unittest.mock import AsyncMock, patch
+
+    from custom_components.habragerone.runtime import BragerRuntime
+
+    runtime, *_rest = make_runtime(flat_values={"P5.s11": 64.0})
+    descriptor = binary_sensor_descriptor(
+        symbol="STATUS_P5_11",
+        pool="P5",
+        chan="s",
+        idx=11,
+        command_rules=[],  # empty cached rules — resolver is the source of truth
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "binary_sensor.pump_status"
+
+    with patch.object(BragerRuntime, "async_resolve_status_label", new=AsyncMock(return_value="On")):
+        await entity.async_update()
+    assert entity.is_on is True
+
+    with patch.object(BragerRuntime, "async_resolve_status_label", new=AsyncMock(return_value="Off")):
+        await entity.async_update()
+    assert entity.is_on is False
+
+
+@pytest.mark.asyncio
 async def test_binary_sensor_uses_rule_mapping_when_configured(hass: HomeAssistant) -> None:
     runtime, *_rest = make_runtime(flat_values={"P5.s5": 768})
     descriptor = binary_sensor_descriptor(

--- a/tests/test_status_rules.py
+++ b/tests/test_status_rules.py
@@ -83,6 +83,15 @@ def test_resolve_rule_bool_maps_on_off_tokens() -> None:
     assert status_label_to_bool("DiodeState['ON']") is True
     assert status_label_to_bool("maybe") is None
 
+    # Empty / paren-only / quote-only leftovers after normalization.
+    assert status_label_to_bool("   ") is None
+    assert status_label_to_bool("()") is None
+    assert status_label_to_bool("'") is None
+
+    # Prefix fallback when the token is not an exact on/off set member.
+    assert status_label_to_bool("ON_STANDBY") is True
+    assert status_label_to_bool("OFF_STANDBY") is False
+
 
 def test_resolve_rule_bool_returns_none_for_non_string_display() -> None:
     descriptor = {"mapping": {"command_rules": [{"conditions": [], "value": 42}]}}

--- a/tests/test_status_rules.py
+++ b/tests/test_status_rules.py
@@ -71,6 +71,18 @@ def test_resolve_rule_bool_maps_on_off_tokens() -> None:
     descriptor["mapping"]["command_rules"][0]["value"] = "Załączony"
     assert resolve_rule_bool(descriptor=descriptor, flat_values={}, default_actual=1) is True
 
+    from custom_components.habragerone.status_rules import status_label_to_bool
+
+    # PumpState / diode SPA labels — enum tags and Polish manual parentheticals.
+    assert status_label_to_bool("e.ON_MANUAL") is True
+    assert status_label_to_bool("e.OFF_MANUAL") is False
+    assert status_label_to_bool("ON") is True
+    assert status_label_to_bool("OFF") is False
+    assert status_label_to_bool("Włączone (ręcznie)") is True
+    assert status_label_to_bool("Wyłączony (ręcznie)") is False
+    assert status_label_to_bool("DiodeState['ON']") is True
+    assert status_label_to_bool("maybe") is None
+
 
 def test_resolve_rule_bool_returns_none_for_non_string_display() -> None:
     descriptor = {"mapping": {"command_rules": [{"conditions": [], "value": 42}]}}

--- a/tests/test_status_rules.py
+++ b/tests/test_status_rules.py
@@ -165,16 +165,36 @@ def test_resolve_entity_bool_prefers_rules_then_input_bit() -> None:
     assert resolve_entity_bool(descriptor=with_input, flat_values={"P5.s0": 64}, default_actual=64) is False
     assert resolve_entity_bool(descriptor=with_input, flat_values={"P5.s0": 65}, default_actual=65) is True
 
-    # Zero / multiple bit inputs → fall back to raw coercion.
+    # Inputs without bit/mask → raw coercion.
     no_bits = {"mapping": {"command_rules": [], "inputs": [{"address": "P5.s0"}]}}
     assert resolve_entity_bool(descriptor=no_bits, flat_values={"P5.s0": 1}, default_actual=1) is True
-    many_bits = {
+
+    # Dual-bit PumpState inputs (bit 1 ON/OFF + bit 3 manual): prefer lowest bit.
+    pump_bits = {
         "mapping": {
             "command_rules": [],
-            "inputs": [{"address": "P5.s0", "bit": 0}, {"address": "P5.s0", "bit": 1}],
+            "inputs": [{"address": "P5.s11", "bit": 1}, {"address": "P5.s11", "bit": 3}],
         }
     }
-    assert resolve_entity_bool(descriptor=many_bits, flat_values={"P5.s0": 65}, default_actual=65) is False
+    assert resolve_entity_bool(descriptor=pump_bits, flat_values={"P5.s11": 64.0}, default_actual=64.0) is False
+    assert resolve_entity_bool(descriptor=pump_bits, flat_values={"P5.s11": 66.0}, default_actual=66.0) is True
+    assert resolve_entity_bool(descriptor=pump_bits, flat_values={"P5.s11": 8.0}, default_actual=8.0) is False
+
+    # Different addresses / mask-only multi-inputs → refuse and coerce raw.
+    split_addr = {
+        "mapping": {
+            "command_rules": [],
+            "inputs": [{"address": "P5.s11", "bit": 1}, {"address": "P5.s12", "bit": 1}],
+        }
+    }
+    assert resolve_entity_bool(descriptor=split_addr, flat_values={"P5.s11": 2}, default_actual=64) is False
+    mask_only = {
+        "mapping": {
+            "command_rules": [],
+            "inputs": [{"address": "P5.s11", "mask": 2}, {"address": "P5.s11", "mask": 8}],
+        }
+    }
+    assert resolve_entity_bool(descriptor=mask_only, flat_values={"P5.s11": 2}, default_actual=64) is False
 
     # Bit input present but actual is non-numeric → raw fallback.
     weird = {"mapping": {"command_rules": [], "inputs": [{"address": "P5.s0", "bit": 0}]}}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Menu cyrkulacji **Status pompy** (PumpState diode) still reported the wrong on/off after RC3. Root cause: `binary_sensor` evaluated only cached `command_rules` / `inputs`, while text `STATUS_*` sensors use `ParamResolver` / `ComputedValueEvaluator` (SPA `any`/`value` maps). PumpState also exposes **two** bits (bit 1 ON/OFF + bit 3 manual), and the previous `len(inputs)==1` fallback always fell through to “OFF”.

**Fix:**
- For `STATUS_*` binary sensors, prefer `runtime.async_resolve_status_label` (same path as sensors), then map the label to bool.
- Harden `status_label_to_bool` for Polish/manual labels (`Włączone (ręcznie)`, `Wyłączony (ręcznie)`) and enum tags (`e.ON_MANUAL`, `DiodeState['ON']`).
- Fallback: when several bit inputs share one address, use the **lowest** bit (ON/OFF before manual).

No `BOOTSTRAP_VERSION` bump — runtime-only.

## Type of change

- [x] Bug fix (non-breaking)
- [x] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] Tests added / updated; offline tests pass; **local diff-cover 100%** vs `main`
- [x] No secrets committed

## Test plan

```bash
uv run poe lint
uv run poe typecheck
uv run poe test
uv run --group test pytest --cov=custom_components/habragerone --cov-report=xml
uv run --with diff-cover diff-cover coverage.xml --compare-branch=origin/main --fail-under=100
```

Live retest after merge + **rc4**: Menu cyrkulacji → Status pompy vs SPA / physical pump (auto + manual on/off).

## Notes for reviewers

**RC3 does not include this PR** — squash-merge this, then cut `2026.8.5rc4` for HACS retest.

Coverage gaps closed on this PR: empty/paren/quote label normalization, `on_`/`off_` prefix fallback, and binary_sensor fallthrough when the resolver returns an unknown label.

Follow-up for py-bragerone (optional): export top-level `value:` diode maps into `command_rules`/`inputs` so cached rules alone are enough without the resolver.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

