### PR TITLE
chore: release 2026.8.6rc9 (py-bragerone 2026.8.9rc7)

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.9rc6",
+    "py-bragerone==2026.8.9rc7",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.6rc8"
+  "version": "2026.8.6rc9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.9rc6",
+    "py-bragerone>=2026.8.9rc7",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.9rc6" },
+    { name = "py-bragerone", specifier = ">=2026.8.9rc7" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.8.9rc6"
+version = "2026.8.9rc7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2226,9 +2226,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/fe/e3/0432ba942c0896f5cfdb0477d31cb2b8149214d0de46142289862ab79599/py_bragerone-2026.8.9rc6.tar.gz", hash = "sha256:2f9e24875176509a4f2e2a699e132373760abdbefdcf7b334f6d402b5a60dc91", size = 119045, upload-time = "2026-08-21T06:46:55.86Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/89/6c/294a27ae0fc7d3cb56a5a6a1a640b57e51c7539acc677d5ba6f09c457dba/py_bragerone-2026.8.9rc7.tar.gz", hash = "sha256:e7a0913fe07c5c5fe37e1e5a45bce867918ba532a364c524f1a52bce7f9354ca", size = 119380, upload-time = "2026-08-21T07:41:28.886Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/1f/4041dea9e06bbd0c36a0af3c00bd0eec5195a25ab45e76ac6cc94dbd3f97/py_bragerone-2026.8.9rc6-py3-none-any.whl", hash = "sha256:902ec4e460a905fe50c2bb09ab8de62b5269b45f4656a6fc0609f27540205995", size = 124897, upload-time = "2026-08-21T06:46:54.47Z" },
+    { url = "https://files.pythonhosted.org/packages/53/34/bc1c1e45d3201e7c67e22325d5aae9fa79cbbc7330894deb282da955dc91/py_bragerone-2026.8.9rc7-py3-none-any.whl", hash = "sha256:72cfd1b8a4543e83f7b537cb14a998cc667094a598ca0ccfb2e496d25b4f1fb5", size = 125247, upload-time = "2026-08-21T07:41:27.583Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Release candidate for the half-degree temperature fix.

- Bump integration to ``2026.8.6rc9``
- Pin ``py-bragerone==2026.8.9rc7`` (PyPI) — skips compose for plain single-register SPA value paths so floats like ``40.5`` are preserved (#219 / py #335)

## Type of change

- [ ] Bug fix (non-breaking)
- [ ] New feature / enhancement (non-breaking)
- [ ] Breaking change (`unique_id`, platforms, config flow version, `BOOTSTRAP_VERSION` / descriptor cache) — call this out explicitly
- [ ] Docs only
- [x] Tests / CI / tooling / chore

## Checklist

- [x] English only in code, comments, and docs; Google-style docstrings
- [ ] `uv run poe validate` passes locally (fmt + lint + mypy --strict + security + tests; sync `--group dev --group test` first)
- [x] Tests added / updated where practical — N/A (pin/version bump only)
- [x] Docs / translations updated when user-facing behavior changes — N/A
- [x] Version pins stay consistent (`manifest.json` `py-bragerone==X` ↔ `pyproject.toml`; `hacs.json` HA minimum ↔ `homeassistant` dependency)
- [x] No secrets / credentials / real device dumps committed; diagnostics remain redacted

## Test plan

```bash
# PyPI already has 2026.8.9rc7 (release workflow green)
uv lock --upgrade-package py-bragerone   # already done in this PR
uv run poe lint
uv run poe typecheck
uv run poe test
```

After merge: tag ``2026.8.6rc9`` for the HACS pre-release zip.

## Notes for reviewers

- Library tag ``2026.8.9rc7`` is already on PyPI / GitHub Releases.
- HA-side gate from #219 is already on ``main``; this RC ships the matching library pin for HACS installs.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3477ef25-aab2-4cf0-aa90-9003ad1db7ce&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

