### PR TITLE
chore: release 2026.8.6rc6 (py-bragerone 2026.8.9rc4)

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.9rc3",
+    "py-bragerone==2026.8.9rc4",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.6rc5"
+  "version": "2026.8.6rc6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.9rc3",
+    "py-bragerone>=2026.8.9rc4",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.9rc3" },
+    { name = "py-bragerone", specifier = ">=2026.8.9rc4" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.9rc3"
+version = "2026.8.9rc4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2226,9 +2226,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/4d/19417dd7231662b5642b239569d72d7e6730fe1b68d26cbfa4446d20535c/py_bragerone-2026.8.9rc3.tar.gz", hash = "sha256:a8c658c7aad2f5038e741976f679388f763660257870d0695d6c50bb0c14936d", size = 114929, upload-time = "2026-08-19T18:35:27.742Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/3d/2bb97c7bfd718fe028fb6d69c304d063fe533936893e2bda482b0cc0421e/py_bragerone-2026.8.9rc4.tar.gz", hash = "sha256:1a550b4eebf2a6fb16449a69939fedd7971bbfc768af82ea7a1919d96672bb7b", size = 115956, upload-time = "2026-08-20T16:31:00.3Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/88/c3/f50168dd034815dd685bf7ffc4ef672c7b2ca17934874b2ab6a4f194e9a7/py_bragerone-2026.8.9rc3-py3-none-any.whl", hash = "sha256:8fe939ef6fa0a21a2f2cdce011046164261bd9537c25fed251d50fd8280513c6", size = 120694, upload-time = "2026-08-19T18:35:25.813Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c9/3be98123385e9647c6380bfdcf2d4f231a0220795f7d5820645d40da73c5/py_bragerone-2026.8.9rc4-py3-none-any.whl", hash = "sha256:54cfedc6f4f2728d12af562b0b2013c1241c0ea548b69b06f061bb8ecb2bc30c", size = 121854, upload-time = "2026-08-20T16:30:58.753Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

HACS pre-release **2026.8.6rc6**:

- Pins `py-bragerone==2026.8.9rc4` (quiet expected 502/503/504 reconnect / re-prime logging from library [#326](https://github.com/marpi82/py-bragerone/pull/326) / [#325](https://github.com/marpi82/py-bragerone/issues/325))
- Bumps integration `manifest.json` version to `2026.8.6rc6`

Library tag/PyPI: https://github.com/marpi82/py-bragerone/releases/tag/2026.8.9rc4

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`)
- [x] `uv.lock` updated for `py-bragerone==2026.8.9rc4`
- [x] Tests pass offline

## Test plan

```bash
uv sync --locked --group dev --group test
uv run poe test
```

## Notes for reviewers

After merge, tag **`2026.8.6rc6`** on `main` to publish the HACS pre-release zip.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

