### PR TITLE
feat: add concise module online/offline transition markers to runtime logs

### DIFF
--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -220,7 +220,7 @@ class BragerRuntime:
         if gateway is not None:
             meta["gateway"] = dict(gateway)
         flipped = previous is not online if online_changed is None else online_changed
-        if flipped:
+        if previous is not None and previous is not online:
             LOGGER.warning(
                 "Module online state changed: devid=%s online=%s connectedAt=%s",
                 devid,

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -220,6 +220,13 @@ class BragerRuntime:
         if gateway is not None:
             meta["gateway"] = dict(gateway)
         flipped = previous is not online if online_changed is None else online_changed
+        if flipped:
+            LOGGER.warning(
+                "Module online state changed: devid=%s online=%s connectedAt=%s",
+                devid,
+                online,
+                connected_at,
+            )
         for callback in list(self._connectivity_listeners):
             try:
                 self._invoke_connectivity_listener(callback, devid, online, flipped)

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -443,4 +443,8 @@ async def test_runtime_logs_online_transition_marker(caplog: pytest.LogCaptureFi
     text = caplog.text
     assert "Module online state changed: devid=DEV1 online=True connectedAt=123" in text
     assert "Module online state changed: devid=DEV1 online=False connectedAt=0" in text
+    caplog.clear()
+    with caplog.at_level("WARNING"):
+        runtime._apply_module_online("DEV1", False, connected_at=0, online_changed=False)
+    assert "Module online state changed" not in caplog.text
     await runtime.stop()

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -433,18 +433,23 @@ async def test_runtime_connectivity_listener_compat_and_seed_edges() -> None:
 @pytest.mark.asyncio
 async def test_runtime_logs_online_transition_marker(caplog: pytest.LogCaptureFixture) -> None:
     """Online/offline flips emit a concise marker for timeline correlation."""
-    runtime, _api, _gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
-    await runtime.start()
+    runtime, _api, gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    gateway._online["DEV1"] = True
+    gateway._connected_at["DEV1"] = 1_700_000_000
 
     with caplog.at_level("WARNING"):
-        runtime._apply_module_online("DEV1", True, connected_at=123)
+        await runtime.start()
+    assert "Module online state changed" not in caplog.text
+
+    with caplog.at_level("WARNING"):
         runtime._apply_module_online("DEV1", False, connected_at=0)
+        runtime._apply_module_online("DEV1", True, connected_at=123)
 
     text = caplog.text
-    assert "Module online state changed: devid=DEV1 online=True connectedAt=123" in text
     assert "Module online state changed: devid=DEV1 online=False connectedAt=0" in text
+    assert "Module online state changed: devid=DEV1 online=True connectedAt=123" in text
     caplog.clear()
     with caplog.at_level("WARNING"):
-        runtime._apply_module_online("DEV1", False, connected_at=0, online_changed=False)
+        runtime._apply_module_online("DEV1", True, connected_at=123, online_changed=False)
     assert "Module online state changed" not in caplog.text
     await runtime.stop()

--- a/tests/test_module_connectivity.py
+++ b/tests/test_module_connectivity.py
@@ -428,3 +428,19 @@ async def test_runtime_connectivity_listener_compat_and_seed_edges() -> None:
     runtime.gateway = _NoConnectivityApi()  # type: ignore[assignment]
     await runtime.start()
     await runtime.stop()
+
+
+@pytest.mark.asyncio
+async def test_runtime_logs_online_transition_marker(caplog: pytest.LogCaptureFixture) -> None:
+    """Online/offline flips emit a concise marker for timeline correlation."""
+    runtime, _api, _gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    await runtime.start()
+
+    with caplog.at_level("WARNING"):
+        runtime._apply_module_online("DEV1", True, connected_at=123)
+        runtime._apply_module_online("DEV1", False, connected_at=0)
+
+    text = caplog.text
+    assert "Module online state changed: devid=DEV1 online=True connectedAt=123" in text
+    assert "Module online state changed: devid=DEV1 online=False connectedAt=0" in text
+    await runtime.stop()


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add a short, timestamped runtime marker when module online state flips, so physical disconnect/reconnect tests can be correlated quickly in HA logs.

New warning log on transition:

- `Module online state changed: devid=<...> online=<bool> connectedAt=<...>`

Emitted only on real cached state flips (`previous is not None and previous != online`), not on startup seed or metadata-only updates.

Copilot review follow-up: marker is independent of listener `online_changed` semantics so startup does not spam one line per module.

## Type of change

- [x] New feature / enhancement (non-breaking)

## Checklist

- [x] English only in code/comments
- [x] `uv run poe lint`
- [x] `uv run poe typecheck`
- [x] Focused regression tests added/updated

## Test plan

```bash
uv run poe fmt
uv run poe lint
uv run poe typecheck
uv run poe test -- tests/test_module_connectivity.py
```

Added test: `test_runtime_logs_online_transition_marker`.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

