### PR TITLE
chore: prepare 2026.8.5rc4 release candidate

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -19,5 +19,5 @@
     "py-bragerone==2026.8.8",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.5rc3"
+  "version": "2026.8.5rc4"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump `manifest.json` to **2026.8.5rc4** for the next HACS pre-release after the pump STATUS binary diode fix (#189):

- `STATUS_*` binary sensors resolve via SPA status label path (same as text sensors)
- Polish/manual labels (`Włączone (ręcznie)`, `e.ON_MANUAL`) map to on/off
- Dual-bit PumpState fallback prefers lowest bit (ON/OFF before manual)

After merge: `./scripts/release.sh 2026.8.5 rc` → tag **`2026.8.5rc4`**.

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] Manifest version matches intended tag
- [x] No secrets committed

## Test plan

CI gates; then tag/release workflow publishes the GitHub pre-release.

## Notes for reviewers

Live retest: Menu cyrkulacji → Status pompy (auto + manual on/off) vs SPA. No bootstrap re-extract required (runtime-only fix).

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

