### PR TITLE
chore(deps): bump py-bragerone to 2026.8.9rc2 for HA 2026.8.6rc2

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.9rc1",
+    "py-bragerone==2026.8.9rc2",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.6rc1"
+  "version": "2026.8.6rc2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.9rc1",
+    "py-bragerone>=2026.8.9rc2",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1136,7 +1136,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.9rc1" },
+    { name = "py-bragerone", specifier = ">=2026.8.9rc2" },
 ]
 
 [package.metadata.requires-dev]
@@ -2190,7 +2190,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.9rc1"
+version = "2026.8.9rc2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2200,9 +2200,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/28/4485830beb9d1bc5ba46a64b022f7be7c07d24e41c9c220e1c0852317d3b/py_bragerone-2026.8.9rc1.tar.gz", hash = "sha256:69beb9190a4da59d171e5e45033664672bb7395a66cd54255003db38284f4939", size = 113264, upload-time = "2026-08-17T17:02:52.941Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/62/23/2a7b96013d2df2b8dc705f32bf29b41e294b68cb278ce9c30191caa3940f/py_bragerone-2026.8.9rc2.tar.gz", hash = "sha256:155a9f9dec8beaaccfe951684397b070e52086ab16c5d2cc0786a368d43069b0", size = 114548, upload-time = "2026-08-18T10:59:20.802Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a3/47/03f6bd2ec1188d5fc45798ac6d288dd80fed534697b6985530f3ce6ce0fe/py_bragerone-2026.8.9rc1-py3-none-any.whl", hash = "sha256:562cbb7f3f59ff73c8c330bef12c64fe47f4f0d209dd1068c2c40b81f0c649b6", size = 119075, upload-time = "2026-08-17T17:02:51.384Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/b5/e059a5c6e58a831a3493c052774bdb5b34eb7c49fd23aba1c04834800533/py_bragerone-2026.8.9rc2-py3-none-any.whl", hash = "sha256:c2857f45fc521dc39c39068c9498bb608b3b7d4128714794101aaa578d1131b1", size = 120291, upload-time = "2026-08-18T10:59:19.523Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump the integration to **2026.8.6rc2** and pin `py-bragerone==2026.8.9rc2` (already on PyPI).

This picks up the Engine.IO abort / zombie-session fix (library #321): Cloud API session goes down immediately when the supervisor sees a dead transport, leftover `disconnect()` cannot wedge reconnect, and REST-prime still runs if ParamUpdates go stale while the socket lies about being up. Diagnostics already expose `last_param_update_age_s` from #197.

After merge, tag `2026.8.6rc2` (HACS pre-release).

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [x] `uv run poe lint` / `test` pass locally
- [x] Tests pass offline
- [x] Docs / translations unchanged (pin-only)
- [x] Version pins stay consistent (`manifest.json` `py-bragerone==2026.8.9rc2` ↔ `pyproject.toml` `>=2026.8.9rc2`)
- [x] No secrets / credentials / real device dumps committed

## Test plan

```bash
uv lock --upgrade-package py-bragerone --python 3.14
uv run poe lint
uv run poe test
```

Wheel-compat already uses `--pre` + retry from #196.

## Notes for reviewers

Install in HA with HACS **Show beta versions**. After this RC, Cloud API session should go off on Engine.IO abort instead of staying Connected with frozen sensors.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

