### PR TITLE
fix: prefetch STATUS mappings and skip slow startup updates

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -12,6 +12,7 @@ ignore:
   - "tests/**/*"
   - "scripts/**/*"
   - "docs/**/*"
+  - "custom_components/habragerone/manifest.json"
 
 comment:
   layout: "reach, diff, flags, files"

--- a/custom_components/habragerone/__init__.py
+++ b/custom_components/habragerone/__init__.py
@@ -34,7 +34,7 @@ from .const import (
     DOMAIN,
     PLATFORMS,
 )
-from .entity_common import async_register_module_parent_devices
+from .entity_common import async_register_module_parent_devices, collect_resolver_warm_symbols
 from .runtime import BragerRuntime
 
 LOGGER = logging.getLogger(__name__)
@@ -210,8 +210,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         modules_meta=modules_meta if isinstance(modules_meta, dict) else {},
     )
 
-    if any(isinstance(item, dict) and str(item.get("symbol") or "").startswith("STATUS_") for item in descriptor_sources):
-        await runtime.async_warm_status_resolver()
+    warm_symbols = collect_resolver_warm_symbols(descriptor_sources)
+    if warm_symbols:
+        await runtime.async_warm_status_resolver(warm_symbols)
 
     await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -146,7 +146,32 @@ class BragerStatusBinarySensor(BinarySensorEntity):
             )
             self.async_write_ha_state()
             return
+        if self._try_apply_status_label_cache(raw_value):
+            self._attr_available = entity_is_available(
+                self._runtime,
+                devid=self._devid,
+                has_value=raw_value is not None or self._runtime.peek_status_label(self._symbol) is not None,
+            )
+            self.async_write_ha_state()
+            return
         self.async_schedule_update_ha_state(True)
+
+    def _try_apply_status_label_cache(self, raw_value: Any | None) -> bool:
+        """Apply on/off from pre-warmed STATUS labels without scheduling ``async_update``."""
+        if not self._symbol.startswith("STATUS_"):
+            return False
+        cached = self._runtime.peek_status_label(self._symbol)
+        if cached is None:
+            return False
+        resolved_bool = status_label_to_bool(cached)
+        if resolved_bool is None:
+            resolved_bool = resolve_entity_bool(
+                descriptor=self._descriptor,
+                flat_values=self._runtime.store.flatten(),
+                default_actual=raw_value if raw_value is not None else cached,
+            )
+        self._attr_is_on = resolved_bool
+        return True
 
     def _try_apply_binary_state_sync(self, raw_value: Any) -> bool:
         """Apply on/off from ParamStore without ``ParamResolver`` when possible."""

