### PR TITLE
fix: drop measurement state_class from alarm/activity feed sensors

### DIFF
--- a/custom_components/habragerone/event_feeds.py
+++ b/custom_components/habragerone/event_feeds.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import asyncio
 from typing import Any
 
-from homeassistant.components.sensor import SensorEntity, SensorStateClass
+from homeassistant.components.sensor import SensorEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import EntityCategory
 from homeassistant.core import HomeAssistant
@@ -88,7 +88,6 @@ class _BragerAlarmsFeedSensor(SensorEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_state_class = SensorStateClass.MEASUREMENT
     _feed_kind: str
 
     def __init__(
@@ -242,7 +241,6 @@ class BragerActivitySensor(SensorEntity):
     _attr_has_entity_name = True
     _attr_should_poll = False
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_state_class = SensorStateClass.MEASUREMENT
 
     def __init__(
         self,

--- a/tests/test_platform_activity.py
+++ b/tests/test_platform_activity.py
@@ -156,6 +156,7 @@ async def test_iter_and_setup_create_activity_sensor(hass: HomeAssistant) -> Non
 
     entity = activity[0]
     assert entity._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert getattr(entity, "_attr_state_class", None) is None
     assert entity._attr_should_poll is False
     assert entity._attr_has_entity_name is True
     assert entity._attr_name == "Activity"

--- a/tests/test_platform_alarms.py
+++ b/tests/test_platform_alarms.py
@@ -183,6 +183,7 @@ async def test_iter_and_setup_create_alarm_sensors(hass: HomeAssistant) -> None:
 
     entity = current[0]
     assert entity._attr_entity_category == EntityCategory.DIAGNOSTIC
+    assert getattr(entity, "_attr_state_class", None) is None
     assert entity._attr_should_poll is False
     assert entity._attr_has_entity_name is True
     assert entity._attr_name == "Current alarms"


### PR DESCRIPTION
## Summary
- Remove `state_class: measurement` from alarm (current/history) and activity feed sensors.
- State remains the loaded row count; `alarms` / `activities` stay in attributes.

## Why
`measurement` makes HA show a statistics/history chart in more-info and hides the attribute list users care about. These entities are snapshot feeds, not chart metrics.

## Test plan
- [x] `uv run poe test tests/test_platform_alarms.py tests/test_platform_activity.py`
- [ ] After a future beta: more-info shows attributes without dominating history chart

## Release
Merge to `release/2026.9`; tag later with the next train beta (not in this PR).