### PR TITLE
chore(deps): bump py-bragerone to 2026.8.9rc3 for HA 2026.8.6rc3

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.9rc2",
+    "py-bragerone==2026.8.9rc3",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.6rc2"
+  "version": "2026.8.6rc3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.9rc2",
+    "py-bragerone>=2026.8.9rc3",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.9rc2" },
+    { name = "py-bragerone", specifier = ">=2026.8.9rc3" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.9rc2"
+version = "2026.8.9rc3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2226,9 +2226,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/62/23/2a7b96013d2df2b8dc705f32bf29b41e294b68cb278ce9c30191caa3940f/py_bragerone-2026.8.9rc2.tar.gz", hash = "sha256:155a9f9dec8beaaccfe951684397b070e52086ab16c5d2cc0786a368d43069b0", size = 114548, upload-time = "2026-08-18T10:59:20.802Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/50/4d/19417dd7231662b5642b239569d72d7e6730fe1b68d26cbfa4446d20535c/py_bragerone-2026.8.9rc3.tar.gz", hash = "sha256:a8c658c7aad2f5038e741976f679388f763660257870d0695d6c50bb0c14936d", size = 114929, upload-time = "2026-08-19T18:35:27.742Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/b5/e059a5c6e58a831a3493c052774bdb5b34eb7c49fd23aba1c04834800533/py_bragerone-2026.8.9rc2-py3-none-any.whl", hash = "sha256:c2857f45fc521dc39c39068c9498bb608b3b7d4128714794101aaa578d1131b1", size = 120291, upload-time = "2026-08-18T10:59:19.523Z" },
+    { url = "https://files.pythonhosted.org/packages/88/c3/f50168dd034815dd685bf7ffc4ef672c7b2ca17934874b2ab6a4f194e9a7/py_bragerone-2026.8.9rc3-py3-none-any.whl", hash = "sha256:8fe939ef6fa0a21a2f2cdce011046164261bd9537c25fed251d50fd8280513c6", size = 120694, upload-time = "2026-08-19T18:35:25.813Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release-candidate dependency bump for HACS pre-release **2026.8.6rc3**:

- Pins `py-bragerone==2026.8.9rc3` (quiet connectivity timeout logging from #323).
- Bumps integration manifest version to `2026.8.6rc3` (module online/offline transition log markers from #199).

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`)
- [x] `uv lock` updated for `py-bragerone==2026.8.9rc3`

## Test plan

```bash
uv sync --locked --group dev --group test
uv run poe test
```

## Notes for reviewers

Tag **2026.8.6rc3** on `main` after merge to publish the HACS pre-release zip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