--- a/custom_components/habragerone/entity_common.py
+++ b/custom_components/habragerone/entity_common.py
@@ -30,6 +30,30 @@ from .const import (
 from .runtime import BragerRuntime
 
 
+def collect_resolver_warm_symbols(items: Iterable[Any]) -> list[str]:
+    """Return symbol names that benefit from bulk ParamResolver prefetch at startup."""
+    symbols: list[str] = []
+    seen: set[str] = set()
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        symbol = str(item.get("symbol") or "").strip()
+        if not symbol or symbol in seen:
+            continue
+        if symbol.startswith("STATUS_"):
+            seen.add(symbol)
+            symbols.append(symbol)
+            continue
+        mapping = item.get("mapping")
+        if not isinstance(mapping, dict):
+            continue
+        channels = mapping.get("channels")
+        if isinstance(channels, dict) and isinstance(channels.get("unit"), list) and channels.get("unit"):
+            seen.add(symbol)
+            symbols.append(symbol)
+    return symbols
+
+
 def device_grouping_mode(entry: ConfigEntry) -> str:
     """Return the configured device grouping mode for *entry* (flat default)."""
     options = getattr(entry, "options", None)

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -7,7 +7,7 @@ import contextlib
 import inspect
 import logging
 import time
-from collections.abc import Callable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -48,6 +48,7 @@ class BragerRuntime:
     _first_update_logged: bool = False
     _status_resolver: ParamResolver | None = None
     _resolver_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _status_label_cache: dict[str, Any] = field(default_factory=dict)
 
     async def start(self) -> None:
         """Start gateway, state store ingestion and update dispatcher."""
@@ -386,20 +387,47 @@ class BragerRuntime:
         if not ok:
             raise HomeAssistantError(f"Command write failed for '{symbol}' via raw command route")
 
-    async def async_warm_status_resolver(self) -> None:
-        """Build ``ParamResolver`` once before platform setup (#204)."""
-        await self._async_get_resolver()
+    async def async_warm_status_resolver(self, symbols: Iterable[str] | None = None) -> None:
+        """Build ``ParamResolver``, prefetch mappings, and pre-resolve STATUS labels (#204)."""
+        symbol_list = list(dict.fromkeys(str(symbol).strip() for symbol in (symbols or []) if str(symbol).strip()))
+        if not symbol_list:
+            return
+        resolver = await self._async_get_resolver()
+        if resolver is None:
+            return
+        await resolver.prefetch_param_mappings(symbol_list)
+        status_symbols = [symbol for symbol in symbol_list if symbol.startswith("STATUS_")]
+        if not status_symbols:
+            return
+        semaphore = asyncio.Semaphore(16)
+
+        async def _resolve_one(symbol: str) -> None:
+            async with semaphore:
+                label = await self._resolve_status_label_uncached(symbol, resolver=resolver)
+            if label is not None:
+                self._status_label_cache[symbol] = label
+
+        async with asyncio.TaskGroup() as group:
+            for symbol in status_symbols:
+                group.create_task(_resolve_one(symbol))
+
+    def peek_status_label(self, symbol: str) -> Any | None:
+        """Return a pre-warmed STATUS label without triggering resolver I/O."""
+        if not symbol.startswith("STATUS_"):
+            return None
+        return self._status_label_cache.get(symbol)
 
     async def async_resolve_status_label(self, symbol: str) -> Any | None:
         """Resolve STATUS_* value exactly as parser/UI logic does."""
         if not symbol.startswith("STATUS_"):
             return None
-        resolved = await self._async_resolve_symbol(symbol)
-        if resolved is None:
-            return None
-        if isinstance(resolved.value_label, str) and resolved.value_label.strip():
-            return resolved.value_label.strip()
-        return resolved.value
+        cached = self._status_label_cache.get(symbol)
+        if cached is not None:
+            return cached
+        label = await self._resolve_status_label_uncached(symbol)
+        if label is not None:
+            self._status_label_cache[symbol] = label
+        return label
 
     async def async_resolve_symbol_value(self, symbol: str) -> Any | None:
         """Resolve symbol value using parser rules and dynamic unit transforms."""
@@ -420,31 +448,51 @@ class BragerRuntime:
         )
         return value, resolved.unit
 
-    async def _async_resolve_symbol(self, symbol: str) -> Any | None:
-        resolver = await self._async_get_resolver()
-        if resolver is None:
-            return None
-        try:
-            return await resolver.resolve_value(symbol)
-        except Exception:
-            return None
-
     async def _async_get_resolver(self) -> ParamResolver | None:
         if self._status_resolver is not None:
             return self._status_resolver
         async with self._resolver_lock:
-            try:
-                self._status_resolver = ParamResolver.from_api(
-                    api=self.api,
-                    store=self.store,
-                    lang=self.language,
-                )
-            except Exception:
-                return None
+            if self._status_resolver is None:
+                try:
+                    self._status_resolver = ParamResolver.from_api(
+                        api=self.api,
+                        store=self.store,
+                        lang=self.language,
+                    )
+                except Exception:
+                    return None
             return self._status_resolver
+
+    async def _resolve_status_label_uncached(
+        self,
+        symbol: str,
+        *,
+        resolver: ParamResolver | None = None,
+    ) -> Any | None:
+        resolved = await self._async_resolve_symbol(symbol, resolver=resolver)
+        if resolved is None:
+            return None
+        if isinstance(resolved.value_label, str) and resolved.value_label.strip():
+            return resolved.value_label.strip()
+        return resolved.value
+
+    async def _async_resolve_symbol(
+        self,
+        symbol: str,
+        *,
+        resolver: ParamResolver | None = None,
+    ) -> Any | None:
+        active_resolver = resolver or await self._async_get_resolver()
+        if active_resolver is None:
+            return None
+        try:
+            return await active_resolver.resolve_value(symbol)
+        except Exception:
+            return None
 
     async def _dispatch_updates(self) -> None:
         async for update in self.gateway.bus.subscribe():
