### PR TITLE
fix: preserve half-degree floats on plain temperature sensors

### DIFF
--- a/custom_components/habragerone/entity_common.py
+++ b/custom_components/habragerone/entity_common.py
@@ -123,6 +123,55 @@ def _address_from_value_selector(entry: Mapping[str, Any]) -> str | None:
     return f"{group.strip()}.{use.strip()[0]}{number}"
 
 
+def _is_address_selector_entry(entry: Any) -> bool:
+    """Return whether *entry* is a ``{group, number, use[, convert, times]}`` selector."""
+    if not isinstance(entry, Mapping):
+        return False
+    group = entry.get("group")
+    number = entry.get("number")
+    use = entry.get("use")
+    return isinstance(group, str) and bool(group) and isinstance(number, int) and isinstance(use, str) and bool(use)
+
+
+def _address_selectors_need_compose(entries: list[Any]) -> bool:
+    """Return whether address selectors need multi-register composition.
+
+    Plain single ``{group, number, use}`` paths must not call compose: older
+    ``py-bragerone`` builds coerce words with ``int()`` and truncate half-degree
+    floats (``40.5`` → ``40``). Compose only for multi-selector lists or
+    selectors that carry ``convert`` / a non-default ``times``.
+    """
+    selectors = [entry for entry in entries if _is_address_selector_entry(entry)]
+    if len(selectors) >= 2:
+        return True
+    if len(selectors) != 1:
+        return False
+    entry = selectors[0]
+    if entry.get("convert"):
+        return True
+    times = entry.get("times")
+    return isinstance(times, (int, float)) and not isinstance(times, bool) and float(times) != 1.0
+
+
+def _mapping_value_selector_entries(mapping: Mapping[str, Any]) -> list[Any] | None:
+    """Return SPA address-selector value paths from a cached descriptor mapping."""
+    for key in ("paths", "raw"):
+        container = mapping.get(key)
+        if not isinstance(container, Mapping):
+            continue
+        candidate = container.get("value")
+        if not isinstance(candidate, list) or not candidate:
+            continue
+        if any(
+            isinstance(entry, Mapping) and any(rule in entry for rule in ("if", "elseif", "then", "else"))
+            for entry in candidate
+        ):
+            continue
+        if any(_is_address_selector_entry(entry) for entry in candidate):
+            return candidate
+    return None
+
+
 def descriptor_refresh_keys(descriptor: dict[str, Any]) -> set[str]:
     """Return address keys that should trigger entity refresh for a descriptor."""
     keys: set[str] = set()
@@ -189,17 +238,21 @@ def descriptor_current_raw_value(store: ParamStore, descriptor: dict[str, Any]) 
 
     Prefer SPA multi-register composition (``convert`` + ``times``) via
     :meth:`ParamResolver.compose_mapping_register_value` when the mapping carries
