### PR TITLE
feat: module activity history sensor (#223)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -65,6 +65,12 @@ is published.
 
 Per-module diagnostic sensors expose SPA **current** and **history** alarms (`alarm.currentAlarms` / `alarm.historyAlarms`) with state = item count and an `alarms` attribute list (`id`, `name`, `devid`, `created_at`, `finished_at`). Labels come from SPA i18n / `AlarmName` via `pybragerone` (never hardcoded PL/EN). Lists refresh on platform setup and when a module connectivity flip goes online — no blind polling. Requires a `py-bragerone` build that provides `modules_alarms` / `modules_alarms_history` (see library PR #338); older pins skip entity creation.
 
+
+### Module activity sensors (#223)
+
+Per-module diagnostic sensors expose the SPA **Activity** feed (`routes.activity.index`) with state = loaded row count (first page, SPA default `limit=20`) and an `activities` attribute list (`id`, `devid`, `parameter`, `parameter_key`, `value`, `value_raw`, `prev_value`, `prev_value_raw`, `state`, `state_key`, `created_at`, `created_by`). Labels come from SPA i18n (`activity.state.*`, parameters/units via `ParamResolver` / catalog) — never hardcoded PL/EN. Lists refresh on platform setup and when a module connectivity flip goes online — no blind polling. Soft-depends on `py-bragerone` `modules_activity` (library PR #338); older pins skip entity creation.
+
+
 ### Publishing Releases
 
 Do **not** cut a stable HACS tag until the same version has been smoke-tested as a HACS **pre-release** on a live Home Assistant install. Tooling already supports this (`scripts/release.sh` + `.github/workflows/release.yml`); skipping the beta/rc step is a process failure, not a tooling gap.

--- a/custom_components/habragerone/event_feeds.py
+++ b/custom_components/habragerone/event_feeds.py
@@ -1,4 +1,4 @@
-"""Module alarms event-feed sensors (SPA Alarms view — issue #222)."""
+"""Module alarms/activity event-feed sensors (SPA Alarms + Activity — #222/#223)."""
 
 from __future__ import annotations
 
@@ -186,3 +186,143 @@ class BragerAlarmsHistorySensor(_BragerAlarmsFeedSensor):
     """Diagnostic sensor: count + list of finished/historical module alarms."""
 
     _feed_kind = "history"
+
+
+async def iter_activity_feed_entities(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    runtime: BragerRuntime,
+) -> list[SensorEntity]:
+    """Build per-module activity sensors when API + i18n allow it.
+
+    Fail closed when SPA ``routes.activity.index`` cannot be resolved (never
+    hardcode PL/EN entity names). State is the loaded row count (SPA first page,
+    ``limit=20``); ``extra_state_attributes.activities`` holds the structured list.
+    """
+    _ = hass
+    if not runtime.supports_module_activity:
+        return []
+
+    modules_meta = entry.data.get(CONF_MODULES_META)
+    if not isinstance(modules_meta, dict) or not modules_meta:
+        modules_meta = runtime.modules_meta
+    if not isinstance(modules_meta, dict) or not modules_meta:
+        return []
+
+    index_label = await runtime.async_get_activity_index_label()
+    if not isinstance(index_label, str) or not index_label.strip():
+        return []
+
+    devids: list[str] = []
+    module_metas: dict[str, dict[str, Any]] = {}
+    for raw_devid, meta in modules_meta.items():
+        devid = str(raw_devid or "").strip()
+        if not devid:
+            continue
+        devids.append(devid)
+        module_metas[devid] = meta if isinstance(meta, dict) else {}
+
+    for devid in devids:
+        await runtime.async_refresh_activity(devid)
+
+    return [
+        BragerActivitySensor(
+            entry=entry,
+            runtime=runtime,
+            devid=devid,
+            module_meta=module_metas[devid],
+            name=index_label.strip(),
+        )
+        for devid in devids
+    ]
+
+
+class BragerActivitySensor(SensorEntity):
+    """Diagnostic sensor: count + list of module activity (SPA Aktywność) rows."""
+
+    _attr_has_entity_name = True
+    _attr_should_poll = False
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_state_class = SensorStateClass.MEASUREMENT
+
+    def __init__(
+        self,
+        *,
+        entry: ConfigEntry,
+        runtime: BragerRuntime,
+        devid: str,
+        module_meta: dict[str, Any],
+        name: str,
+    ) -> None:
+        """Initialize one diagnostic activity feed sensor for *devid*."""
+        self._entry = entry
+        self._runtime = runtime
+        self._devid = devid
+        self._module_meta = module_meta
+        self._attr_name = name
+        self._attr_unique_id = f"{entry.entry_id}_{devid}_activity".lower().replace(" ", "_")
+        self._attr_suggested_object_id = slugify(f"{devid}_activity")
+        self._attr_native_value = len(self._activities())
+        self._attr_available = True
+        self._unsubscribe_feed: Any = None
+        self._unsubscribe_connectivity: Any = None
+
+    def _activities(self) -> list[dict[str, Any]]:
+        return self._runtime.activity(self._devid)
+
+    @property
+    def device_info(self) -> DeviceInfo:
+        """Attach to the internet module device (same parent as connectivity via_device)."""
+        meta = self._runtime.modules_meta.get(self._devid, self._module_meta)
+        module_name = str(meta.get("name") or self._module_meta.get("name") or self._devid)
+        return DeviceInfo(
+            identifiers={(DOMAIN, self._devid)},
+            manufacturer="BragerOne",
+            name=module_name,
+            model=str(meta.get("title") or self._module_meta.get("title") or module_name),
+            sw_version=str(meta.get("version") or self._module_meta.get("version") or "") or None,
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Expose the structured activities list for automations and dashboards."""
+        return {"activities": self._activities()}
+
+    async def async_added_to_hass(self) -> None:
+        """Subscribe to feed + connectivity; initial list was refreshed at setup."""
+        self._unsubscribe_feed = self._runtime.add_event_feed_listener(self._on_event_feed)
+        self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        self._apply_from_cache()
+        self.async_write_ha_state()
+
+    async def async_will_remove_from_hass(self) -> None:
+        """Detach runtime listeners before entity removal."""
+        if callable(self._unsubscribe_feed):
+            self._unsubscribe_feed()
+            self._unsubscribe_feed = None
+        if callable(self._unsubscribe_connectivity):
+            self._unsubscribe_connectivity()
+            self._unsubscribe_connectivity = None
+
+    async def async_update(self) -> None:
+        """Refresh state from the runtime activity cache (no REST from here)."""
+        self._apply_from_cache()
+
+    def _apply_from_cache(self) -> None:
+        activities = self._activities()
+        self._attr_native_value = len(activities)
+        self._attr_available = module_is_reachable(self._runtime, self._devid)
+
+    def _on_event_feed(self, devid: str) -> None:
+        if devid != self._devid:
+            return
+        self._apply_from_cache()
+        self.async_write_ha_state()
+
+    def _on_connectivity(self, devid: str, online: bool, online_changed: bool = True) -> None:
+        if devid != self._devid:
+            return
+        if online and online_changed:
+            self.hass.async_create_task(self._runtime.async_refresh_activity(self._devid))
+        self._apply_from_cache()
+        self.async_schedule_update_ha_state(False)

--- a/custom_components/habragerone/event_feeds.py
+++ b/custom_components/habragerone/event_feeds.py
@@ -222,8 +222,7 @@ async def iter_activity_feed_entities(
         devids.append(devid)
         module_metas[devid] = meta if isinstance(meta, dict) else {}
 
-    for devid in devids:
-        await runtime.async_refresh_activity(devid)
+    await asyncio.gather(*(runtime.async_refresh_activity(devid) for devid in devids))
 
     return [
         BragerActivitySensor(
@@ -238,7 +237,7 @@ async def iter_activity_feed_entities(
 
 
 class BragerActivitySensor(SensorEntity):
-    """Diagnostic sensor: count + list of module activity (SPA Aktywność) rows."""
+    """Diagnostic sensor: count + list of module activity rows."""
 
     _attr_has_entity_name = True
     _attr_should_poll = False

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -25,11 +25,13 @@ UpdateCallback = Callable[[ParamUpdate], None]
 ConnectivityCallback = Callable[[str, bool, bool], None]
 # library↔cloud Socket.IO session: up, changed.
 CloudSessionCallback = Callable[[bool, bool], None]
-# Module event-feed (alarms) refresh completed for one devid.
+# Module event-feed (alarms / activity) refresh completed for one devid.
 EventFeedCallback = Callable[[str], None]
 LOGGER = logging.getLogger(__name__)
 
 _ALARM_CHROME_KEYS = ("currentAlarms", "historyAlarms")
+_ACTIVITY_PAGE = 1
+_ACTIVITY_LIMIT = 20
 
 
 @dataclass(slots=True)
@@ -62,6 +64,12 @@ class BragerRuntime:
     _alarm_assets_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _alarm_names_loaded: bool = False
     _alarms_refresh_tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
+    _activity: dict[str, list[dict[str, Any]]] = field(default_factory=dict)
+    _activity_index_label: str | None = None
+    _activity_state_i18n: dict[str, str] = field(default_factory=dict)
+    _activity_assets_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    _activity_assets_loaded: bool = False
+    _activity_refresh_tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
 
     async def start(self) -> None:
         """Start gateway, state store ingestion and update dispatcher."""
@@ -134,7 +142,7 @@ class BragerRuntime:
         return _remove
 
     def add_event_feed_listener(self, callback: EventFeedCallback) -> Callable[[], None]:
-        """Register a module alarms/event-feed listener and return unsubscribe callable."""
+        """Register a module alarms/activity event-feed listener and return unsubscribe callable."""
         self._event_feed_listeners.add(callback)
 
         def _remove() -> None:
@@ -349,6 +357,196 @@ class BragerRuntime:
                         }
         except Exception:
             LOGGER.debug("Failed to load AlarmName / errors i18n maps", exc_info=True)
+
+    @property
+    def supports_module_activity(self) -> bool:
+        """Return whether the API client exposes ``modules_activity`` (#223)."""
+        return callable(getattr(self.api, "modules_activity", None))
+
+    def activity(self, devid: str) -> list[dict[str, Any]]:
+        """Return cached activity rows for *devid* (empty when unknown)."""
+        return list(self._activity.get(devid, ()))
+
+    async def async_get_activity_index_label(self) -> str | None:
+        """Return SPA ``routes.activity.index`` entity name, or ``None``.
+
+        Fail closed when catalog/i18n cannot supply the chrome string so the
+        sensor is never created with a hardcoded language fallback.
+        """
+        async with self._activity_assets_lock:
+            if self._activity_assets_loaded:
+                label = self._activity_index_label
+                return label if isinstance(label, str) and label.strip() else None
+            await self._load_activity_assets()
+            self._activity_assets_loaded = True
+            label = self._activity_index_label
+            return label if isinstance(label, str) and label.strip() else None
+
+    async def async_refresh_activity(self, devid: str) -> None:
+        """Fetch first-page activity rows for *devid*, normalize, and notify listeners.
+
+        Uses the SPA default window (``page=1``, ``limit=20``). No-ops when the
+        installed pybragerone build lacks ``modules_activity``. Concurrent
+        refreshes for the same devid share one in-flight task.
+        """
+        devid_key = str(devid or "").strip()
+        if not devid_key or not self.supports_module_activity:
+            return
+
+        existing = self._activity_refresh_tasks.get(devid_key)
+        if existing is not None and not existing.done():
+            await existing
+            return
+
+        task = asyncio.create_task(
+            self._async_refresh_activity_impl(devid_key),
+            name=f"habragerone-activity-{devid_key}",
+        )
+        self._activity_refresh_tasks[devid_key] = task
+        try:
+            await task
+        finally:
+            if self._activity_refresh_tasks.get(devid_key) is task:
+                self._activity_refresh_tasks.pop(devid_key, None)
+
+    async def _async_refresh_activity_impl(self, devid_key: str) -> None:
+        activity_fn = getattr(self.api, "modules_activity", None)
+        if not callable(activity_fn):
+            return
+
+        await self._ensure_activity_assets()
+        resolver = await self._async_get_resolver()
+
+        try:
+            result = await activity_fn(
+                [devid_key],
+                page=_ACTIVITY_PAGE,
+                limit=_ACTIVITY_LIMIT,
+                return_data=True,
+            )
+        except Exception:
+            LOGGER.exception("Failed to refresh module activity for devid=%s", devid_key)
+            return
+
+        rows = _extract_activity_rows(result)
+        self._activity[devid_key] = [
+            await self._normalize_activity_row(row, default_devid=devid_key, resolver=resolver) for row in rows
+        ]
+        self._notify_event_feed_listeners(devid_key)
+
+    async def _ensure_activity_assets(self) -> None:
+        """Best-effort load of activity chrome + ``activity.state.*`` i18n."""
+        async with self._activity_assets_lock:
+            if self._activity_assets_loaded:
+                return
+            try:
+                await self._load_activity_assets()
+            finally:
+                self._activity_assets_loaded = True
+
+    async def _load_activity_assets(self) -> None:
+        """Load ``routes.activity.index`` and ``activity.state`` labels from the catalog."""
+        catalog = _try_live_assets_catalog(self.api)
+        lang = (self.language or "").strip()
+        if catalog is None or not lang:
+            self._activity_index_label = None
+            return
+
+        try:
+            refresh = getattr(catalog, "refresh_index_minimal", None) or getattr(catalog, "refresh_index", None)
+            if callable(refresh):
+                await refresh()
+            get_i18n = getattr(catalog, "get_i18n", None)
+            if not callable(get_i18n):
+                self._activity_index_label = None
+                return
+
+            routes_ns = await get_i18n(lang, "routes")
+            index_label: str | None = None
+            if isinstance(routes_ns, Mapping):
+                activity_routes = routes_ns.get("activity")
+                if isinstance(activity_routes, Mapping):
+                    raw_index = activity_routes.get("index")
+                    if isinstance(raw_index, str) and raw_index.strip():
+                        index_label = raw_index.strip()
+            self._activity_index_label = index_label
+
+            activity_ns = await get_i18n(lang, "activity")
+            state_map: dict[str, str] = {}
+            if isinstance(activity_ns, Mapping):
+                state_ns = activity_ns.get("state")
+                if isinstance(state_ns, Mapping):
+                    for key, value in state_ns.items():
+                        if isinstance(key, str) and isinstance(value, str) and value.strip():
+                            state_map[key.strip()] = value.strip()
+            self._activity_state_i18n = state_map
+        except Exception:
+            LOGGER.debug("Failed to load activity chrome / state i18n", exc_info=True)
+            self._activity_index_label = None
+
+    async def _normalize_activity_row(
+        self,
+        row: Mapping[str, Any],
+        *,
+        default_devid: str,
+        resolver: Any,
+    ) -> dict[str, Any]:
+        """Normalize one REST activity row into the HA attributes shape."""
+        raw_id = row.get("id")
+        activity_id: int | None
+        if isinstance(raw_id, bool):
+            activity_id = None
+        elif isinstance(raw_id, int):
+            activity_id = raw_id
+        elif isinstance(raw_id, float) and raw_id.is_integer():
+            activity_id = int(raw_id)
+        elif isinstance(raw_id, str) and raw_id.strip().isdigit():
+            activity_id = int(raw_id.strip())
+        else:
+            activity_id = None
+
+        devid = _activity_row_devid(row, default_devid=default_devid)
+
+        parameter_key_raw = row.get("name")
+        parameter_key = parameter_key_raw.strip() if isinstance(parameter_key_raw, str) and parameter_key_raw.strip() else None
+        parameter = await _resolve_activity_i18n_token(parameter_key, resolver=resolver)
+
+        unit_code = row.get("unit")
+        value_raw = _activity_value_scalar(row.get("value"))
+        prev_raw = row.get("prev_value")
+        if prev_raw is None:
+            prev_raw = row.get("prevValue")
+        prev_value_raw = _activity_value_scalar(prev_raw)
+
+        value = await _resolve_activity_display_value(value_raw, unit_code=unit_code, resolver=resolver)
+        prev_value = await _resolve_activity_display_value(prev_value_raw, unit_code=unit_code, resolver=resolver)
+
+        state_key_raw = row.get("state")
+        state_key = state_key_raw.strip() if isinstance(state_key_raw, str) and state_key_raw.strip() else None
+        state_label: str | None = None
+        if state_key is not None:
+            mapped = self._activity_state_i18n.get(state_key)
+            if isinstance(mapped, str) and mapped.strip():
+                state_label = mapped.strip()
+
+        created_at = row.get("created_at")
+        created_by_raw = row.get("user")
+        created_by = created_by_raw.strip() if isinstance(created_by_raw, str) and created_by_raw.strip() else None
+
+        return {
+            "id": activity_id,
+            "devid": devid,
+            "parameter": parameter,
+            "parameter_key": parameter_key,
+            "value": value,
+            "value_raw": value_raw,
+            "prev_value": prev_value,
+            "prev_value_raw": prev_value_raw,
+            "state": state_label,
+            "state_key": state_key,
+            "created_at": created_at if isinstance(created_at, str) else None,
+            "created_by": created_by,
+        }
 
     def _seed_module_online_from_gateway(self) -> None:
         """Pull initial online bits from the gateway after start."""
@@ -875,6 +1073,96 @@ def _compare_condition(*, operation: str, actual: Any, expected: Any) -> bool:
     if op == "notEqualTo":
         return bool(actual != expected)
     return False
+
+
+def _extract_activity_rows(result: Any) -> list[Mapping[str, Any]]:
+    """Pull activity row mappings from a ``modules_activity`` ``return_data`` result."""
+    payload: Any = result
+    if isinstance(result, tuple) and len(result) >= 2:
+        payload = result[1]
+    if not isinstance(payload, Mapping):
+        return []
+    activities = payload.get("activities")
+    if isinstance(activities, list):
+        return [row for row in activities if isinstance(row, Mapping)]
+    if isinstance(activities, Mapping):
+        data = activities.get("data")
+        if isinstance(data, list):
+            return [row for row in data if isinstance(row, Mapping)]
+    return []
+
+
+def _activity_row_devid(row: Mapping[str, Any], *, default_devid: str) -> str:
+    """Resolve devid from a row or nested ``module`` object."""
+    row_devid = row.get("devid")
+    if isinstance(row_devid, str) and row_devid.strip():
+        return row_devid.strip()
+    module = row.get("module")
+    if isinstance(module, Mapping):
+        module_devid = module.get("devid")
+        if isinstance(module_devid, str) and module_devid.strip():
+            return module_devid.strip()
+    return default_devid
+
+
+def _activity_value_scalar(raw: Any) -> Any:
+    """Unwrap nested SPA value maps to a display/raw scalar when possible."""
+    if isinstance(raw, Mapping):
+        if "value" in raw:
+            return _activity_value_scalar(raw.get("value"))
+        if "prevValue" in raw:
+            return _activity_value_scalar(raw.get("prevValue"))
+        return None
+    return raw
+
+
+async def _resolve_activity_i18n_token(token: str | None, *, resolver: Any) -> str | None:
+    """Best-effort resolve of dotted i18n tokens via ParamResolver."""
+    if not isinstance(token, str) or not token.strip() or resolver is None:
+        return None
+    resolve_token = getattr(resolver, "_resolve_i18n_token", None)
+    if not callable(resolve_token):
+        return None
+    try:
+        label = await resolve_token(token.strip())
+    except Exception:
+        return None
+    return label.strip() if isinstance(label, str) and label.strip() else None
+
+
+async def _resolve_activity_display_value(raw: Any, *, unit_code: Any, resolver: Any) -> Any:
+    """Map a raw activity value through unit enum tables when possible."""
+    if resolver is None or unit_code is None or raw is None:
+        return raw
+    resolve_unit = getattr(resolver, "resolve_unit", None)
+    if not callable(resolve_unit):
+        return raw
+    try:
+        unit = await resolve_unit(unit_code)
+    except Exception:
+        return raw
+    if not isinstance(unit, Mapping):
+        return raw
+
+    mapping_label = getattr(resolver, "_unit_mapping_value_label", None)
+    label: str | None = None
+    if callable(mapping_label):
+        try:
+            mapped = mapping_label(unit, raw)
+        except Exception:
+            mapped = None
+        if isinstance(mapped, str) and mapped.strip():
+            label = mapped.strip()
+    if label is None:
+        for key in (raw, str(raw)):
+            mapped = unit.get(key)
+            if isinstance(mapped, str) and mapped.strip():
+                label = mapped.strip()
+                break
+    if label is None:
+        return raw
+    resolved = await _resolve_activity_i18n_token(label, resolver=resolver)
+    return resolved or label
 
 
 def _extract_alarm_rows(result: Any) -> list[Mapping[str, Any]]:

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -36,7 +36,7 @@ from .entity_common import (
     get_runtime_and_descriptors,
     record_platform_entity_stats,
 )
-from .event_feeds import iter_alarm_feed_entities
+from .event_feeds import iter_activity_feed_entities, iter_alarm_feed_entities
 from .runtime import BragerRuntime
 from .status_rules import resolve_rule_display_value
 
@@ -52,12 +52,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry, async_add_e
         BragerSymbolSensor(entry=entry, runtime=runtime, descriptor=descriptor) for descriptor in descriptors
     ]
     alarm_entities = await iter_alarm_feed_entities(hass, entry, runtime)
+    activity_entities = await iter_activity_feed_entities(hass, entry, runtime)
     entities.extend(alarm_entities)
+    entities.extend(activity_entities)
     record_platform_entity_stats(
         hass,
         entry,
         platform="sensor",
-        descriptor_count=len(descriptors) + len(alarm_entities),
+        descriptor_count=len(descriptors) + len(alarm_entities) + len(activity_entities),
         created_count=len(entities),
     )
     async_add_entities(entities)

--- a/tests/test_platform_activity.py
+++ b/tests/test_platform_activity.py
@@ -1,0 +1,236 @@
+"""Tests for module activity feed sensors (#223)."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from homeassistant.const import EntityCategory
+from homeassistant.core import HomeAssistant
+
+from tests.conftest import install_pybragerone_stubs
+
+install_pybragerone_stubs()
+
+from custom_components.habragerone.const import (  # noqa: E402
+    CONF_MODULES_META,
+    DATA_ENTITY_STATS,
+    DOMAIN,
+)
+from custom_components.habragerone.event_feeds import (  # noqa: E402
+    BragerActivitySensor,
+    iter_activity_feed_entities,
+)
+from custom_components.habragerone.sensor import async_setup_entry  # noqa: E402
+from tests.helpers.descriptors import sensor_descriptor  # noqa: E402
+from tests.helpers.fakes import FakeApi, make_runtime  # noqa: E402
+from tests.helpers.hass import register_config_entry  # noqa: E402
+
+
+class _ActivityApi(FakeApi):
+    """Fake API with modules_activity list helper."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.calls = 0
+        self.payload: dict[str, Any] = {
+            "status": True,
+            "activities": {
+                "data": [
+                    {
+                        "id": 610249,
+                        "devid": "DEV1",
+                        "name": "parameters.PARAM_219",
+                        "unit": 12,
+                        "value": 0,
+                        "prevValue": 2,
+                        "state": "success",
+                        "created_at": "2026-08-19T18:39:24.000+00:00",
+                        "user": "marpi82",
+                    }
+                ]
+            },
+        }
+
+    async def modules_activity(
+        self,
+        modules: list[str],
+        *,
+        page: int = 1,
+        limit: int = 20,
+        return_data: bool = False,
+    ) -> tuple[int, Any] | bool:
+        self.calls += 1
+        assert modules == ["DEV1"]
+        assert page == 1
+        assert limit == 20
+        return (200, self.payload) if return_data else True
+
+
+def _runtime_with_activity(*, language: str = "en") -> tuple[Any, _ActivityApi]:
+    api = _ActivityApi()
+    runtime, *_rest = make_runtime(api=api, modules_meta={"DEV1": {"name": "Boiler", "title": "DasPell", "version": "V2"}})
+    runtime.language = language
+    runtime._activity_index_label = "Activity"
+    runtime._activity_state_i18n = {"success": "Completed"}
+    runtime._activity_assets_loaded = True
+    return runtime, api
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_activity_normalizes_rows() -> None:
+    runtime, api = _runtime_with_activity()
+    seen: list[str] = []
+    runtime.add_event_feed_listener(seen.append)
+
+    await runtime.async_refresh_activity("DEV1")
+
+    assert api.calls == 1
+    assert seen == ["DEV1"]
+    rows = runtime.activity("DEV1")
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["id"] == 610249
+    assert row["devid"] == "DEV1"
+    assert row["parameter_key"] == "parameters.PARAM_219"
+    assert row["value_raw"] == 0
+    assert row["prev_value_raw"] == 2
+    assert row["state_key"] == "success"
+    assert row["state"] == "Completed"
+    assert row["created_at"] == "2026-08-19T18:39:24.000+00:00"
+    assert row["created_by"] == "marpi82"
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_activity_noops_without_api() -> None:
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    await runtime.async_refresh_activity("DEV1")
+    assert runtime.activity("DEV1") == []
+    assert runtime.supports_module_activity is False
+
+
+@pytest.mark.asyncio
+async def test_iter_activity_feed_entities_fail_closed_without_label(hass: HomeAssistant) -> None:
+    runtime, api = _runtime_with_activity()
+    runtime._activity_index_label = None
+    runtime._activity_assets_loaded = True
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_MODULES_META: {"DEV1": {"name": "Boiler"}}},
+    )
+    entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
+
+    entities = await iter_activity_feed_entities(hass, entry, runtime)
+    assert entities == []
+    assert api.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_iter_and_setup_create_activity_sensor(hass: HomeAssistant) -> None:
+    runtime, api = _runtime_with_activity()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[sensor_descriptor()])
+    hass.config_entries.async_update_entry(
+        entry,
+        data={
+            **entry.data,
+            CONF_MODULES_META: {"DEV1": {"name": "Boiler", "title": "DasPell", "version": "V2"}},
+        },
+    )
+    entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
+
+    added: list[object] = []
+    await async_setup_entry(hass, entry, added.extend)
+
+    activity = [entity for entity in added if isinstance(entity, BragerActivitySensor)]
+    assert len(activity) == 1
+    assert api.calls == 1
+
+    entity = activity[0]
+    assert entity._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert entity._attr_should_poll is False
+    assert entity._attr_has_entity_name is True
+    assert entity._attr_name == "Activity"
+    assert entity._attr_unique_id == f"{entry.entry_id}_dev1_activity"
+    assert entity._attr_native_value == 1
+    attrs = entity.extra_state_attributes
+    assert attrs["activities"][0]["id"] == 610249
+    assert attrs["activities"][0]["parameter_key"] == "parameters.PARAM_219"
+    assert attrs["activities"][0]["state"] == "Completed"
+    assert attrs["activities"][0]["created_by"] == "marpi82"
+
+    info = entity.device_info
+    assert info is not None
+    assert (DOMAIN, "DEV1") in info["identifiers"]
+    assert info.get("manufacturer") == "BragerOne"
+
+    stats = hass.data[DOMAIN][entry.entry_id][DATA_ENTITY_STATS]["sensor"]
+    # 1 descriptor sensor + 1 activity (alarms skipped: no modules_alarms on API)
+    assert stats["created_count"] == 2
+    assert stats["descriptor_count"] == 2
+
+
+@pytest.mark.asyncio
+async def test_activity_sensor_refreshes_when_module_comes_online(hass: HomeAssistant) -> None:
+    runtime, api = _runtime_with_activity()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    entity = BragerActivitySensor(
+        entry=entry,
+        runtime=runtime,
+        devid="DEV1",
+        module_meta={"name": "Boiler"},
+        name="Activity",
+    )
+    entity.hass = hass
+    entity.async_write_ha_state = lambda: None  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = lambda *a, **k: None  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+    assert api.calls == 0
+
+    api.payload = {
+        "status": True,
+        "activities": {
+            "data": [
+                {"id": 1, "devid": "DEV1", "name": "parameters.PARAM_1", "value": 1, "state": "success"},
+                {"id": 2, "devid": "DEV1", "name": "parameters.PARAM_2", "value": 2, "state": "success"},
+            ]
+        },
+    }
+    runtime._module_online["DEV1"] = False
+    entity._on_connectivity("DEV1", True, True)
+    await hass.async_block_till_done()
+    await entity.async_update()
+    assert api.calls >= 1
+    assert entity._attr_native_value == 2
+
+    await entity.async_will_remove_from_hass()
+    assert entity._unsubscribe_feed is None
+    assert entity._unsubscribe_connectivity is None
+
+
+@pytest.mark.asyncio
+async def test_activity_sensor_event_feed_updates_state(hass: HomeAssistant) -> None:
+    runtime, _api = _runtime_with_activity()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    entity = BragerActivitySensor(
+        entry=entry,
+        runtime=runtime,
+        devid="DEV1",
+        module_meta={"name": "Boiler"},
+        name="Activity",
+    )
+    entity.hass = hass
+    entity.async_write_ha_state = lambda: None  # type: ignore[method-assign]
+    entity.async_schedule_update_ha_state = lambda *a, **k: None  # type: ignore[method-assign]
+
+    await entity.async_added_to_hass()
+    runtime._activity["DEV1"] = [
+        {"id": 1, "devid": "DEV1", "parameter_key": "parameters.PARAM_1"},
+        {"id": 2, "devid": "DEV1", "parameter_key": "parameters.PARAM_2"},
+        {"id": 3, "devid": "DEV1", "parameter_key": "parameters.PARAM_3"},
+    ]
+    entity._on_event_feed("DEV1")
+    assert entity._attr_native_value == 3
+    entity._on_event_feed("OTHER")
+    assert entity._attr_native_value == 3

--- a/tests/test_platform_activity.py
+++ b/tests/test_platform_activity.py
@@ -24,7 +24,11 @@ from custom_components.habragerone.event_feeds import (  # noqa: E402
     BragerActivitySensor,
     iter_activity_feed_entities,
 )
-from custom_components.habragerone.runtime import _extract_activity_rows  # noqa: E402
+from custom_components.habragerone.runtime import (  # noqa: E402
+    _activity_row_devid,
+    _activity_value_scalar,
+    _extract_activity_rows,
+)
 from custom_components.habragerone.sensor import async_setup_entry  # noqa: E402
 from tests.helpers.descriptors import sensor_descriptor  # noqa: E402
 from tests.helpers.fakes import FakeApi, make_runtime  # noqa: E402
@@ -296,3 +300,61 @@ async def test_async_get_activity_index_label_loads_from_catalog(monkeypatch: py
     runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
     runtime.language = "en"
     assert await runtime.async_get_activity_index_label() == "Activity"
+
+
+def test_activity_row_devid_and_value_scalar_helpers() -> None:
+    """Row devid falls back to module.devid; nested value maps unwrap."""
+    assert _activity_row_devid({"module": {"devid": "M1"}}, default_devid="DEV1") == "M1"
+    assert _activity_row_devid({}, default_devid="DEV1") == "DEV1"
+    assert _activity_value_scalar({"value": {"prevValue": 3}}) == 3
+    assert _activity_value_scalar({"other": 1}) is None
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_activity_noops_on_blank_devid() -> None:
+    """Whitespace devids are ignored."""
+    runtime, api = _runtime_with_activity()
+    await runtime.async_refresh_activity("  ")
+    assert api.calls == 0
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_activity_logs_api_failures() -> None:
+    """REST failures are logged and leave caches empty."""
+    runtime, api = _runtime_with_activity()
+
+    async def boom(*_a: object, **_k: object) -> tuple[int, Any]:
+        raise RuntimeError("network down")
+
+    api.modules_activity = boom  # type: ignore[method-assign]
+    await runtime.async_refresh_activity("DEV1")
+    assert runtime.activity("DEV1") == []
+
+
+@pytest.mark.asyncio
+async def test_load_activity_assets_fail_closed_without_language(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing language prevents activity chrome from loading."""
+    catalog = types.SimpleNamespace(refresh_index=AsyncMock(), get_i18n=AsyncMock())
+    monkeypatch.setattr(
+        "custom_components.habragerone.runtime._try_live_assets_catalog",
+        lambda _api: catalog,
+    )
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    runtime.language = None
+    assert await runtime.async_get_activity_index_label() is None
+    catalog.get_i18n.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_iter_activity_feed_entities_skips_blank_devids(hass: HomeAssistant) -> None:
+    """Blank module keys in modules_meta are ignored."""
+    runtime, api = _runtime_with_activity()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_MODULES_META: {"": {"name": "Empty"}, "DEV1": {"name": "Boiler"}}},
+    )
+    entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
+    entities = await iter_activity_feed_entities(hass, entry, runtime)
+    assert len(entities) == 1
+    assert api.calls == 1

--- a/tests/test_platform_activity.py
+++ b/tests/test_platform_activity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import pytest
@@ -21,6 +22,7 @@ from custom_components.habragerone.event_feeds import (  # noqa: E402
     BragerActivitySensor,
     iter_activity_feed_entities,
 )
+from custom_components.habragerone.runtime import _extract_activity_rows  # noqa: E402
 from custom_components.habragerone.sensor import async_setup_entry  # noqa: E402
 from tests.helpers.descriptors import sensor_descriptor  # noqa: E402
 from tests.helpers.fakes import FakeApi, make_runtime  # noqa: E402
@@ -234,3 +236,40 @@ async def test_activity_sensor_event_feed_updates_state(hass: HomeAssistant) -> 
     assert entity._attr_native_value == 3
     entity._on_event_feed("OTHER")
     assert entity._attr_native_value == 3
+
+
+def test_extract_activity_rows_handles_list_and_nested_shapes() -> None:
+    """REST payloads may expose activities as a list or ``{data: [...]}`` mapping."""
+    list_payload = (200, {"activities": [{"id": 1}]})
+    nested_payload = (200, {"activities": {"data": [{"id": 2}]}})
+    assert _extract_activity_rows(list_payload) == [{"id": 1}]
+    assert _extract_activity_rows(nested_payload) == [{"id": 2}]
+    assert _extract_activity_rows((200, {"activities": "bad"})) == []
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_activity_dedupes_concurrent_tasks() -> None:
+    """Parallel refreshes for one devid share a single in-flight task."""
+    runtime, api = _runtime_with_activity()
+
+    async def slow_activity(*_args: Any, **kwargs: Any) -> tuple[int, Any] | bool:
+        await asyncio.sleep(0.05)
+        api.calls += 1
+        return (200, api.payload) if kwargs.get("return_data") else True
+
+    api.modules_activity = slow_activity  # type: ignore[method-assign]
+    await asyncio.gather(runtime.async_refresh_activity("DEV1"), runtime.async_refresh_activity("DEV1"))
+    assert api.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_iter_activity_feed_entities_fail_closed_without_api(hass: HomeAssistant) -> None:
+    """No entities when the API client lacks activity helpers."""
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    hass.config_entries.async_update_entry(
+        entry,
+        data={**entry.data, CONF_MODULES_META: {"DEV1": {"name": "Boiler"}}},
+    )
+    entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
+    assert await iter_activity_feed_entities(hass, entry, runtime) == []

--- a/tests/test_platform_activity.py
+++ b/tests/test_platform_activity.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+import types
 from typing import Any
+from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.const import EntityCategory
@@ -273,3 +275,24 @@ async def test_iter_activity_feed_entities_fail_closed_without_api(hass: HomeAss
     )
     entry = hass.config_entries.async_get_entry(entry.entry_id) or entry
     assert await iter_activity_feed_entities(hass, entry, runtime) == []
+
+
+@pytest.mark.asyncio
+async def test_async_get_activity_index_label_loads_from_catalog(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Activity index label is fetched from routes + i18n when not cached."""
+    catalog = types.SimpleNamespace(
+        refresh_index=AsyncMock(),
+        get_i18n=AsyncMock(
+            side_effect=[
+                {"activity": {"index": " Activity "}},
+                {"state": {"success": "Completed"}},
+            ]
+        ),
+    )
+    monkeypatch.setattr(
+        "custom_components.habragerone.runtime._try_live_assets_catalog",
+        lambda _api: catalog,
+    )
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    runtime.language = "en"
+    assert await runtime.async_get_activity_index_label() == "Activity"


### PR DESCRIPTION
## Summary
- Per-module diagnostic **Activity** sensor (SPA Aktywność): state = loaded row count (page 1, limit 20), `activities` attribute list.
- Labels from SPA i18n only (`routes.activity.index`, `activity.state.*`, parameter/unit resolve when available).
- Refresh on setup + module online; soft-depends on [py-bragerone#338](https://github.com/marpi82/py-bragerone/pull/338) `modules_activity`.

**Merge order:** land [ha#226](https://github.com/marpi82/ha-bragerone/pull/226) first (shared event-feed runtime). This branch currently contains #226 commits — after #226 merges into `release/2026.9`, rebase this branch onto the train tip to leave only the activity commit.

Closes #223

## Test plan
- [x] `pytest tests/test_platform_activity.py tests/test_platform_alarms.py`
- [ ] Live smoke with local py-bragerone from the release train (read-only)
- [ ] CI green