+            self._status_label_cache.clear()
             if not self._first_update_logged and self._start_monotonic is not None:
                 source = update.meta.get("_source") if isinstance(update.meta, dict) else None
                 LOGGER.debug(

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -395,21 +395,24 @@ class BragerRuntime:
         resolver = await self._async_get_resolver()
         if resolver is None:
             return
-        await resolver.prefetch_param_mappings(symbol_list)
-        status_symbols = [symbol for symbol in symbol_list if symbol.startswith("STATUS_")]
-        if not status_symbols:
-            return
-        semaphore = asyncio.Semaphore(16)
+        try:
+            await resolver.prefetch_param_mappings(symbol_list)
+            status_symbols = [symbol for symbol in symbol_list if symbol.startswith("STATUS_")]
+            if not status_symbols:
+                return
+            semaphore = asyncio.Semaphore(16)
 
-        async def _resolve_one(symbol: str) -> None:
-            async with semaphore:
-                label = await self._resolve_status_label_uncached(symbol, resolver=resolver)
-            if label is not None:
-                self._status_label_cache[symbol] = label
+            async def _resolve_one(symbol: str) -> None:
+                async with semaphore:
+                    label = await self._resolve_status_label_uncached(symbol, resolver=resolver)
+                if label is not None:
+                    self._status_label_cache[symbol] = label
 
-        async with asyncio.TaskGroup() as group:
-            for symbol in status_symbols:
-                group.create_task(_resolve_one(symbol))
+            async with asyncio.TaskGroup() as group:
+                for symbol in status_symbols:
+                    group.create_task(_resolve_one(symbol))
+        except Exception:
+            LOGGER.debug("STATUS resolver warm-up failed; continuing without prefetch", exc_info=True)
 
     def peek_status_label(self, symbol: str) -> Any | None:
         """Return a pre-warmed STATUS label without triggering resolver I/O."""
@@ -452,16 +455,16 @@ class BragerRuntime:
         if self._status_resolver is not None:
             return self._status_resolver
         async with self._resolver_lock:
-            await asyncio.sleep(0)
-            if self._status_resolver is None:
-                try:
+            try:
+                if self._status_resolver is None:
                     self._status_resolver = ParamResolver.from_api(
                         api=self.api,
                         store=self.store,
                         lang=self.language,
                     )
-                except Exception:
-                    return None
+            except Exception:
+                LOGGER.debug("ParamResolver init failed", exc_info=True)
+                return None
             return self._status_resolver
 
     async def _resolve_status_label_uncached(

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -452,6 +452,7 @@ class BragerRuntime:
         if self._status_resolver is not None:
             return self._status_resolver
         async with self._resolver_lock:
+            await asyncio.sleep(0)
             if self._status_resolver is None:
                 try:
                     self._status_resolver = ParamResolver.from_api(

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -101,7 +101,41 @@ class BragerSymbolSensor(SensorEntity):
         """Subscribe to push updates when entity is added to HA."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
         self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        if self._try_apply_initial_state_sync():
+            self.async_write_ha_state()
+            return
         self.async_schedule_update_ha_state(True)
+
+    def _try_apply_initial_state_sync(self) -> bool:
+        """Set first state synchronously when rules or pre-warmed labels allow it."""
+        raw_value = descriptor_current_raw_value(self._runtime.store, self._descriptor)
+        has_value = raw_value is not None
+        if self._is_status_symbol and self._runtime.peek_status_label(self._symbol) is not None:
+            has_value = True
+        self._attr_available = entity_is_available(
+            self._runtime,
+            devid=self._devid,
+            has_value=has_value,
+        )
+        if raw_value is not None:
+            mapped_by_unit = self._raw_to_label.get(str(raw_value))
+            if mapped_by_unit is not None:
+                self._attr_native_value = _normalize_text_state(mapped_by_unit)
+                return True
+            mapped_rule = resolve_rule_display_value(
+                descriptor=self._descriptor,
+                flat_values=self._runtime.store.flatten(),
+                default_actual=raw_value,
+            )
+            if mapped_rule is not None:
+                self._attr_native_value = _normalize_text_state(mapped_rule)
+                return True
+        if self._is_status_symbol:
+            cached = self._runtime.peek_status_label(self._symbol)
+            if cached is not None:
+                self._attr_native_value = _normalize_text_state(cached)
+                return True
+        return False
 
     async def async_will_remove_from_hass(self) -> None:
         """Detach runtime listeners when entity is removed from HA."""

--- a/tests/test_entity_common.py
+++ b/tests/test_entity_common.py
@@ -518,3 +518,13 @@ def test_collect_resolver_warm_symbols_deduplicates_status_and_enum() -> None:
         {"symbol": "TEMP1"},
     ]
     assert collect_resolver_warm_symbols(items) == ["STATUS_P5_0", "PARAM_14"]
+
+
+def test_collect_resolver_warm_symbols_skips_invalid_entries() -> None:
+    items: list[Any] = [
+        "bad",
+        {"symbol": ""},
+        {"symbol": "PARAM_1", "mapping": "bad"},
+        {"symbol": "PARAM_2", "mapping": {"channels": {"unit": []}}},
+    ]
+    assert collect_resolver_warm_symbols(items) == []

--- a/tests/test_entity_common.py
+++ b/tests/test_entity_common.py
@@ -23,6 +23,7 @@ from custom_components.habragerone.const import (  # noqa: E402
 from custom_components.habragerone.entity_common import (  # noqa: E402
     _menu_device_display_name,
     async_register_module_parent_devices,
+    collect_resolver_warm_symbols,
     descriptor_current_raw_value,
     descriptor_enum_map,
     descriptor_options,
@@ -507,3 +508,13 @@ async def test_record_platform_entity_stats_persists_counts(hass: HomeAssistant)
 
     stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]
     assert stats == {"switch": {"descriptor_count": 3, "created_count": 2}}
+
+
+def test_collect_resolver_warm_symbols_deduplicates_status_and_enum() -> None:
+    items = [
+        {"symbol": "STATUS_P5_0"},
+        {"symbol": "STATUS_P5_0"},
+        {"symbol": "PARAM_14", "mapping": {"channels": {"unit": ["a", "b"]}}},
+        {"symbol": "TEMP1"},
+    ]
+    assert collect_resolver_warm_symbols(items) == ["STATUS_P5_0", "PARAM_14"]

--- a/tests/test_init_lifecycle.py
+++ b/tests/test_init_lifecycle.py
@@ -81,7 +81,7 @@ async def test_async_setup_entry_registers_parents_and_warms_resolver(hass: Home
     ):
         assert await async_setup_entry(hass, entry) is True
 
-    fake_runtime.async_warm_status_resolver.assert_awaited_once()
+    fake_runtime.async_warm_status_resolver.assert_awaited_once_with(["STATUS_P5_11"])
     assert dr.async_get(hass).async_get_device(identifiers={(DOMAIN, "DEV1")}) is not None
 
 

--- a/tests/test_platform_binary_sensor.py
+++ b/tests/test_platform_binary_sensor.py
@@ -174,6 +174,54 @@ async def test_binary_sensor_added_to_hass_uses_prewarmed_status_label(hass: Hom
 
 
 @pytest.mark.asyncio
+async def test_binary_sensor_status_label_cache_falls_back_to_entity_bool(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s11": 66.0})
+    runtime._status_label_cache["STATUS_P5_11"] = "unknown-state"
+    descriptor = binary_sensor_descriptor(
+        symbol="STATUS_P5_11",
+        pool="P5",
+        chan="s",
+        idx=11,
+        command_rules=[],
+        mapping_inputs=[{"address": "P5.s11", "bit": 1}],
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._try_apply_status_label_cache(66.0) is True
+    assert entity.is_on is True
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_status_label_cache_returns_false_without_entry(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s11": 64.0})
+    descriptor = binary_sensor_descriptor(symbol="STATUS_P5_11", pool="P5", chan="s", idx=11)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+
+    assert entity._try_apply_status_label_cache(64.0) is False
+
+
+@pytest.mark.asyncio
+async def test_binary_sensor_added_to_hass_uses_cache_without_raw_value(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={})
+    runtime._status_label_cache["STATUS_P5_11"] = "On"
+    descriptor = binary_sensor_descriptor(symbol="STATUS_P5_11", pool="P5", chan="s", idx=11)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "binary_sensor.pump_status"
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+
+    entity.async_write_ha_state.assert_called_once()
+    entity.async_schedule_update_ha_state.assert_not_called()
+    assert entity.is_on is True
+
+
+@pytest.mark.asyncio
 async def test_binary_sensor_status_with_bit_inputs_skips_resolver(hass: HomeAssistant) -> None:
     from unittest.mock import AsyncMock, patch
 

--- a/tests/test_platform_binary_sensor.py
+++ b/tests/test_platform_binary_sensor.py
@@ -149,6 +149,31 @@ async def test_binary_sensor_try_apply_sync_returns_false_without_sync_path(hass
 
 
 @pytest.mark.asyncio
+async def test_binary_sensor_added_to_hass_uses_prewarmed_status_label(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s11": 64.0})
+    runtime._status_label_cache["STATUS_P5_11"] = "On"
+    descriptor = binary_sensor_descriptor(
+        symbol="STATUS_P5_11",
+        pool="P5",
+        chan="s",
+        idx=11,
+        command_rules=[],
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerStatusBinarySensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "binary_sensor.pump_status"
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+
+    entity.async_write_ha_state.assert_called_once()
+    entity.async_schedule_update_ha_state.assert_not_called()
+    assert entity.is_on is True
+
+
+@pytest.mark.asyncio
 async def test_binary_sensor_status_with_bit_inputs_skips_resolver(hass: HomeAssistant) -> None:
     from unittest.mock import AsyncMock, patch
 

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -144,6 +144,68 @@ async def test_sensor_added_to_hass_uses_prewarmed_status_label(hass: HomeAssist
 
 
 @pytest.mark.asyncio
+async def test_sensor_initial_sync_uses_raw_to_label_map(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P6.v0": 2})
+    descriptor = sensor_descriptor(raw_to_label={"2": "Eco"})
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_mode"
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+
+    entity.async_write_ha_state.assert_called_once()
+    entity.async_schedule_update_ha_state.assert_not_called()
+    assert entity.native_value == "eco"
+
+
+@pytest.mark.asyncio
+async def test_sensor_initial_sync_uses_rule_display_value(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s11": 1})
+    descriptor = sensor_descriptor(
+        symbol="STATUS_P5_11",
+        pool="P5",
+        chan="s",
+        idx=11,
+        unit=None,
+        command_rules=[{"logic": "on", "value": "On", "conditions": []}],
+    )
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_rule"
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+
+    entity.async_write_ha_state.assert_called_once()
+    entity.async_schedule_update_ha_state.assert_not_called()
+    assert entity.native_value == "on"
+
+
+@pytest.mark.asyncio
+async def test_sensor_initial_sync_uses_cache_without_raw_value(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={})
+    runtime._status_label_cache["STATUS_BOILER"] = "Work"
+    descriptor = sensor_descriptor(symbol="STATUS_BOILER", pool="P5", chan="s", idx=5, unit=None)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_status_cached"
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+
+    entity.async_write_ha_state.assert_called_once()
+    entity.async_schedule_update_ha_state.assert_not_called()
+    assert entity.native_value == "work"
+
+
+@pytest.mark.asyncio
 async def test_sensor_update_uses_dynamic_unit_resolver(hass: HomeAssistant) -> None:
     store = FakeStore(flat_values={"P10.v2": 33})
     resolve_with_unit = AsyncMock(return_value=(42.0, "%"))

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -125,6 +125,25 @@ async def test_sensor_update_uses_status_resolver_for_status_symbols(hass: HomeA
 
 
 @pytest.mark.asyncio
+async def test_sensor_added_to_hass_uses_prewarmed_status_label(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s5": 768})
+    runtime._status_label_cache["STATUS_BOILER"] = "Work"
+    descriptor = sensor_descriptor(symbol="STATUS_BOILER", pool="P5", chan="s", idx=5, unit=None)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_status"
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+
+    entity.async_write_ha_state.assert_called_once()
+    entity.async_schedule_update_ha_state.assert_not_called()
+    assert entity.native_value == "work"
+
+
+@pytest.mark.asyncio
 async def test_sensor_update_uses_dynamic_unit_resolver(hass: HomeAssistant) -> None:
     store = FakeStore(flat_values={"P10.v2": 33})
     resolve_with_unit = AsyncMock(return_value=(42.0, "%"))

--- a/tests/test_platform_sensor.py
+++ b/tests/test_platform_sensor.py
@@ -206,6 +206,23 @@ async def test_sensor_initial_sync_uses_cache_without_raw_value(hass: HomeAssist
 
 
 @pytest.mark.asyncio
+async def test_sensor_initial_sync_status_without_cache_schedules_update(hass: HomeAssistant) -> None:
+    runtime, *_rest = make_runtime(flat_values={"P5.s5": 1})
+    descriptor = sensor_descriptor(symbol="STATUS_BOILER", pool="P5", chan="s", idx=5, unit=None)
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[descriptor])
+    entity = BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor)
+    entity.hass = hass
+    entity.entity_id = "sensor.test_status_pending"
+    entity.async_write_ha_state = MagicMock()  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = MagicMock()  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+
+    entity.async_write_ha_state.assert_not_called()
+    entity.async_schedule_update_ha_state.assert_called_once()
+
+
+@pytest.mark.asyncio
 async def test_sensor_update_uses_dynamic_unit_resolver(hass: HomeAssistant) -> None:
     store = FakeStore(flat_values={"P10.v2": 33})
     resolve_with_unit = AsyncMock(return_value=(42.0, "%"))

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -176,6 +176,43 @@ async def test_dispatch_updates_clears_status_label_cache() -> None:
 
 
 @pytest.mark.asyncio
+async def test_async_resolve_status_label_returns_none_for_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+
+    class _MissingStatusResolver(_FakeResolver):
+        async def resolve_value(self, symbol: str) -> object | None:
+            _ = symbol
+            return None
+
+    monkeypatch.setattr(runtime_module, "ParamResolver", _MissingStatusResolver)
+
+    assert await runtime.async_resolve_status_label("STATUS_MISSING") is None
+    assert "STATUS_MISSING" not in runtime._status_label_cache
+
+
+@pytest.mark.asyncio
+async def test_resolve_status_label_uncached_returns_none_when_resolver_misses(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+
+    class _MissingStatusResolver(_FakeResolver):
+        async def resolve_value(self, symbol: str) -> object | None:
+            _ = symbol
+            return None
+
+    monkeypatch.setattr(runtime_module, "ParamResolver", _MissingStatusResolver)
+
+    assert await runtime._resolve_status_label_uncached("STATUS_MISSING") is None
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_symbol_with_unit_handles_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+
+    assert await runtime.async_resolve_symbol_with_unit("MISSING") == (None, None)
+
+
+@pytest.mark.asyncio
 async def test_async_resolve_symbol_value_and_with_unit(monkeypatch: pytest.MonkeyPatch) -> None:
     runtime, _api, _gateway, _store = make_runtime()
     monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -176,6 +176,27 @@ async def test_dispatch_updates_clears_status_label_cache() -> None:
 
 
 @pytest.mark.asyncio
+async def test_dispatch_updates_logs_first_update_once() -> None:
+    runtime, _api, gateway, _store = make_runtime()
+    received = 0
+
+    def _listener(_update: FakeParamUpdate) -> None:
+        nonlocal received
+        received += 1
+
+    runtime.add_listener(_listener)
+    await runtime.start()
+    try:
+        gateway.bus.push(FakeParamUpdate(pool="P1", chan="v", idx=1))
+        gateway.bus.push(FakeParamUpdate(pool="P1", chan="v", idx=2))
+        await asyncio.sleep(0.05)
+        assert received == 2
+        assert runtime._first_update_logged is True
+    finally:
+        await runtime.stop()
+
+
+@pytest.mark.asyncio
 async def test_async_resolve_status_label_returns_none_for_unresolved(monkeypatch: pytest.MonkeyPatch) -> None:
     runtime, _api, _gateway, _store = make_runtime()
 
@@ -210,6 +231,20 @@ async def test_async_resolve_symbol_with_unit_handles_missing(monkeypatch: pytes
     monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
 
     assert await runtime.async_resolve_symbol_with_unit("MISSING") == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_async_get_resolver_is_idempotent_under_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    runtime._status_resolver = None
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+
+    first, second = await asyncio.gather(
+        runtime._async_get_resolver(),
+        runtime._async_get_resolver(),
+    )
+
+    assert first is second
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -79,6 +79,103 @@ async def test_async_resolve_status_label_uses_value_label(monkeypatch: pytest.M
 
 
 @pytest.mark.asyncio
+async def test_peek_status_label_rejects_non_status_symbols() -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    runtime._status_label_cache["STATUS_P5_0"] = "On"
+
+    assert runtime.peek_status_label("PARAM_1") is None
+    assert runtime.peek_status_label("STATUS_P5_0") == "On"
+
+
+@pytest.mark.asyncio
+async def test_async_warm_status_resolver_returns_when_resolver_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+
+    class _BrokenFactory:
+        @classmethod
+        def from_api(cls, api: object, store: object, lang: object) -> None:
+            _ = api, store, lang
+            raise RuntimeError("factory failed")
+
+    monkeypatch.setattr(runtime_module, "ParamResolver", _BrokenFactory)
+
+    await runtime.async_warm_status_resolver(["STATUS_P5_0"])
+
+    assert runtime._status_resolver is None
+    assert runtime._status_label_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_async_warm_status_resolver_prefetches_non_status_symbols_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+
+    await runtime.async_warm_status_resolver(["PARAM_14"])
+
+    assert runtime._status_resolver is not None
+    assert runtime._status_resolver.prefetched == ["PARAM_14"]
+    assert runtime._status_label_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_async_warm_status_resolver_skips_unresolved_labels(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+
+    class _EmptyLabelResolver(_FakeResolver):
+        async def resolve_value(self, symbol: str) -> object | None:
+            _ = symbol
+            return SimpleNamespace(value=None, value_label="", unit=None)
+
+    monkeypatch.setattr(runtime_module, "ParamResolver", _EmptyLabelResolver)
+
+    await runtime.async_warm_status_resolver(["STATUS_P5_0", "STATUS_P5_1"])
+
+    assert runtime._status_label_cache == {}
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_status_label_populates_cache_on_miss(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+
+    assert await runtime.async_resolve_status_label("STATUS_P5_0") == "Ten"
+    assert runtime._status_label_cache["STATUS_P5_0"] == "Ten"
+
+
+@pytest.mark.asyncio
+async def test_resolve_status_label_uncached_returns_raw_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+
+    class _RawValueResolver(_FakeResolver):
+        async def resolve_value(self, symbol: str) -> object | None:
+            _ = symbol
+            return SimpleNamespace(value=42, value_label="", unit=None)
+
+    monkeypatch.setattr(runtime_module, "ParamResolver", _RawValueResolver)
+
+    assert await runtime._resolve_status_label_uncached("STATUS_P5_0") == 42
+
+
+@pytest.mark.asyncio
+async def test_dispatch_updates_clears_status_label_cache() -> None:
+    runtime, _api, gateway, _store = make_runtime()
+    runtime._status_label_cache["STATUS_P5_0"] = "On"
+    cleared = asyncio.Event()
+
+    def _listener(_update: FakeParamUpdate) -> None:
+        cleared.set()
+
+    runtime.add_listener(_listener)
+    await runtime.start()
+    try:
+        gateway.bus.push(FakeParamUpdate(pool="P1", chan="v", idx=1))
+        await asyncio.wait_for(cleared.wait(), timeout=1.0)
+        assert runtime._status_label_cache == {}
+    finally:
+        await runtime.stop()
+
+
+@pytest.mark.asyncio
 async def test_async_resolve_symbol_value_and_with_unit(monkeypatch: pytest.MonkeyPatch) -> None:
     runtime, _api, _gateway, _store = make_runtime()
     monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Iterable
 from types import SimpleNamespace
 
 import pytest
@@ -19,11 +20,15 @@ from tests.helpers.fakes import FakeParamUpdate, make_runtime  # noqa: E402
 class _FakeResolver:
     def __init__(self, resolved: object | None) -> None:
         self._resolved = resolved
+        self.prefetched: list[str] = []
 
     @classmethod
     def from_api(cls, api: object, store: object, lang: object) -> _FakeResolver:
         _ = api, store, lang
         return cls(SimpleNamespace(value=10, value_label="Ten", unit="°C"))
+
+    async def prefetch_param_mappings(self, symbols: Iterable[str]) -> None:
+        self.prefetched.extend(list(symbols))
 
     async def resolve_value(self, symbol: str) -> object | None:
         if symbol == "MISSING":
@@ -37,9 +42,31 @@ async def test_async_warm_status_resolver_builds_resolver(monkeypatch: pytest.Mo
     runtime._status_resolver = None
     monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
 
-    await runtime.async_warm_status_resolver()
+    await runtime.async_warm_status_resolver(["STATUS_P5_0"])
 
     assert runtime._status_resolver is not None
+    assert runtime.peek_status_label("STATUS_P5_0") == "Ten"
+    assert runtime._status_resolver.prefetched == ["STATUS_P5_0"]
+
+
+@pytest.mark.asyncio
+async def test_async_warm_status_resolver_noop_without_symbols(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    runtime._status_resolver = None
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+
+    await runtime.async_warm_status_resolver([])
+
+    assert runtime._status_resolver is None
+
+
+@pytest.mark.asyncio
+async def test_async_resolve_status_label_uses_cache(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+    runtime._status_label_cache["STATUS_P5_0"] = "Cached"
+
+    assert await runtime.async_resolve_status_label("STATUS_P5_0") == "Cached"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -234,6 +234,23 @@ async def test_async_resolve_symbol_with_unit_handles_missing(monkeypatch: pytes
 
 
 @pytest.mark.asyncio
+async def test_async_warm_status_resolver_continues_when_prefetch_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+
+    class _FailingPrefetchResolver(_FakeResolver):
+        async def prefetch_param_mappings(self, symbols: Iterable[str]) -> None:
+            _ = symbols
+            raise RuntimeError("prefetch failed")
+
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FailingPrefetchResolver)
+
+    await runtime.async_warm_status_resolver(["STATUS_P5_0"])
+
+    assert runtime._status_resolver is not None
+    assert runtime._status_label_cache == {}
+
+
+@pytest.mark.asyncio
 async def test_async_get_resolver_is_idempotent_under_concurrency(monkeypatch: pytest.MonkeyPatch) -> None:
     runtime, _api, _gateway, _store = make_runtime()
     runtime._status_resolver = None
@@ -245,6 +262,21 @@ async def test_async_get_resolver_is_idempotent_under_concurrency(monkeypatch: p
     )
 
     assert first is second
+
+
+@pytest.mark.asyncio
+async def test_async_get_resolver_reuses_instance_for_lock_waiter(monkeypatch: pytest.MonkeyPatch) -> None:
+    runtime, _api, _gateway, _store = make_runtime()
+    runtime._status_resolver = None
+    monkeypatch.setattr(runtime_module, "ParamResolver", _FakeResolver)
+
+    await runtime._resolver_lock.acquire()
+    pending = asyncio.create_task(runtime._async_get_resolver())
+    await asyncio.sleep(0)
+    runtime._status_resolver = _FakeResolver.from_api(runtime.api, runtime.store, runtime.language)
+    runtime._resolver_lock.release()
+
+    assert await pending is runtime._status_resolver
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to #204 / `2026.8.6rc4`: startup warnings like `Update of binary_sensor.* is taking over 10 seconds` can still appear because rc4 only built `ParamResolver` once — it did **not** bulk-prefetch JS param mappings or avoid per-entity `async_update` scheduling.

This PR:
1. Collects all `STATUS_*` (and enum) symbols from cached descriptors
2. **Bulk-prefetches** param mappings via `ParamResolver.prefetch_param_mappings`
3. **Pre-resolves** STATUS labels in parallel (bounded concurrency) into a runtime cache
4. Applies cached labels synchronously in `async_added_to_hass` for binary sensors and STATUS sensors — **no `async_schedule_update_ha_state`** when initial state is known
5. Clears the label cache on live ParamStore updates so push updates stay fresh

Fixes the remaining startup perf path for entities like pump/fan/thermostat STATUS diodes and STATUS text sensors (e.g. mixing valve status).

## Type of change

- [x] Bug fix (non-breaking)

## Checklist

- [x] `uv run poe validate` passes locally
- [x] Tests added / updated
- [x] No secrets committed

## Test plan

```bash
uv run poe validate
```

381 tests passed.

## Notes for reviewers

After merge, cut `2026.8.6rc5` for HACS testing. Expected outcome: no `helpers/entity.py:1348` warnings at restart for STATUS entities that previously hit the resolver queue.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

