### PR TITLE
feat: include last ParamUpdate age in Cloud API session diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This custom component provides integration between Home Assistant and the Brager
 - Configurable through Home Assistant UI
 - Support for multiple device types
 - Per-module cloud connectivity diagnostic (SPA `connectedAt` / `module.connection.*` labels) on a **separate** child device (`{devid}:module.connection`, linked with `via_device`); this is intentional in **flat** and group-by-menu alike — parameter entities go unavailable when the module is offline; writes are refused while offline. Module offline is observe-only (wait for the plant to reconnect).
-- Separate **Cloud API session** diagnostic (library↔cloud Socket.IO) on a config-entry service device — detectable and self-healing; never folded into module `connectedAt`
+- Separate **Cloud API session** diagnostic (library↔cloud Socket.IO) on a config-entry service device — detectable and self-healing; never folded into module `connectedAt`. Config-entry diagnostics include `last_param_update_age_s` (seconds since the last parameter snapshot/delta) to distinguish a live session from a frozen push stream.
 - Optional device grouping by menu (options: flat default vs group-by-menu child devices per **parent** menu route with `via_device`)
 
 ## Installation

--- a/custom_components/habragerone/diagnostics.py
+++ b/custom_components/habragerone/diagnostics.py
@@ -53,9 +53,12 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
                     "online": brager_runtime.module_online(devid),
                     "connectedAt": connected_at if isinstance(connected_at, int) else None,
                 }
+            age_fn = getattr(brager_runtime.gateway, "last_param_update_age_s", None)
+            age_s = age_fn() if callable(age_fn) else None
             cloud_session = {
                 "up": brager_runtime.cloud_session_up(),
                 "supported": brager_runtime.supports_cloud_session,
+                "last_param_update_age_s": round(age_s, 1) if isinstance(age_s, (int, float)) else None,
             }
 
     platform_counter: Counter[str] = Counter()

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -74,6 +74,7 @@ class FakeGateway:
         self._connectivity_callbacks: list[Any] = []
         self._cloud_session_callbacks: list[Any] = []
         self._ws_session_up = False
+        self._last_param_update_age_s: float | None = None
         self._start_error = start_error
         self._start_delay = start_delay
         self.started = False
@@ -118,7 +119,10 @@ class FakeGateway:
 
     def last_param_update_age_s(self) -> float | None:
         """Return seconds since the last fake ParamUpdate, or ``None``."""
-        return getattr(self, "_last_param_update_age_s", None)
+        age = self._last_param_update_age_s
+        if isinstance(age, bool) or not isinstance(age, int | float):
+            return None
+        return float(age)
 
     def emit_connectivity(
         self,

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -116,6 +116,10 @@ class FakeGateway:
         """Return whether the fake Socket.IO session is up."""
         return self._ws_session_up
 
+    def last_param_update_age_s(self) -> float | None:
+        """Return seconds since the last fake ParamUpdate, or ``None``."""
+        return getattr(self, "_last_param_update_age_s", None)
+
     def emit_connectivity(
         self,
         devid: str,

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -135,7 +135,22 @@ async def test_diagnostics_includes_module_connectivity(hass: HomeAssistant) -> 
     assert connectivity["DEV1"]["online"] is True
     assert connectivity["DEV1"]["connectedAt"] == 99
     assert "DEV2" in connectivity
-    assert payload["cloud_session"] == {"up": None, "supported": True}
+    assert payload["cloud_session"] == {"up": None, "supported": True, "last_param_update_age_s": None}
+
+
+@pytest.mark.asyncio
+async def test_diagnostics_reports_last_param_update_age(hass: HomeAssistant) -> None:
+    from custom_components.habragerone.const import DATA_RUNTIME
+    from tests.helpers.fakes import make_runtime
+
+    runtime, _api, gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    gateway._last_param_update_age_s = 12.34
+    runtime._cloud_session_up = True
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.data[DOMAIN][entry.entry_id][DATA_RUNTIME] = runtime
+
+    payload = await async_get_config_entry_diagnostics(hass, entry)
+    assert payload["cloud_session"] == {"up": True, "supported": True, "last_param_update_age_s": 12.3}
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `last_param_update_age_s` to config-entry diagnostics next to `cloud_session.up`. Uses `getattr` on the gateway so it stays `None` until `py-bragerone` exposes `BragerOneGateway.last_param_update_age_s()` (sibling library PR).

This is for the 18 Aug soak: both connectivity sensors stayed **Connected** while parameters froze. The next diagnostics dump will show how long it has been since a `ParamUpdate`, instead of only the two boolean bits.

## Type of change

- [x] New feature / enhancement (non-breaking)

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] `uv run poe lint` / `typecheck` / `test` pass locally
- [x] Tests added / updated where practical. Tests pass offline
- [x] Docs / translations updated when user-facing behavior changes (`README.md`)
- [x] Version pins stay consistent (unchanged in this PR)
- [x] No secrets / credentials / real device dumps committed; diagnostics remain redacted

## Test plan

```bash
uv run poe lint
uv run poe typecheck
uv run poe test
```

## Notes for reviewers

Does not bump `py-bragerone`. After the library zombie-session fix is tagged `2026.8.9rc2`, a separate pin PR can follow (`2026.8.6rc2`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

