### PR TITLE
docs: track obfuscated min/max diagnostics (py #329)

### DIFF
--- a/.github/workflows/hacs.yml
+++ b/.github/workflows/hacs.yml
@@ -2,9 +2,9 @@ name: HACS Validation
 
 on:
     push:
-        branches: [main]
+        branches: [main, "release/**"]
     pull_request:
-        branches: [main]
+        branches: [main, "release/**"]
     schedule:
         # Run weekly to catch any HACS requirement changes
         - cron: "0 6 * * 1"

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -48,6 +48,19 @@ CI uploads `coverage.xml` to Codecov (skipped for Dependabot/Renovate and fork P
 
 Issue and PR templates live under `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`. Optional Copilot code review is configured in the GitHub repo settings (not via a workflow).
 
+### Diagnostics: obfuscated `minValue` / `maxValue` strings
+
+Some SPA factory mappings still emit unevaluated expressions in diagnostics dumps
+(for example `_0x…?.['minValue']||[{group,number,use}]`). Everyday Number/Select
+`min`/`max` already come from ParamStore channels `n`/`x` on the primary register,
+so users usually see correct limits.
+
+Catalog-side extraction of those `||` fallbacks is tracked and fixed in
+[py-bragerone#329](https://github.com/marpi82/py-bragerone/issues/329) /
+PR targeting `release/2026.9`. No Home Assistant code change is required for that
+parser fix; bump the `py-bragerone` pin when a matching pre-release from that train
+is published.
+
 ### Publishing Releases
 
 Do **not** cut a stable HACS tag until the same version has been smoke-tested as a HACS **pre-release** on a live Home Assistant install. Tooling already supports this (`scripts/release.sh` + `.github/workflows/release.yml`); skipping the beta/rc step is a process failure, not a tooling gap.


### PR DESCRIPTION
## Summary
- Document that diagnostics may still show SPA `minValue`/`maxValue` expression strings, while HA entity limits already come from ParamStore `n`/`x`.
- Point maintainers at [py-bragerone#329](https://github.com/marpi82/py-bragerone/issues/329) / catalog fix on `release/2026.9` for extracting `||` fallbacks.
- No runtime HA change required for this tracking issue.

Closes #216

## Test plan
- [ ] Docs-only review
- [ ] After py pre-release from the train: bump `py-bragerone` pin in a follow-up