### PR TITLE
chore: release 2026.8.6rc5

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -19,5 +19,5 @@
     "py-bragerone==2026.8.9rc3",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.6rc4"
+  "version": "2026.8.6rc5"
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Bump integration manifest to **2026.8.6rc5** for HACS pre-release testing.

Since rc4:
- **#207** — bulk prefetch STATUS mappings, pre-warmed label cache, skip slow startup `async_update` queue
- **#208** — README CI/quality badges (docs only in HACS readme)

`py-bragerone` pin unchanged at `==2026.8.9rc3`.

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] `uv run poe validate` passes locally
- [x] Version pins consistent

## Test plan

```bash
uv run poe validate
```

395 tests passed.

## Notes for reviewers

After merge, tag `2026.8.6rc5` on main to trigger the HACS pre-release workflow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