-    address-selector value paths (#327 / ha-bragerone#214). Fall back to direct
-    ``pool/chan/idx``, then the first mapping input address.
+    multi-register / converted address-selector value paths (#327 /
+    ha-bragerone#214). Plain single ``{group, number, use}`` selectors fall through
+    to a direct store read so half-degree floats are preserved. Fall back to
+    direct ``pool/chan/idx``, then the first mapping input address.
     """
     from pybragerone.models.param_resolver import ParamResolver
 
     mapping = descriptor.get("mapping")
     compose = getattr(ParamResolver, "compose_mapping_register_value", None)
     if callable(compose) and isinstance(mapping, dict):
-        composed = compose(store, mapping)
-        if composed is not None:
-            return composed
+        entries = _mapping_value_selector_entries(mapping)
+        if entries is not None and _address_selectors_need_compose(entries):
+            composed = compose(store, mapping)
+            if composed is not None:
+                return composed
 
     pool = descriptor.get("pool")
     chan = descriptor.get("chan")

--- a/custom_components/habragerone/entity_common.py
+++ b/custom_components/habragerone/entity_common.py
@@ -163,8 +163,7 @@ def _mapping_value_selector_entries(mapping: Mapping[str, Any]) -> list[Any] | N
         if not isinstance(candidate, list) or not candidate:
             continue
         if any(
-            isinstance(entry, Mapping) and any(rule in entry for rule in ("if", "elseif", "then", "else"))
-            for entry in candidate
+            isinstance(entry, Mapping) and any(rule in entry for rule in ("if", "elseif", "then", "else")) for entry in candidate
         ):
             continue
         if any(_is_address_selector_entry(entry) for entry in candidate):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -110,7 +110,26 @@ def install_pybragerone_stubs() -> None:
                 return None
             if any(isinstance(e, dict) and any(k in e for k in ("if", "elseif", "then", "else")) for e in entries):
                 return None
-            if not any(isinstance(e, dict) and "group" in e and "number" in e and "use" in e for e in entries):
+
+            def _is_selector(entry: object) -> bool:
+                if not isinstance(entry, dict):
+                    return False
+                group = entry.get("group")
+                number = entry.get("number")
+                use = entry.get("use")
+                return isinstance(group, str) and bool(group) and isinstance(number, int) and isinstance(use, str) and bool(use)
+
+            selectors = [entry for entry in entries if _is_selector(entry)]
+            if not selectors:
+                return None
+            needs_compose = len(selectors) >= 2
+            if not needs_compose:
+                only = selectors[0]
+                times = only.get("times")
+                needs_compose = bool(only.get("convert")) or (
+                    isinstance(times, (int, float)) and not isinstance(times, bool) and float(times) != 1.0
+                )
+            if not needs_compose:
                 return None
 
             total = 0.0
@@ -133,20 +152,22 @@ def install_pybragerone_stubs() -> None:
                 if raw_val is None:
                     continue
                 try:
-                    word = int(raw_val)
+                    word_f = float(raw_val)
                 except TypeError:
                     continue
                 except ValueError:
                     continue
                 if selector.get("convert"):
-                    word = word & 0xFFFF
+                    word: int | float = int(word_f) & 0xFFFF
+                elif word_f.is_integer():
+                    word = int(word_f)
+                else:
+                    word = word_f
                 times = selector.get("times", 1)
-                try:
-                    times_n = int(times) if times is not None else 1
-                except TypeError:
-                    times_n = 1
-                except ValueError:
-                    times_n = 1
+                if isinstance(times, bool) or not isinstance(times, (int, float)):
+                    times_n: int | float = 1
+                else:
+                    times_n = times
                 total += float(word) * float(times_n)
                 found = True
             if not found:

--- a/tests/test_entity_common.py
+++ b/tests/test_entity_common.py
@@ -21,6 +21,9 @@ from custom_components.habragerone.const import (  # noqa: E402
     DOMAIN,
 )
 from custom_components.habragerone.entity_common import (  # noqa: E402
+    _address_selectors_need_compose,
+    _is_address_selector_entry,
+    _mapping_value_selector_entries,
     _menu_device_display_name,
     async_register_module_parent_devices,
     collect_resolver_warm_symbols,
@@ -214,6 +217,64 @@ def test_descriptor_current_raw_value_preserves_half_degree_float() -> None:
         },
     }
     assert descriptor_current_raw_value(store, descriptor) == 40.5
+
+
+def test_address_selector_compose_helpers() -> None:
+    """Cover compose-gate helpers used before calling ParamResolver."""
+    assert _is_address_selector_entry("not-a-mapping") is False
+    assert _is_address_selector_entry({"group": "P7", "number": 12, "use": "v"}) is True
+    assert _address_selectors_need_compose([]) is False
+    assert _address_selectors_need_compose([{"group": "P7", "number": 12, "use": "v"}]) is False
+    assert _address_selectors_need_compose([{"group": "P4", "number": 59, "use": "v", "convert": "_x"}]) is True
+    assert (
+        _address_selectors_need_compose(
+            [
+                {"group": "P4", "number": 59, "use": "v"},
+                {"group": "P4", "number": 60, "use": "v", "times": 65536},
+            ]
+        )
+        is True
+    )
+
+    assert _mapping_value_selector_entries({"paths": "not-a-dict"}) is None
+    assert _mapping_value_selector_entries({"paths": {"value": []}}) is None
+    assert _mapping_value_selector_entries({"paths": {"value": [{"foo": 1}]}}) is None
+    assert _mapping_value_selector_entries(
+        {
+            "paths": {"value": [{"if": [], "then": "e.ON"}]},
+            "raw": {"value": [{"group": "P7", "number": 1, "use": "v"}]},
+        }
+    ) == [{"group": "P7", "number": 1, "use": "v"}]
+
+
+def test_descriptor_current_raw_value_compose_none_falls_back_when_needed() -> None:
+    """When compose is required but returns None, fall back to pool/chan/idx."""
+    from pybragerone.models import param_resolver as resolver_mod
+
+    original = resolver_mod.ParamResolver.compose_mapping_register_value
+
+    def _always_none(store: object, mapping: object) -> int | float | None:
+        return None
+
+    resolver_mod.ParamResolver.compose_mapping_register_value = staticmethod(_always_none)
+    try:
+        store = FakeStore(flat_values={"P4.v59": 12})
+        descriptor = {
+            "pool": "P4",
+            "chan": "v",
+            "idx": 59,
+            "mapping": {
+                "paths": {
+                    "value": [
+                        {"group": "P4", "number": 59, "use": "v", "convert": "_x"},
+                        {"group": "P4", "number": 60, "use": "v", "convert": "_x", "times": 65536},
+                    ],
+                },
+            },
+        }
+        assert descriptor_current_raw_value(store, descriptor) == 12
+    finally:
+        resolver_mod.ParamResolver.compose_mapping_register_value = original
 
 
 def test_descriptor_current_raw_value_falls_back_to_mapping_input() -> None:

--- a/tests/test_entity_common.py
+++ b/tests/test_entity_common.py
@@ -200,6 +200,22 @@ def test_descriptor_current_raw_value_composes_multi_register_feeder_runtime() -
     assert descriptor_current_raw_value(store, descriptor) == 38063
 
 
+def test_descriptor_current_raw_value_preserves_half_degree_float() -> None:
+    """Plain single-selector temp mappings must not int-truncate store floats."""
+    store = FakeStore(flat_values={"P7.v12": 40.5})
+    descriptor = {
+        "pool": "P7",
+        "chan": "v",
+        "idx": 12,
+        "mapping": {
+            "paths": {
+                "value": [{"group": "P7", "number": 12, "use": "v"}],
+            },
+        },
+    }
+    assert descriptor_current_raw_value(store, descriptor) == 40.5
+
+
 def test_descriptor_current_raw_value_falls_back_to_mapping_input() -> None:
     store = FakeStore(flat_values={"P1.v2": 7})
     descriptor = {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Valve 1 history lost fractional `.5` values around yesterday ~20:30 / `2026.8.6rc7` (`#215` + `py-bragerone` `#328`). `#215` preferred `ParamResolver.compose_mapping_register_value` for every address-selector mapping. Ordinary temperature paths are a single `{group, number, use}` selector; compose coerced with `int()` and truncated store floats (`40.5` → `40`).

Gate compose to multi-register / `convert` / non-default `times` only, then fall back to the direct `pool/chan/idx` store read. Mirror the same gate in the test stub.

## Type of change

- [x] Bug fix (non-breaking)
- [ ] New feature / enhancement (non-breaking)
- [ ] Breaking change (`unique_id`, platforms, config flow version, `BOOTSTRAP_VERSION` / descriptor cache) — call this out explicitly
- [ ] Docs only
- [ ] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [ ] `uv run poe validate` passes locally (fmt + lint + mypy --strict + security + tests; sync `--group dev --group test` first)
- [x] Tests added / updated where practical (regression test for bug fixes; cover enum/numeric write safety when touching the write path). Tests pass offline
- [x] Docs / translations updated when user-facing behavior changes (`README.md`, `docs/`, `strings.json` + `translations/en.json`) — N/A (behavior restore)
- [x] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency) — no pin bump required for this defensive gate
- [x] No secrets / credentials / real device dumps committed; diagnostics remain redacted

## Test plan

```bash
uv run pytest tests/test_entity_common.py -q
uv run poe lint
uv run poe typecheck
```

New regression: plain single-selector descriptor with store `40.5` stays `40.5`; feeder multi-word still composes to `38063`.

## Notes for reviewers

- Companion `py-bragerone` PR applies the same rule inside `compose_mapping_register_value`.
- This HA-side gate restores half-degrees on current `py-bragerone==2026.8.9rc6` without waiting for a library release.
- Feeder runtime (`PARAM_P4_59`) path from `#214` / `#215` is unchanged.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

