### PR TITLE
ci: allow pre-releases from release/* trains only

### DIFF
--- a/.github/branch-protection-checklist.md
+++ b/.github/branch-protection-checklist.md
@@ -1,9 +1,24 @@
-# Branch protection checklist (`main`)
+# Branch and tag protection checklist
 
 Scorecard `BranchProtection` / `CodeReview` alerts need GitHub Settings changes
 (not only repository files). `CODEOWNERS` is already in `.github/CODEOWNERS`.
 
+Release channel policy (enforced in CI by `.github/workflows/release.yml` and
+locally by `scripts/release.sh`):
+
+- **`main`**: stable CalVer tags and pre-releases (`aN` / `bN` / `rcN`)
+- **`release/*`**: pre-releases only — `release.sh` refuses `stable` on these
+  branches; the release workflow also fails if a stable tag’s commit is not on
+  `origin/main`
+
+Rulesets below are hardening around that policy; the workflow remains the source
+of truth for “stable ⇒ commit on main”.
+
+## Branch ruleset: `main`
+
 Open: https://github.com/marpi82/ha-bragerone/settings/branches
+
+(or Rules → https://github.com/marpi82/ha-bragerone/settings/rules )
 
 Recommended rules for `main`:
 
@@ -15,3 +30,38 @@ Recommended rules for `main`:
 6. Do **not** allow force pushes
 7. Do **not** allow deletions
 8. Require status checks to pass — only the aggregate gates (`CI`, `HA Integration Tests`, `HACS Validation`) so renaming matrix legs never needs a ruleset change
+
+## Branch ruleset: `release/**` (release trains)
+
+Open: https://github.com/marpi82/ha-bragerone/settings/rules
+
+Create a ruleset targeting `release/**` (or `release/*`):
+
+1. Require a pull request before merging into the train
+2. Do **not** allow force pushes
+3. Restrict deletions (allow maintainers only after the train is closed)
+4. Optionally require the aggregate gate `CI` (same idea as `main`)
+
+Trains are named `release/YYYY.M` or `release/YYYY.M.N` (for example
+`release/2026.9`). Cut pre-release tags from the train tip; merge to `main`
+before any unsuffixed stable tag.
+
+## Tag ruleset (CalVer)
+
+Open: https://github.com/marpi82/ha-bragerone/settings/rules
+
+Create a **tag** ruleset (pattern `20*` — this repo does not use a `v` prefix):
+
+1. Restrict tag creations to maintainers / selected actors
+2. Block tag deletions
+3. Block force updates of existing tags
+
+Note: GitHub cannot bind “this tag must point at `main`” the way the release
+workflow does. Use the tag ruleset to limit who can create/overwrite tags; rely
+on **Enforce release channel** in `release.yml` (and `release.sh` on
+`release/*`) to refuse stable publishes from commits not on `main`.
+
+## After enabling
+
+Re-run Scorecard / Security Checks if those workflows are enabled for this repo
+so BranchProtection re-evaluates.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,10 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          git fetch origin main "+refs/heads/release/*:refs/remotes/origin/release/*"
+          # Explicit refspecs refresh origin/main and origin/release/* (not only FETCH_HEAD).
+          git fetch --prune origin \
+            "+refs/heads/main:refs/remotes/origin/main" \
+            "+refs/heads/release/*:refs/remotes/origin/release/*"
 
           on_main=false
           on_release=false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,26 @@ jobs:
           fi
           echo "Detected tag: ${TAG:-<none>}"
 
+      # Stable tags (no a/b/rc suffix) require the tagged commit on origin/main.
+      # Pre-releases may be cut from main or release/* trains.
+      - name: Enforce release channel
+        if: ${{ steps.meta.outputs.tag != '' }}
+        shell: bash
+        run: |
+          TAG="${{ steps.meta.outputs.tag }}"
+          PRERELEASE="${{ steps.meta.outputs.prerelease }}"
+          if [[ "$PRERELEASE" == "true" ]]; then
+            echo "Pre-release tag ${TAG}: allowed from main or release/*"
+            exit 0
+          fi
+          git fetch origin main
+          if git merge-base --is-ancestor HEAD origin/main; then
+            echo "Stable tag ${TAG}: commit is on origin/main"
+            exit 0
+          fi
+          echo "::error::Stable tag ${TAG} is not on origin/main. Cut stables from main after merging; from release/* use aN/bN/rcN only."
+          exit 1
+
       - name: Checkout py-bragerone
         if: ${{ steps.meta.outputs.tag != '' }}
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,20 +41,40 @@ jobs:
           fi
           echo "Detected tag: ${TAG:-<none>}"
 
-      # Stable tags (no a/b/rc suffix) require the tagged commit on origin/main.
-      # Pre-releases may be cut from main or release/* trains.
+      # Stable tags require the tagged commit on origin/main.
+      # Pre-releases require the commit on origin/main or origin/release/*.
       - name: Enforce release channel
         if: ${{ steps.meta.outputs.tag != '' }}
+        env:
+          TAG: ${{ steps.meta.outputs.tag }}
+          PRERELEASE: ${{ steps.meta.outputs.prerelease }}
         shell: bash
         run: |
-          TAG="${{ steps.meta.outputs.tag }}"
-          PRERELEASE="${{ steps.meta.outputs.prerelease }}"
-          if [[ "$PRERELEASE" == "true" ]]; then
-            echo "Pre-release tag ${TAG}: allowed from main or release/*"
-            exit 0
-          fi
-          git fetch origin main
+          set -euo pipefail
+          git fetch origin main "+refs/heads/release/*:refs/remotes/origin/release/*"
+
+          on_main=false
+          on_release=false
           if git merge-base --is-ancestor HEAD origin/main; then
+            on_main=true
+          fi
+          while IFS= read -r ref; do
+            if git merge-base --is-ancestor HEAD "$ref"; then
+              on_release=true
+              break
+            fi
+          done < <(git for-each-ref --format="%(refname)" "refs/remotes/origin/release")
+
+          if [[ "$PRERELEASE" == "true" ]]; then
+            if [[ "$on_main" == "true" || "$on_release" == "true" ]]; then
+              echo "Pre-release tag ${TAG}: commit is on main or release/*"
+              exit 0
+            fi
+            echo "::error::Pre-release tag ${TAG} is not on origin/main or origin/release/*. Cut pre-releases from main or a release train only."
+            exit 1
+          fi
+
+          if [[ "$on_main" == "true" ]]; then
             echo "Stable tag ${TAG}: commit is on origin/main"
             exit 0
           fi

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,6 +8,7 @@ HACS custom integration (`custom_components/habragerone`) connecting BragerOne h
 - **Python**: `>=3.14.2,<3.15`; **HA**: `homeassistant>=2026.3.0`; iot_class `cloud_push`.
 - **Dependencies**: **uv** (`uv.lock` committed). Runtime deps pinned exactly in `manifest.json`.
 - **Build/versioning**: hatchling + hatch-vcs, CalVer from git tags.
+- **Releases**: `scripts/release.sh` tags the current branch; HACS zip via `.github/workflows/release.yml`. `main` may cut stable or `aN`/`bN`/`rcN`; `release/*` trains are pre-only (script + workflow refuse stable off main). See `DEVELOPMENT.md` and `.github/branch-protection-checklist.md`.
 
 ## Common commands
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -52,9 +52,18 @@ Issue and PR templates live under `.github/ISSUE_TEMPLATE/` and `.github/PULL_RE
 
 Do **not** cut a stable HACS tag until the same version has been smoke-tested as a HACS **pre-release** on a live Home Assistant install. Tooling already supports this (`scripts/release.sh` + `.github/workflows/release.yml`); skipping the beta/rc step is a process failure, not a tooling gap.
 
-#### Release checklist (maintainers)
+**Channels:**
 
-1. Land the release candidates on `main` (CI green).
+| Branch | Allowed tags |
+|--------|----------------|
+| `main` | Stable (`2026.x.y`) and pre (`aN` / `bN` / `rcN`) |
+| `release/YYYY.M` or `release/YYYY.M.N` | Pre only — `release.sh` and the release workflow refuse stable |
+
+`scripts/release.sh` tags the **current** branch (it no longer switches to `main`). Pin `py-bragerone==…` in `manifest.json` to a published library pre-release when testing a train. Ruleset checklist: `.github/branch-protection-checklist.md`.
+
+#### Release checklist (maintainers) — from `main`
+
+1. Land the release candidates on `main` (CI green), or merge a finished `release/*` train.
 2. Tag a **pre-release** (prefer `beta`, then `rc` if needed):
 
    ```bash
@@ -70,9 +79,17 @@ Do **not** cut a stable HACS tag until the same version has been smoke-tested as
    ./scripts/release.sh 2026.x.y stable # pushes 2026.x.y → GitHub release (HACS default)
    ```
 
+#### Release train (future work off `main`)
+
+1. `git checkout -b release/2026.9` from `main` and develop there.
+2. Publish library pre on PyPI from the matching `py-bragerone` train, then bump the integration pin / `manifest.json` `"version"`.
+3. From the train branch: `./scripts/release.sh 2026.9.0 rc` (alpha/beta/rc only).
+4. HACS beta smoke as above.
+5. Open a PR `release/2026.9` → `main`; after merge, cut stable from `main`.
+
 Bump `custom_components/habragerone/manifest.json` `"version"` to the **exact** tag string before tagging (the HACS zip embeds that file).
 
-Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release`) sets `prerelease=true` when the tag matches `(a|b|rc)[0-9]+$` (`2026.x.ya1`, `…b1`, `…rc1`). HACS surfaces those as opt-in pre-releases; unsuffixed `2026.x.y` is the stable channel. Tags do **not** use a `v` prefix (match existing releases such as `2026.8.4`).
+Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release`) sets `prerelease=true` when the tag matches `(a|b|rc)[0-9]+$` (`2026.x.ya1`, `…b1`, `…rc1`). **Enforce release channel** fails the job if a stable tag’s commit is not on `origin/main`. HACS surfaces pre tags as opt-in; unsuffixed `2026.x.y` is the stable channel. Tags do **not** use a `v` prefix (match existing releases such as `2026.8.4`).
 
 #### Commands
 
@@ -80,7 +97,7 @@ Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release
 # Pre-release (alpha / beta / rc) — always before the matching stable
 ./scripts/release.sh 2026.x.y beta
 
-# Stable — only after live smoke on the pre-release
+# Stable — only after live smoke; only from main (not release/*)
 ./scripts/release.sh 2026.x.y
 # or explicitly:
 ./scripts/release.sh 2026.x.y stable

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -59,7 +59,7 @@ Do **not** cut a stable HACS tag until the same version has been smoke-tested as
 | `main` | Stable (`2026.x.y`) and pre (`aN` / `bN` / `rcN`) |
 | `release/YYYY.M` or `release/YYYY.M.N` | Pre only — `release.sh` and the release workflow refuse stable |
 
-`scripts/release.sh` tags the **current** branch (it no longer switches to `main`). Pin `py-bragerone==…` in `manifest.json` to a published library pre-release when testing a train. Ruleset checklist: `.github/branch-protection-checklist.md`.
+`scripts/release.sh` tags the **current** branch (it no longer switches to `main`). The branch tip must already be on the remote. When testing a train, pin `py-bragerone==…` in `manifest.json`, keep `pyproject.toml` / `uv.lock` aligned, and bump `manifest.json` `"version"` to the tag. Ruleset checklist: `.github/branch-protection-checklist.md`.
 
 #### Release checklist (maintainers) — from `main`
 
@@ -81,15 +81,20 @@ Do **not** cut a stable HACS tag until the same version has been smoke-tested as
 
 #### Release train (future work off `main`)
 
-1. `git checkout -b release/2026.9` from `main` and develop there.
-2. Publish library pre on PyPI from the matching `py-bragerone` train, then bump the integration pin / `manifest.json` `"version"`.
-3. From the train branch: `./scripts/release.sh 2026.9.0 rc` (alpha/beta/rc only).
+1. `git checkout -b release/2026.9` from `main`, develop there, then publish the branch:
+
+   ```bash
+   git push -u origin release/2026.9
+   ```
+
+2. Publish library pre on PyPI from the matching `py-bragerone` train, then bump the integration pin in `manifest.json`, `pyproject.toml`, and `uv.lock`, plus `manifest.json` `"version"`.
+3. From the train branch (already pushed): `./scripts/release.sh 2026.9.0 rc` (alpha/beta/rc only).
 4. HACS beta smoke as above.
 5. Open a PR `release/2026.9` → `main`; after merge, cut stable from `main`.
 
 Bump `custom_components/habragerone/manifest.json` `"version"` to the **exact** tag string before tagging (the HACS zip embeds that file).
 
-Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release`) sets `prerelease=true` when the tag matches `(a|b|rc)[0-9]+$` (`2026.x.ya1`, `…b1`, `…rc1`). **Enforce release channel** fails the job if a stable tag’s commit is not on `origin/main`. HACS surfaces pre tags as opt-in; unsuffixed `2026.x.y` is the stable channel. Tags do **not** use a `v` prefix (match existing releases such as `2026.8.4`).
+Tag suffix matters: `.github/workflows/release.yml` (`Detect tag and pre-release`) sets `prerelease=true` when the tag matches `(a|b|rc)[0-9]+$` (`2026.x.ya1`, `…b1`, `…rc1`). **Enforce release channel** fails the job if a stable tag’s commit is not on `origin/main`, or if a pre-release commit is not on `origin/main` / `origin/release/*`. HACS surfaces pre tags as opt-in; unsuffixed `2026.x.y` is the stable channel. Tags do **not** use a `v` prefix (match existing releases such as `2026.8.4`).
 
 #### Commands
 

--- a/docs/PYPI_SETUP.md
+++ b/docs/PYPI_SETUP.md
@@ -1,60 +1,63 @@
 # Release Setup
 
-This project is released through GitHub tags and GitHub Actions.
-It is **not** published to PyPI/TestPyPI.
+This project is released through GitHub tags and GitHub Actions (HACS zip +
+GitHub Release). It is **not** published to PyPI.
 
 > **Note:** This file keeps the legacy name `PYPI_SETUP.md`.
-> It documents GitHub release setup for this repository.
+> Canonical maintainer checklist: [`DEVELOPMENT.md`](../DEVELOPMENT.md) →
+> “Publishing Releases”. Branch/tag rulesets:
+> [`.github/branch-protection-checklist.md`](../.github/branch-protection-checklist.md).
 
 ## Configuration Overview
 
-- **Stable releases** (tags without `a`, `b`, `rc`) -> GitHub Release
-- **Pre-releases** (alpha, beta, rc tags) -> GitHub Pre-release
-- Release assets are attached to the GitHub release page
+- **Stable releases** (tags without `a` / `b` / `rc`) → GitHub Release (HACS default)
+- **Pre-releases** (`aN` / `bN` / `rcN` tags) → GitHub Pre-release (HACS beta)
+- Tags use CalVer **without** a `v` prefix (for example `2026.9.0`, `2026.9.0rc1`)
+- **`main`**: stable and pre-releases
+- **`release/*`**: pre-releases only — merge to `main` before a stable tag
 
 ## Release Process
 
-### Creating releases
-
-You can create tags manually:
+Prefer the helper (tags the **current** branch):
 
 ```bash
-# Stable release
-git tag v2025.1.0
-git push origin v2025.1.0
+# From main or release/YYYY.M — pre-release first
+./scripts/release.sh 2026.9.0 rc
 
-# Pre-release
-git tag v2025.1.0a1   # alpha
-git push origin v2025.1.0a1
+# Stable — only from main, after HACS beta smoke
+./scripts/release.sh 2026.9.0 stable
 ```
 
-Or use the helper script:
+Manual tags (same naming rules):
 
 ```bash
-./scripts/release.sh 2025.1.0
-./scripts/release.sh 2025.1.0 alpha
+git tag -a 2026.9.0rc1 -m "Release 2026.9.0rc1"
+git push origin 2026.9.0rc1
 ```
+
+Bump `custom_components/habragerone/manifest.json` `"version"` to the exact tag
+string before tagging.
 
 ### What happens automatically
 
-1. GitHub Actions starts on tag push
-2. Build artifacts are generated
-3. GitHub release or pre-release is created
-4. Artifacts are uploaded to the release page
+1. CI runs on the tag push
+2. On CI success, the Release workflow builds artifacts and creates a GitHub release
+3. **Enforce release channel** refuses a stable tag unless the commit is on
+   `origin/main`, and refuses a pre-release unless the commit is on `main` or
+   `release/*`
+4. Assets (including `ha-bragerone-hacs.zip`) are attached to the release
 
 ## Versioning
 
-The project uses CalVer-style tags:
-
-- Stable: `vYYYY.M.MICRO` (e.g. `v2025.1.0`)
-- Pre-release: `vYYYY.M.MICROaN`, `vYYYY.M.MICRObN`, `vYYYY.M.MICROrcN`
+- Stable: `YYYY.M.N` (e.g. `2026.9.0`)
+- Pre-release: `YYYY.M.NaN`, `YYYY.M.NbN`, `YYYY.M.NrcN`
 
 ## Troubleshooting
 
 ### Release workflow did not start
 
 - Verify the tag was pushed to `origin`
-- Check GitHub Actions permissions and workflow triggers
+- Confirm CI completed successfully (Release is `workflow_run` after CI)
 
 ### Release exists but no assets
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -42,16 +42,18 @@ Main development workflow helper with various commands:
 ```
 
 ### release.sh
-Release helper that creates and pushes version tags used by the GitHub release workflow.
+Release helper that creates and pushes version tags from the **current** branch
+(`main` or `release/*`). Used by the GitHub release workflow. Stable tags are
+refused on `release/*` — merge to `main` first. See `DEVELOPMENT.md`.
 
 ```bash
-# Stable release tag (2025.1.0)
-./scripts/release.sh 2025.1.0
+# Stable release tag from main (2026.9.0)
+./scripts/release.sh 2026.9.0
 
-# Pre-release tags (2025.1.0a1 / 2025.1.0b1 / 2025.1.0rc1)
-./scripts/release.sh 2025.1.0 alpha
-./scripts/release.sh 2025.1.0 beta
-./scripts/release.sh 2025.1.0 rc
+# Pre-release tags (2026.9.0a1 / 2026.9.0b1 / 2026.9.0rc1)
+./scripts/release.sh 2026.9.0 alpha
+./scripts/release.sh 2026.9.0 beta
+./scripts/release.sh 2026.9.0 rc
 ```
 
 ## Quick Start

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -73,6 +73,10 @@ if [ "$BRANCH" = "HEAD" ]; then
     log_error "Detached HEAD — check out main or a release/* branch before tagging"
     exit 1
 fi
+if [ "$BRANCH" != "main" ] && [[ "$BRANCH" != release/* ]]; then
+    log_error "Releases must be tagged from main or release/* (current: ${BRANCH})"
+    exit 1
+fi
 
 # Exact tag existence (avoid grep regex false positives on CalVer dots).
 tag_exists() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -11,6 +11,8 @@
 #
 # Tag from the current branch (main or release/*). Stable tags are refused
 # on release/* — merge to main first. main may cut both pre and stable.
+# The branch tip must already be on the remote (CI checks origin/main and
+# origin/release/* only).
 #
 # Before tagging a pre-release/stable, bump custom_components/habragerone/manifest.json
 # "version" to the same string as the tag (HACS zip embeds that file).
@@ -22,7 +24,9 @@
 #   ./scripts/release.sh 2026.8.5 alpha  # Early alpha if needed
 #
 # Release trains (pre-only):
-#   git checkout -b release/2026.9 && ./scripts/release.sh 2026.9.0 rc
+#   git checkout -b release/2026.9
+#   git push -u origin release/2026.9
+#   ./scripts/release.sh 2026.9.0 rc
 
 set -e
 
@@ -78,10 +82,55 @@ if [ "$BRANCH" != "main" ] && [[ "$BRANCH" != release/* ]]; then
     exit 1
 fi
 
+# release/* trains may only publish pre-releases (a/b/rc).
+if [[ "$BRANCH" == release/* ]] && [ "$RELEASE_TYPE" = "stable" ]; then
+    log_error "Stable tags are not allowed on ${BRANCH}."
+    log_error "Merge the train into main, then cut the stable tag from main."
+    log_error "From release/* use: alpha, beta, or rc."
+    exit 1
+fi
+
 # Exact tag existence (avoid grep regex false positives on CalVer dots).
 tag_exists() {
     git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1
 }
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+MANIFEST_PATH="$REPO_ROOT/custom_components/habragerone/manifest.json"
+
+# Refresh from upstream before constructing the tag so sequence / manifest
+# checks apply to the tip that will actually be tagged.
+log_info "Fetching origin/${BRANCH}..."
+if ! git fetch origin "refs/heads/${BRANCH}:refs/remotes/origin/${BRANCH}"; then
+    log_error "Could not fetch origin/${BRANCH}."
+    log_error "Push the branch first: git push -u origin ${BRANCH}"
+    exit 1
+fi
+if ! git rev-parse -q --verify "refs/remotes/origin/${BRANCH}" >/dev/null; then
+    log_error "Remote branch origin/${BRANCH} does not exist."
+    log_error "Push the branch first: git push -u origin ${BRANCH}"
+    exit 1
+fi
+
+if git rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1; then
+    log_info "Pulling latest for ${BRANCH}..."
+    git pull --ff-only
+else
+    log_info "Setting upstream to origin/${BRANCH}..."
+    git branch --set-upstream-to="origin/${BRANCH}" "$BRANCH"
+    git pull --ff-only
+fi
+
+# HEAD must already be on the remote tip history (no unpushed commits).
+if ! git merge-base --is-ancestor HEAD "origin/${BRANCH}"; then
+    log_error "Local ${BRANCH} has commits not on origin/${BRANCH}."
+    log_error "Push them first: git push origin ${BRANCH}"
+    exit 1
+fi
+if [ "$(git rev-parse HEAD)" != "$(git rev-parse "origin/${BRANCH}")" ]; then
+    log_error "Local ${BRANCH} is behind origin/${BRANCH} after pull — unexpected state."
+    exit 1
+fi
 
 # Construct tag name based on release type (no "v" prefix — matches existing tags)
 case $RELEASE_TYPE in
@@ -89,7 +138,6 @@ case $RELEASE_TYPE in
         TAG="$VERSION"
         ;;
     alpha)
-        # Find next alpha number
         ALPHA_NUM=1
         while tag_exists "${VERSION}a${ALPHA_NUM}"; do
             ((ALPHA_NUM++))
@@ -97,7 +145,6 @@ case $RELEASE_TYPE in
         TAG="${VERSION}a${ALPHA_NUM}"
         ;;
     beta)
-        # Find next beta number
         BETA_NUM=1
         while tag_exists "${VERSION}b${BETA_NUM}"; do
             ((BETA_NUM++))
@@ -105,7 +152,6 @@ case $RELEASE_TYPE in
         TAG="${VERSION}b${BETA_NUM}"
         ;;
     rc)
-        # Find next rc number
         RC_NUM=1
         while tag_exists "${VERSION}rc${RC_NUM}"; do
             ((RC_NUM++))
@@ -119,15 +165,6 @@ case $RELEASE_TYPE in
         ;;
 esac
 
-# release/* trains may only publish pre-releases (a/b/rc).
-if [[ "$BRANCH" == release/* ]] && [ "$RELEASE_TYPE" = "stable" ]; then
-    log_error "Stable tags are not allowed on ${BRANCH}."
-    log_error "Merge the train into main, then cut the stable tag from main."
-    log_error "From release/* use: alpha, beta, or rc."
-    exit 1
-fi
-
-# Check if tag already exists
 if tag_exists "$TAG"; then
     log_error "Tag $TAG already exists"
     exit 1
@@ -136,8 +173,6 @@ fi
 log_info "Preparing release $TAG ($RELEASE_TYPE) on branch $BRANCH"
 
 # HACS zip embeds manifest.json — version must match the tag.
-REPO_ROOT="$(git rev-parse --show-toplevel)"
-MANIFEST_PATH="$REPO_ROOT/custom_components/habragerone/manifest.json"
 MANIFEST_VERSION="$(python3 -c "import json; print(json.load(open(\"$MANIFEST_PATH\"))[\"version\"])" 2>/dev/null || true)"
 if [ -z "$MANIFEST_VERSION" ]; then
     log_error "Could not read $MANIFEST_PATH version"
@@ -148,14 +183,12 @@ if [ "$MANIFEST_VERSION" != "$TAG" ]; then
     exit 1
 fi
 
-# Show what will be published
 if [ "$RELEASE_TYPE" = "stable" ]; then
     log_info "This will create a stable GitHub release"
 else
     log_info "This will create a GitHub pre-release"
 fi
 
-# Confirm with user
 read -p "Do you want to continue? (y/N) " -n 1 -r
 echo
 if [[ ! $REPLY =~ ^[Yy]$ ]]; then
@@ -163,15 +196,6 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit 0
 fi
 
-# Refresh current branch from its upstream (do not switch branches).
-if git rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1; then
-    log_info "Pulling latest for $BRANCH..."
-    git pull --ff-only
-else
-    log_warn "No upstream for $BRANCH — tagging local tip"
-fi
-
-# Create and push tag
 log_info "Creating tag $TAG..."
 git tag -a "$TAG" -m "Release $TAG"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -9,6 +9,9 @@
 # Tag suffix drives GitHub/HACS channel via .github/workflows/release.yml
 # (tags matching (a|b|rc)[0-9]+$ are marked prerelease=true).
 #
+# Tag from the current branch (main or release/*). Stable tags are refused
+# on release/* — merge to main first. main may cut both pre and stable.
+#
 # Before tagging a pre-release/stable, bump custom_components/habragerone/manifest.json
 # "version" to the same string as the tag (HACS zip embeds that file).
 #
@@ -17,6 +20,9 @@
 #   ./scripts/release.sh 2026.8.5 rc     # Optional RC after beta (2026.8.5rc1)
 #   ./scripts/release.sh 2026.8.5        # Stable only after live smoke (2026.8.5)
 #   ./scripts/release.sh 2026.8.5 alpha  # Early alpha if needed
+#
+# Release trains (pre-only):
+#   git checkout -b release/2026.9 && ./scripts/release.sh 2026.9.0 rc
 
 set -e
 
@@ -62,6 +68,12 @@ if [ -z "$VERSION" ]; then
     exit 1
 fi
 
+BRANCH="$(git rev-parse --abbrev-ref HEAD)"
+if [ "$BRANCH" = "HEAD" ]; then
+    log_error "Detached HEAD — check out main or a release/* branch before tagging"
+    exit 1
+fi
+
 # Exact tag existence (avoid grep regex false positives on CalVer dots).
 tag_exists() {
     git rev-parse -q --verify "refs/tags/$1" >/dev/null 2>&1
@@ -103,13 +115,21 @@ case $RELEASE_TYPE in
         ;;
 esac
 
+# release/* trains may only publish pre-releases (a/b/rc).
+if [[ "$BRANCH" == release/* ]] && [ "$RELEASE_TYPE" = "stable" ]; then
+    log_error "Stable tags are not allowed on ${BRANCH}."
+    log_error "Merge the train into main, then cut the stable tag from main."
+    log_error "From release/* use: alpha, beta, or rc."
+    exit 1
+fi
+
 # Check if tag already exists
 if tag_exists "$TAG"; then
     log_error "Tag $TAG already exists"
     exit 1
 fi
 
-log_info "Preparing release $TAG ($RELEASE_TYPE)"
+log_info "Preparing release $TAG ($RELEASE_TYPE) on branch $BRANCH"
 
 # HACS zip embeds manifest.json — version must match the tag.
 REPO_ROOT="$(git rev-parse --show-toplevel)"
@@ -139,10 +159,13 @@ if [[ ! $REPLY =~ ^[Yy]$ ]]; then
     exit 0
 fi
 
-# Update to latest main branch
-log_info "Updating to latest main branch..."
-git checkout main
-git pull origin main
+# Refresh current branch from its upstream (do not switch branches).
+if git rev-parse --abbrev-ref '@{upstream}' >/dev/null 2>&1; then
+    log_info "Pulling latest for $BRANCH..."
+    git pull --ff-only
+else
+    log_warn "No upstream for $BRANCH — tagging local tip"
+fi
 
 # Create and push tag
 log_info "Creating tag $TAG..."


### PR DESCRIPTION
## Summary
- Add **Enforce release channel** to `release.yml` (same policy as py-bragerone): stables only when the commit is on `main`; pre-releases OK from `release/*`.
- Update `scripts/release.sh` to tag the current branch and refuse `stable` on `release/*`.
- Expand branch/tag protection checklist and document trains in `DEVELOPMENT.md` / `AGENTS.md`.

## Test plan
- [ ] Confirm `release.sh` on a local `release/2026.9` branch rejects `stable` and accepts `rc`
- [ ] Review CI gate messaging in `release.yml`
- [ ] After merge, optionally enable rulesets per `.github/branch-protection-checklist.md`