### PR TITLE
chore: release 2026.8.6rc8 (py-bragerone 2026.8.9rc6)

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.9rc5",
+    "py-bragerone==2026.8.9rc6",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.6rc7"
+  "version": "2026.8.6rc8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.9rc5",
+    "py-bragerone>=2026.8.9rc6",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.9rc5" },
+    { name = "py-bragerone", specifier = ">=2026.8.9rc6" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.9rc5"
+version = "2026.8.9rc6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2226,9 +2226,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/33/60/a772bffffdb49a249b5234ebb97e33ed460a498b7080ccbd50757adbe469/py_bragerone-2026.8.9rc5.tar.gz", hash = "sha256:0d628c075b5aca33106f4c35e6b2ef872f0b32c2efde366cf14f74706c2e92ac", size = 117561, upload-time = "2026-08-20T19:10:07.249Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/e3/0432ba942c0896f5cfdb0477d31cb2b8149214d0de46142289862ab79599/py_bragerone-2026.8.9rc6.tar.gz", hash = "sha256:2f9e24875176509a4f2e2a699e132373760abdbefdcf7b334f6d402b5a60dc91", size = 119045, upload-time = "2026-08-21T06:46:55.86Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/65/76/950a71d5c5e345c514165f814970bd66e678c60150c8720b223591ba9929/py_bragerone-2026.8.9rc5-py3-none-any.whl", hash = "sha256:9f4a5064943adc3e1bb9acdfe1fac9a599406f3716a73496652e2cd2bc94de0f", size = 123438, upload-time = "2026-08-20T19:10:05.637Z" },
+    { url = "https://files.pythonhosted.org/packages/95/1f/4041dea9e06bbd0c36a0af3c00bd0eec5195a25ab45e76ac6cc94dbd3f97/py_bragerone-2026.8.9rc6-py3-none-any.whl", hash = "sha256:902ec4e460a905fe50c2bb09ab8de62b5269b45f4656a6fc0609f27540205995", size = 124897, upload-time = "2026-08-21T06:46:54.47Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

HACS pre-release **2026.8.6rc8**:

- Pins `py-bragerone==2026.8.9rc6` (zombie Socket.IO hard-restart after stale ParamUpdate primes + SPA event `22` MEMORY_UPDATED REST-prime — library [#334](https://github.com/marpi82/py-bragerone/pull/334))
- Bumps integration `manifest.json` version to `2026.8.6rc8`

Library tag/PyPI: https://github.com/marpi82/py-bragerone/releases/tag/2026.8.9rc6

## Type of change

- [x] Tests / CI / tooling / chore

## Checklist

- [x] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`)
- [x] `uv.lock` updated for `py-bragerone==2026.8.9rc6`
- [x] Tests pass offline

## Test plan

```bash
uv sync --locked --group dev --group test
uv run poe test
```

## Notes for reviewers

After merge, tag **`2026.8.6rc8`** on `main` to publish the HACS pre-release zip.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

