### PR TITLE
docs: add README badges and delete stale ci/coverage-tests-and-badge branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,14 @@
 # BragerOne
 
+[![Release](https://img.shields.io/github/v/release/marpi82/ha-bragerone?include_prereleases&label=release)](https://github.com/marpi82/ha-bragerone/releases)
+[![CI](https://img.shields.io/github/actions/workflow/status/marpi82/ha-bragerone/ci.yml?branch=main&label=CI)](https://github.com/marpi82/ha-bragerone/actions/workflows/ci.yml)
+[![HA Integration](https://img.shields.io/github/actions/workflow/status/marpi82/ha-bragerone/ha-integration-test.yml?branch=main&label=HA%20integration)](https://github.com/marpi82/ha-bragerone/actions/workflows/ha-integration-test.yml)
+[![HACS](https://img.shields.io/github/actions/workflow/status/marpi82/ha-bragerone/hacs.yml?branch=main&label=HACS)](https://github.com/marpi82/ha-bragerone/actions/workflows/hacs.yml)
+[![Codecov](https://codecov.io/gh/marpi82/ha-bragerone/graph/badge.svg)](https://codecov.io/gh/marpi82/ha-bragerone)
+[![License](https://img.shields.io/github/license/marpi82/ha-bragerone)](https://github.com/marpi82/ha-bragerone/blob/main/LICENSE)
+[![Renovate](https://img.shields.io/badge/renovate-enabled-blue?logo=renovate&logoColor=white)](https://app.renovatebot.com/dashboard)
+[![Home Assistant](https://img.shields.io/badge/Home%20Assistant-%E2%89%A52026.3.0-blue)](https://www.home-assistant.io/)
+
 Home Assistant custom integration for BragerOne web service.
 
 **Status:** Stable (Production/Stable)


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add an HA-focused badge row to `README.md` (release, CI, HA integration, HACS, Codecov, license, Renovate, minimum HA version).

Also deletes the stale remote branch `ci/coverage-tests-and-badge` — it pointed at the already-merged #143 merge commit with no unique work.

## Type of change

- [x] Docs only

## Checklist

- [x] English only
- [x] No version pin / code changes

## Test plan

Verified badge shield URLs return HTTP 200.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

