### PR TITLE
chore: prepare 2026.8.5 stable release

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -19,5 +19,5 @@
     "py-bragerone==2026.8.8",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.5rc4"
+  "version": "2026.8.5"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump `manifest.json` to **2026.8.5** for the stable HACS release after live smoke on **rc1–rc4** (including pump STATUS diode on rc4).

Highlights since **2026.8.4**:
- UI filter + group-by-menu; entity naming / Podajnik orphans
- Number scale transforms; boiler bit-gated switches; STATUS pump diodes via SPA resolver
- `py-bragerone==2026.8.8`

After merge: `./scripts/release.sh 2026.8.5 stable` → tag **`2026.8.5`** (HACS default channel).

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] Manifest version matches intended stable tag
- [x] Live HACS pre-release smoke completed (rc4; pump OK)
- [x] No secrets committed

## Test plan

CI gates; then tag/release workflow publishes the GitHub stable release.

## Notes for reviewers

Maintainer confirmed live smoke; proceeding to stable per `DEVELOPMENT.md` checklist.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

