### PR TITLE
chore(deps): bump py-bragerone to 2026.8.9rc1 for HA 2026.8.6rc1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,17 +213,29 @@ jobs:
           # Include musllinux 1.2 and 1.1 tags to cover wheels built against both musl baselines.
           # Prefer musllinux (HAOS/Alpine); fall back to manylinux where musl
           # wheels are not yet published for CPython 3.14 (e.g. tree-sitter aarch64).
-          python -m pip download \
-            --dest "${RUNNER_TEMP}/wheels-${{ matrix.arch }}" \
-            --requirement "${RUNNER_TEMP}/manifest-requirements.txt" \
-            --only-binary=:all: \
-            --platform musllinux_1_2_${{ matrix.arch }} \
-            --platform musllinux_1_1_${{ matrix.arch }} \
-            --platform manylinux2014_${{ matrix.arch }} \
-            --platform manylinux_2_17_${{ matrix.arch }} \
-            --platform manylinux_2_28_${{ matrix.arch }} \
-            --implementation cp \
-            --python-version 3.14.2
+          # --pre: allow exact pins like py-bragerone==YYYY.M.NrcN (and tolerate brief
+          # PyPI index lag after a fresh pre-release publish).
+          for attempt in 1 2 3 4 5; do
+            if python -m pip download \
+              --dest "${RUNNER_TEMP}/wheels-${{ matrix.arch }}" \
+              --requirement "${RUNNER_TEMP}/manifest-requirements.txt" \
+              --pre \
+              --only-binary=:all: \
+              --platform musllinux_1_2_${{ matrix.arch }} \
+              --platform musllinux_1_1_${{ matrix.arch }} \
+              --platform manylinux2014_${{ matrix.arch }} \
+              --platform manylinux_2_17_${{ matrix.arch }} \
+              --platform manylinux_2_28_${{ matrix.arch }} \
+              --implementation cp \
+              --python-version 3.14.2; then
+              break
+            fi
+            if [ "$attempt" -eq 5 ]; then
+              exit 1
+            fi
+            echo "pip download failed (attempt ${attempt}/5); retrying in $((attempt * 15))s..."
+            sleep $((attempt * 15))
+          done
 
   tests:
     name: tests (3.14)

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.8",
+    "py-bragerone==2026.8.9rc1",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.5"
+  "version": "2026.8.6rc1"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.8",
+    "py-bragerone>=2026.8.9rc1",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.8" },
+    { name = "py-bragerone", specifier = ">=2026.8.9rc1" },
 ]
 
 [package.metadata.requires-dev]
@@ -2190,7 +2190,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.8"
+version = "2026.8.9rc1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2200,9 +2200,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/7d/be/5bd66440abea0243067dede971d11ed9aea467e598c6b8e4a7d4ec2fba23/py_bragerone-2026.8.8.tar.gz", hash = "sha256:974d3ae1daf85243d870635627da8f5c4fa13bedc23814b9bc9a000a7dcc3b12", size = 112184, upload-time = "2026-08-15T19:03:00.977Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1f/28/4485830beb9d1bc5ba46a64b022f7be7c07d24e41c9c220e1c0852317d3b/py_bragerone-2026.8.9rc1.tar.gz", hash = "sha256:69beb9190a4da59d171e5e45033664672bb7395a66cd54255003db38284f4939", size = 113264, upload-time = "2026-08-17T17:02:52.941Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/33/4f/122040a3ddd90c5506ee47a801df210431d1866f35d130614f76e72a6d1a/py_bragerone-2026.8.8-py3-none-any.whl", hash = "sha256:a707f725fba508a46793e0734908dec8e96b0b2e52981161cee0c2b42acd89a6", size = 117937, upload-time = "2026-08-15T19:02:59.616Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/47/03f6bd2ec1188d5fc45798ac6d288dd80fed534697b6985530f3ce6ce0fe/py_bragerone-2026.8.9rc1-py3-none-any.whl", hash = "sha256:562cbb7f3f59ff73c8c330bef12c64fe47f4f0d209dd1068c2c40b81f0c649b6", size = 119075, upload-time = "2026-08-17T17:02:51.384Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump `py-bragerone` to **2026.8.9rc1** (on PyPI) and set the HACS integration pre-release to **2026.8.6rc1**.

Also harden wheel-compat CI: `--pre` + short retry so exact RC pins work right after publish (aarch64 failed once on a stale PyPI index listing).

Picks up library↔cloud `CloudSessionConnectivity` / WS self-heal from [py-bragerone #320](https://github.com/marpi82/py-bragerone/pull/320) / release [2026.8.9rc1](https://github.com/marpi82/py-bragerone/releases/tag/2026.8.9rc1).

Depends on: merged #195.

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature / enhancement (non-breaking)
- [ ] Breaking change
- [ ] Docs only
- [x] Tests / CI / tooling / chore

## Checklist

- [x] `manifest.json` `py-bragerone==2026.8.9rc1` ↔ `pyproject.toml` `>=2026.8.9rc1` + `uv.lock`
- [x] Integration `version` = `2026.8.6rc1` (matches upcoming tag)
- [x] No secrets

## Test plan

```bash
uv lock
uv run poe test -- tests/test_cloud_session.py
# local aarch64-style download with --pre succeeds for 2026.8.9rc1
```

## Notes for reviewers

After merge I will tag `2026.8.6rc1` on main (HACS pre-release).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

