### PR TITLE
fix(activity): map prevValue scalar and nested user.name

### DIFF
--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -506,9 +506,12 @@ class BragerRuntime:
 
         unit_code = row.get("unit")
         value_raw = _activity_value_scalar(row.get("value"))
-        prev_raw = row.get("prev_value")
+        # Live SPA rows expose the scalar previous value as camelCase ``prevValue``.
+        # Snake-case ``prev_value`` is a nested param snapshot (``{P*: {n: {v,u}}}``),
+        # not the display scalar — prefer camelCase, then fall back.
+        prev_raw = row.get("prevValue")
         if prev_raw is None:
-            prev_raw = row.get("prevValue")
+            prev_raw = row.get("prev_value")
         prev_value_raw = _activity_value_scalar(prev_raw)
 
         value = await _resolve_activity_display_value(value_raw, unit_code=unit_code, resolver=resolver)
@@ -523,8 +526,7 @@ class BragerRuntime:
                 state_label = mapped.strip()
 
         created_at = row.get("created_at")
-        created_by_raw = row.get("user")
-        created_by = created_by_raw.strip() if isinstance(created_by_raw, str) and created_by_raw.strip() else None
+        created_by = _activity_created_by(row.get("user"))
 
         return {
             "id": activity_id,
@@ -1099,14 +1101,38 @@ def _activity_row_devid(row: Mapping[str, Any], *, default_devid: str) -> str:
 
 
 def _activity_value_scalar(raw: Any) -> Any:
-    """Unwrap nested SPA value maps to a display/raw scalar when possible."""
+    """Unwrap nested SPA value maps to a display/raw scalar when possible.
+
+    Handles:
+    - plain scalars
+    - ``{"value": ...}`` / ``{"prevValue": ...}`` wrappers
+    - nested param snapshots ``{"P6": {"219": {"v": 2, "u": 38}}}``
+    """
     if isinstance(raw, Mapping):
         if "value" in raw:
             return _activity_value_scalar(raw.get("value"))
         if "prevValue" in raw:
             return _activity_value_scalar(raw.get("prevValue"))
+        if "v" in raw:
+            return _activity_value_scalar(raw.get("v"))
+        for nested in raw.values():
+            if isinstance(nested, Mapping):
+                extracted = _activity_value_scalar(nested)
+                if extracted is not None:
+                    return extracted
         return None
     return raw
+
+
+def _activity_created_by(raw: Any) -> str | None:
+    """Extract the activity author label from a string or ``{name, id}`` user object."""
+    if isinstance(raw, str):
+        return raw.strip() or None
+    if isinstance(raw, Mapping):
+        name = raw.get("name")
+        if isinstance(name, str) and name.strip():
+            return name.strip()
+    return None
 
 
 async def _resolve_activity_i18n_token(token: str | None, *, resolver: Any) -> str | None:

--- a/tests/test_platform_activity.py
+++ b/tests/test_platform_activity.py
@@ -25,6 +25,7 @@ from custom_components.habragerone.event_feeds import (  # noqa: E402
     iter_activity_feed_entities,
 )
 from custom_components.habragerone.runtime import (  # noqa: E402
+    _activity_created_by,
     _activity_row_devid,
     _activity_value_scalar,
     _extract_activity_rows,
@@ -47,14 +48,19 @@ class _ActivityApi(FakeApi):
                 "data": [
                     {
                         "id": 610249,
-                        "devid": "DEV1",
+                        "module": {"devid": "DEV1", "id": 302},
+                        "module_id": 302,
                         "name": "parameters.PARAM_219",
-                        "unit": 12,
+                        "unit": 38,
                         "value": 0,
+                        # Scalar previous value (SPA camelCase). Snake-case
+                        # ``prev_value`` is a nested param snapshot — must not win.
                         "prevValue": 2,
+                        "prev_value": {"P6": {"219": {"v": 2, "u": 38}}},
                         "state": "success",
                         "created_at": "2026-08-19T18:39:24.000+00:00",
-                        "user": "marpi82",
+                        "user": {"name": "marpi82", "id": 861},
+                        "user_id": 861,
                     }
                 ]
             },
@@ -334,6 +340,33 @@ def test_activity_row_devid_and_value_scalar_helpers() -> None:
     assert _activity_row_devid({}, default_devid="DEV1") == "DEV1"
     assert _activity_value_scalar({"value": {"prevValue": 3}}) == 3
     assert _activity_value_scalar({"other": 1}) is None
+    assert _activity_value_scalar({"P6": {"219": {"v": 2, "u": 38}}}) == 2
+    assert _activity_created_by({"name": "marpi82", "id": 861}) == "marpi82"
+    assert _activity_created_by("alice") == "alice"
+    assert _activity_created_by({"id": 1}) is None
+    assert _activity_created_by(None) is None
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_activity_prefers_prevvalue_over_nested_snapshot() -> None:
+    """When both prevValue and nested prev_value exist, use the scalar."""
+    runtime, api = _runtime_with_activity()
+    api.payload["activities"]["data"][0]["prevValue"] = 7
+    api.payload["activities"]["data"][0]["prev_value"] = {"P6": {"219": {"v": 99, "u": 38}}}
+    await runtime.async_refresh_activity("DEV1")
+    row = runtime.activity("DEV1")[0]
+    assert row["prev_value_raw"] == 7
+
+
+@pytest.mark.asyncio
+async def test_async_refresh_activity_falls_back_to_nested_prev_value() -> None:
+    """Without camelCase prevValue, dig the nested param snapshot for ``v``."""
+    runtime, api = _runtime_with_activity()
+    row0 = api.payload["activities"]["data"][0]
+    del row0["prevValue"]
+    row0["prev_value"] = {"P6": {"219": {"v": 5, "u": 38}}}
+    await runtime.async_refresh_activity("DEV1")
+    assert runtime.activity("DEV1")[0]["prev_value_raw"] == 5
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Prefer SPA camelCase `prevValue` for activity previous values; snake-case `prev_value` is a nested param snapshot and was incorrectly winning → `null`.
- Read `created_by` from `user.name` when the API returns `{id, name}` (live shape), not only a bare string.
- Tests updated to the live `modules/activity` payload shape.

Depends on / pairs with the py-bragerone 2026.9 train beta that documents the same contract. After that beta is on PyPI, follow up with a pin bump to `2026.9.0b3` and HA pre-release `2026.9.0b3`.

## Test plan
- [x] `uv run poe test -- tests/test_platform_activity.py`
- [ ] CI green on `release/2026.9`
- [ ] After merge + py pin: activity rows show `prev_value*` and `created_by` matching the SPA