### PR TITLE
fix: Strefy czasowe menu bootstrap + runtime visibility (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This custom component provides integration between Home Assistant and the Brager
 - Per-module cloud connectivity diagnostic (SPA `connectedAt` / `module.connection.*` labels) on the **internet-module** device together with alarms/activity diagnostics — in **flat** mode all entities share that device; in **group-by-menu** mode parameter entities sit on menu child devices (`via_device`) while connectivity, alarms, and activity stay on the parent module device. Parameter entities go unavailable when the module is offline; writes are refused while offline. Module offline is observe-only (wait for the plant to reconnect).
 - Separate **Cloud API session** diagnostic (library↔cloud Socket.IO) on a config-entry service device — detectable and self-healing; never folded into module `connectedAt`. Config-entry diagnostics include `last_param_update_age_s` (seconds since the last parameter snapshot/delta) to distinguish a live session from a frozen push stream.
 - Optional device grouping by menu (options: flat default vs group-by-menu child devices per **parent** menu route with `via_device`)
+- Everyday-UI menu routes (including static SPA shells such as **Strefy czasowe**) map to panel groups and, in group-by-menu mode, child devices; UI-route entities respect SPA route visibility at runtime (`available`) without changing entity-registry enable state
 
 ## Installation
 
@@ -52,6 +53,8 @@ The integration can be configured through the Home Assistant UI. You will need:
 - BragerOne / TiSConnect credentials and backend platform
 - Installation and module selection
 - Device grouping (flat = one HA device per internet module for parameters, connectivity, alarms, and activity; group by menu = parameter entities on child devices per **parent** menu route with `via_device`, while connectivity/alarms/activity stay on the parent module — remaps device membership when changed).
+
+After upgrading to a release that bumps `BOOTSTRAP_VERSION` (currently **13** for static menu routes / #192), reload the integration or re-add it so entity descriptors pick up new menu metadata.
 
 Every permission-gated parameter becomes an entity — there is no separate UI/permissions filtering mode to choose. Entities that are outside the everyday BragerOne web UI (installer-only panels, or panels the SPA itself hides) are still created, but start **disabled** in the entity registry; enable them manually if you need them. Enable/disable state can be changed per-entity at any time from the entity registry.
 

--- a/custom_components/habragerone/__init__.py
+++ b/custom_components/habragerone/__init__.py
@@ -150,6 +150,11 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         modules_meta={str(k): dict(v) for k, v in modules_meta.items()} if isinstance(modules_meta, dict) else {},
         language=language,
     )
+    descriptor_sources: list[Any] = list(descriptors) if isinstance(descriptors, list) else []
+    connection_descriptors = entry.data.get(CONF_CONNECTION_DESCRIPTORS)
+    if isinstance(connection_descriptors, list):
+        descriptor_sources.extend(connection_descriptors)
+    runtime.register_route_visibility(descriptor_sources)
     await runtime.start()
 
     entry.async_on_unload(entry.add_update_listener(_async_update_listener))
@@ -162,11 +167,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         DATA_RUNTIME: runtime,
         CONF_ENTITY_DESCRIPTORS: descriptors,
     }
-
-    descriptor_sources: list[Any] = list(descriptors) if isinstance(descriptors, list) else []
-    connection_descriptors = entry.data.get(CONF_CONNECTION_DESCRIPTORS)
-    if isinstance(connection_descriptors, list):
-        descriptor_sources.extend(connection_descriptors)
 
     await async_register_module_parent_devices(
         hass,

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -19,6 +19,7 @@ from .const import (
     DOMAIN,
 )
 from .entity_common import (
+    attach_route_visibility_listener,
     descriptor_current_raw_value,
     descriptor_display_name,
     descriptor_enabled_by_default,
@@ -125,6 +126,7 @@ class BragerStatusBinarySensor(BinarySensorEntity):
         self._refresh_keys = descriptor_refresh_keys(descriptor)
         self._unsubscribe_listener: Any = None
         self._unsubscribe_connectivity: Any = None
+        self._unsubscribe_route_visibility: Any = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -139,6 +141,12 @@ class BragerStatusBinarySensor(BinarySensorEntity):
         """Attach runtime listeners when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
         self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        self._unsubscribe_route_visibility = attach_route_visibility_listener(
+            self._runtime,
+            devid=self._devid,
+            descriptor=self._descriptor,
+            schedule_update=lambda: self.async_schedule_update_ha_state(True),
+        )
         raw_value = descriptor_current_raw_value(self._runtime.store, self._descriptor)
         if raw_value is not None and self._try_apply_binary_state_sync(raw_value):
             self._attr_available = entity_is_available(
@@ -201,6 +209,9 @@ class BragerStatusBinarySensor(BinarySensorEntity):
         if callable(self._unsubscribe_connectivity):
             self._unsubscribe_connectivity()
             self._unsubscribe_connectivity = None
+        if callable(self._unsubscribe_route_visibility):
+            self._unsubscribe_route_visibility()
+            self._unsubscribe_route_visibility = None
 
     async def async_update(self) -> None:
         """Refresh state from ParamStore / SPA status resolver."""

--- a/custom_components/habragerone/binary_sensor.py
+++ b/custom_components/habragerone/binary_sensor.py
@@ -145,6 +145,7 @@ class BragerStatusBinarySensor(BinarySensorEntity):
                 self._runtime,
                 devid=self._devid,
                 has_value=True,
+                descriptor=self._descriptor,
             )
             self.async_write_ha_state()
             return
@@ -153,6 +154,7 @@ class BragerStatusBinarySensor(BinarySensorEntity):
                 self._runtime,
                 devid=self._devid,
                 has_value=raw_value is not None or self._runtime.peek_status_label(self._symbol) is not None,
+                descriptor=self._descriptor,
             )
             self.async_write_ha_state()
             return
@@ -207,6 +209,7 @@ class BragerStatusBinarySensor(BinarySensorEntity):
             self._runtime,
             devid=self._devid,
             has_value=raw_value is not None,
+            descriptor=self._descriptor,
         )
         if raw_value is None:
             return

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -18,6 +18,10 @@ from .const import (
     CONF_OPTIONS,
     CONF_PLATFORM,
     CONF_RAW_TO_LABEL,
+    CONF_ROUTE_VISIBILITY_DEPS,
+    CONF_ROUTE_VISIBILITY_NAME,
+    CONF_ROUTE_VISIBILITY_PATH,
+    CONF_UI_ROUTE_SYMBOL,
     CONF_UPSTREAM_ASSETS_FINGERPRINT,
     CONNECTION_MENU_KEY,
     DEFAULT_ENTITY_FILTER_MODE,
@@ -65,6 +69,10 @@ class EntityDescriptor(TypedDict, total=False):
     raw_to_label: dict[str, str]
     menu_kinds: list[str]
     enabled_by_default: bool
+    ui_route_symbol: bool
+    route_visibility_deps: list[str]
+    route_visibility_name: str
+    route_visibility_path: str
 
 
 _SWITCHISH_RULE_VALUES = {"0", "1", "true", "false", "on", "off", "enabled", "disabled", "yes", "no"}
@@ -578,6 +586,100 @@ def _stable_menu_key_from_route_meta(routes: list[dict[str, Any]]) -> str | None
     return None
 
 
+def _enrich_symbol_routes_from_shell_diagnostics(
+    panel_paths: dict[str, str],
+    symbol_routes: dict[str, list[dict[str, Any]]],
+    diagnostics: list[dict[str, Any]],
+) -> None:
+    """Attach panel-shell route meta to symbols that only appear via static overlays (#192)."""
+    shell_by_panel: dict[str, dict[str, Any]] = {}
+    for row in diagnostics:
+        if not isinstance(row, dict) or not bool(row.get("panel_shell")):
+            continue
+        if not bool(row.get("accepted")):
+            continue
+        panel_title = str(row.get("panel_title") or row.get("title") or "").strip()
+        if panel_title:
+            shell_by_panel[panel_title] = row
+        title = str(row.get("title") or "").strip()
+        if title:
+            shell_by_panel.setdefault(title, row)
+
+    for symbol, panel_path in panel_paths.items():
+        if symbol_routes.get(symbol):
+            continue
+        normalized = _normalize_panel_path(panel_path)
+        if not normalized:
+            continue
+        shell_row = shell_by_panel.get(normalized)
+        if shell_row is None:
+            continue
+        symbol_routes.setdefault(symbol, []).append(
+            {
+                "name": shell_row.get("name"),
+                "path": shell_row.get("path"),
+                "display_name": shell_row.get("title"),
+                "is_visible_on_side_menu": shell_row.get("is_visible_on_side_menu"),
+                "display_dropdown": shell_row.get("display_dropdown"),
+                "component": shell_row.get("component"),
+                "ancestors": [],
+            }
+        )
+
+
+def _route_dep_index_from_menu(menu: Any) -> dict[tuple[str, str], list[str]]:
+    """Map ``(route name, route path)`` to route-visibility dependency keys."""
+    from pybragerone.models.param_resolver import ParamResolver
+
+    index: dict[tuple[str, str], list[str]] = {}
+    routes = _get_field(menu, "routes") or []
+    for route, ancestors in ParamResolver._iter_routes_with_ancestors(routes):
+        name = str(getattr(route, "name", "") or "")
+        path = str(getattr(route, "path", "") or "")
+        deps = sorted(ParamResolver.route_visibility_dependency_keys(route, ancestors=ancestors))
+        if name or path:
+            index[(name, path)] = deps
+    return index
+
+
+def _route_visibility_deps_for_symbol(
+    routes: list[dict[str, Any]],
+    route_dep_index: Mapping[tuple[str, str], list[str]],
+    *,
+    payload: Mapping[str, Any] | None,
+    flat_values: Mapping[str, Any],
+) -> list[str]:
+    """Collect ParamStore keys that may affect route visibility for *symbol*."""
+    from pybragerone.models.param_resolver import ParamResolver
+
+    deps: set[str] = set()
+    for route in routes:
+        name = str(route.get("name") or "")
+        path = str(route.get("path") or "")
+        for dep in route_dep_index.get((name, path), []):
+            deps.add(dep)
+    if payload is not None:
+        mapping = payload.get("mapping")
+        if isinstance(mapping, Mapping):
+            for entry in ParamResolver._status_paths_for_visibility(mapping, flat_values):
+                group = entry.get("group")
+                use = entry.get("use")
+                number = entry.get("number")
+                if isinstance(group, str) and isinstance(use, str) and isinstance(number, int):
+                    deps.add(f"{group}.{use}{number}")
+    return sorted(deps)
+
+
+def _primary_route_identity(routes: list[dict[str, Any]]) -> tuple[str, str]:
+    """Return the first usable route ``(name, path)`` tuple from route meta."""
+    for route in routes:
+        name = str(route.get("name") or "").strip()
+        path = str(route.get("path") or "").strip()
+        if name or path:
+            return name, path
+    return "", ""
+
+
 def _menu_keys_by_panel_path(
     panel_paths: dict[str, str],
     symbol_routes: dict[str, list[dict[str, Any]]],
@@ -892,6 +994,7 @@ async def _build_permission_gated_panel_groups(
     devid: str,
     web_ui_only: bool = False,
     warn_if_empty: bool = True,
+    flat_values: Mapping[str, Any] | None = None,
 ) -> dict[str, list[str]]:
     """Build panel groups for *permissions* only — never retry with ``permissions=None``.
 
@@ -912,6 +1015,8 @@ async def _build_permission_gated_panel_groups(
         warn_if_empty: When True, log a warning if the result is empty. Callers pass
             False for the ``web_ui_only=True`` UI-route probe, where an empty result
             just means the module has no everyday-UI routes (not a discovery failure).
+        flat_values: Optional flattened prime values for runtime-aware route visibility
+            during panel group construction (#192).
 
     Returns:
         Mapping of panel name to symbols (possibly empty).
@@ -923,6 +1028,7 @@ async def _build_permission_gated_panel_groups(
             permissions=permissions,
             all_panels=True,
             web_ui_only=web_ui_only,
+            flat_values=flat_values,
         ),
     )
     if warn_if_empty and not _panel_group_symbols(groups):
@@ -1046,12 +1152,14 @@ async def async_build_bootstrap_payload(
         if st in (200, 204) and isinstance(data, dict):
             store.ingest_prime_payload(data)
 
+    flat_values = store.flatten()
     per_module_candidate_symbols: dict[str, set[str]] = {}
     per_module_panel_paths: dict[str, dict[str, str]] = {}
     per_module_ui_route_symbols: dict[str, set[str]] = {}
     per_module_symbol_kinds: dict[str, dict[str, set[str]]] = {}
     per_module_symbol_routes: dict[str, dict[str, list[dict[str, Any]]]] = {}
     per_module_route_diagnostics: dict[str, list[dict[str, Any]]] = {}
+    per_module_route_dep_index: dict[str, dict[tuple[str, str], list[str]]] = {}
     all_candidate_symbols: set[str] = set()
     bootstrap_debug: dict[str, Any] = {"modules": {}, "limits": {"max_rejections_per_module": 500}}
 
@@ -1067,6 +1175,7 @@ async def async_build_bootstrap_payload(
             permissions=module_permissions,
             devid=str(module.devid),
             web_ui_only=False,
+            flat_values=flat_values,
         )
         symbols = _panel_group_symbols(groups)
         for panel_name, panel_symbols in groups.items():
@@ -1087,6 +1196,7 @@ async def async_build_bootstrap_payload(
             devid=str(module.devid),
             web_ui_only=True,
             warn_if_empty=False,
+            flat_values=flat_values,
         )
         per_module_ui_route_symbols[module.devid] = _panel_group_symbols(ui_groups)
 
@@ -1095,17 +1205,26 @@ async def async_build_bootstrap_payload(
         per_module_symbol_kinds[module.devid] = {}
         per_module_symbol_routes[module.devid] = {}
         per_module_route_diagnostics[module.devid] = []
+        module_route_dep_index: dict[tuple[str, str], list[str]] = {}
         assets = getattr(resolver, "_assets", None)
         if assets is not None and hasattr(assets, "get_module_menu"):
             try:
                 menu = await assets.get_module_menu(device_menu=module.deviceMenu, permissions=module_permissions)
                 per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu)
                 per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu)
+                module_route_dep_index = _route_dep_index_from_menu(menu)
+                routes_i18n = await resolver._i18n.get_namespace("routes")
                 per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
                     menu,
                     all_panels=True,
                     web_ui_only=False,
-                    routes_i18n=await resolver._i18n.get_namespace("routes"),
+                    routes_i18n=routes_i18n,
+                    flat_values=flat_values,
+                )
+                _enrich_symbol_routes_from_shell_diagnostics(
+                    panel_paths,
+                    per_module_symbol_routes[module.devid],
+                    per_module_route_diagnostics[module.devid],
                 )
             except Exception:
                 LOGGER.debug("Menu kind extraction failed for %s", module.devid, exc_info=True)
@@ -1118,14 +1237,23 @@ async def async_build_bootstrap_payload(
                 )
                 per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu_retry)
                 per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu_retry)
+                module_route_dep_index = _route_dep_index_from_menu(menu_retry)
+                routes_i18n = await resolver._i18n.get_namespace("routes")
                 per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
                     menu_retry,
                     all_panels=True,
                     web_ui_only=False,
-                    routes_i18n=await resolver._i18n.get_namespace("routes"),
+                    routes_i18n=routes_i18n,
+                    flat_values=flat_values,
+                )
+                _enrich_symbol_routes_from_shell_diagnostics(
+                    panel_paths,
+                    per_module_symbol_routes[module.devid],
+                    per_module_route_diagnostics[module.devid],
                 )
             except Exception:
                 LOGGER.debug("Menu kind retry extraction failed for %s", module.devid, exc_info=True)
+        per_module_route_dep_index[module.devid] = module_route_dep_index
         all_candidate_symbols.update(symbols)
 
     details = await resolver.describe_symbols(sorted(all_candidate_symbols))
@@ -1358,12 +1486,20 @@ async def async_build_bootstrap_payload(
             "device_menu": module.deviceMenu,
             "module_interface": module.moduleInterface,
             "module_address": module.moduleAddress,
+            "permissions": [str(perm) for perm in getattr(module, "permissions", []) or []],
         }
 
         for symbol in sorted(per_module_symbols.get(module.devid, set())):
             payload = details.get(symbol)
             if payload is None:
                 continue
+
+            routes_map = per_module_symbol_routes.get(module.devid, {})
+            panel_paths_map = per_module_panel_paths.get(module.devid, {})
+            panel_menu_keys = _menu_keys_by_panel_path(panel_paths_map, routes_map)
+            route_dep_index = per_module_route_dep_index.get(module.devid, {})
+            module_ui_route_symbols = per_module_ui_route_symbols.get(module.devid, set())
+            symbol_routes = routes_map.get(symbol, [])
 
             mapping = payload.get("mapping") if isinstance(payload.get("mapping"), dict) else None
             symbol_kinds = per_module_symbol_kinds.get(module.devid, {}).get(symbol, set())
@@ -1378,6 +1514,14 @@ async def async_build_bootstrap_payload(
             )
             menu_title = _menu_title_from_panel_path(panel_path)
             menu_group_title = _menu_group_title_from_panel_path(panel_path)
+            route_name, route_path = _primary_route_identity(symbol_routes)
+            route_visibility_deps = _route_visibility_deps_for_symbol(
+                symbol_routes,
+                route_dep_index,
+                payload=payload if isinstance(payload, Mapping) else None,
+                flat_values=flat_values,
+            )
+            ui_route_symbol = symbol in module_ui_route_symbols
             unit_value = payload.get("unit")
             if unit_value is None and isinstance(mapping, dict):
                 unit_candidates: list[Any] = []
@@ -1427,7 +1571,13 @@ async def async_build_bootstrap_payload(
                 "writable": writable,
                 "menu_kinds": sorted(symbol_kinds),
                 "enabled_by_default": module_enabled_by_default.get(symbol, False),
+                CONF_UI_ROUTE_SYMBOL: ui_route_symbol,
+                CONF_ROUTE_VISIBILITY_DEPS: route_visibility_deps,
             }
+            if route_name:
+                descriptor[CONF_ROUTE_VISIBILITY_NAME] = route_name
+            if route_path:
+                descriptor[CONF_ROUTE_VISIBILITY_PATH] = route_path
             if menu_key:
                 descriptor["menu_key"] = menu_key
             if menu_title:

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -1489,23 +1489,25 @@ async def async_build_bootstrap_payload(
             "permissions": [str(perm) for perm in getattr(module, "permissions", []) or []],
         }
 
+        routes_map = per_module_symbol_routes.get(module.devid, {})
+        panel_paths_map = per_module_panel_paths.get(module.devid, {})
+        panel_menu_keys = _menu_keys_by_panel_path(panel_paths_map, routes_map)
+        route_dep_index = per_module_route_dep_index.get(module.devid, {})
+        module_ui_route_symbols = per_module_ui_route_symbols.get(module.devid, set())
+        module_symbol_kinds = per_module_symbol_kinds.get(module.devid, {})
+
         for symbol in sorted(per_module_symbols.get(module.devid, set())):
             payload = details.get(symbol)
             if payload is None:
                 continue
 
-            routes_map = per_module_symbol_routes.get(module.devid, {})
-            panel_paths_map = per_module_panel_paths.get(module.devid, {})
-            panel_menu_keys = _menu_keys_by_panel_path(panel_paths_map, routes_map)
-            route_dep_index = per_module_route_dep_index.get(module.devid, {})
-            module_ui_route_symbols = per_module_ui_route_symbols.get(module.devid, set())
             symbol_routes = routes_map.get(symbol, [])
 
             mapping = payload.get("mapping") if isinstance(payload.get("mapping"), dict) else None
-            symbol_kinds = per_module_symbol_kinds.get(module.devid, {}).get(symbol, set())
+            symbol_kinds = module_symbol_kinds.get(symbol, set())
             writable = _is_menu_command_action(symbol=symbol, symbol_kinds=symbol_kinds, mapping=mapping)
             label = str(payload.get("label")) if isinstance(payload.get("label"), str) else symbol
-            panel_path = per_module_panel_paths.get(module.devid, {}).get(symbol, "")
+            panel_path = panel_paths_map.get(symbol, "")
             menu_key = _resolve_menu_key_for_symbol(
                 symbol=symbol,
                 panel_path=panel_path,

--- a/custom_components/habragerone/const.py
+++ b/custom_components/habragerone/const.py
@@ -21,6 +21,10 @@ FILTER_MODE_PERMISSIONS: Final = "permissions"
 FILTER_MODES: Final[tuple[str, str]] = (FILTER_MODE_UI, FILTER_MODE_PERMISSIONS)
 DEFAULT_ENTITY_FILTER_MODE: Final = FILTER_MODE_UI
 CONF_ENABLED_BY_DEFAULT: Final = "enabled_by_default"
+CONF_UI_ROUTE_SYMBOL: Final = "ui_route_symbol"
+CONF_ROUTE_VISIBILITY_DEPS: Final = "route_visibility_deps"
+CONF_ROUTE_VISIBILITY_NAME: Final = "route_visibility_name"
+CONF_ROUTE_VISIBILITY_PATH: Final = "route_visibility_path"
 CONF_DEVICE_GROUPING: Final = "device_grouping"
 DEVICE_GROUPING_FLAT: Final = "flat"
 DEVICE_GROUPING_BY_MENU: Final = "group_by_menu"
@@ -36,7 +40,7 @@ CONF_RAW_TO_LABEL: Final = "raw_to_label"
 CONF_BOOTSTRAP_DEBUG: Final = "bootstrap_debug"
 CONF_BOOTSTRAP_VERSION: Final = "bootstrap_version"
 CONF_UPSTREAM_ASSETS_FINGERPRINT: Final = "upstream_assets_fingerprint"
-BOOTSTRAP_VERSION: Final = 12
+BOOTSTRAP_VERSION: Final = 13
 
 # Stable non-menu source key for module connectivity (SPA ``module.connection.*`` i18n).
 # Kept separate from menu-router paths so HA #165 can place these on a child device.

--- a/custom_components/habragerone/entity_common.py
+++ b/custom_components/habragerone/entity_common.py
@@ -21,6 +21,7 @@ from .const import (
     CONF_OPTIONS,
     CONF_PLATFORM,
     CONF_RAW_TO_LABEL,
+    CONF_UI_ROUTE_SYMBOL,
     DATA_ENTITY_STATS,
     DATA_RUNTIME,
     DEFAULT_DEVICE_GROUPING,
@@ -429,8 +430,23 @@ def module_is_reachable(runtime: BragerRuntime, devid: str) -> bool:
     return online
 
 
-def entity_is_available(runtime: BragerRuntime, *, devid: str, has_value: bool) -> bool:
-    """Combine ParamStore value presence with module cloud connectivity."""
+def entity_is_available(
+    runtime: BragerRuntime,
+    *,
+    devid: str,
+    has_value: bool,
+    descriptor: Mapping[str, Any] | None = None,
+    symbol: str | None = None,
+) -> bool:
+    """Combine value presence, module connectivity, and SPA route visibility (#192)."""
+    symbol_name = symbol
+    if descriptor is not None:
+        if bool(descriptor.get(CONF_UI_ROUTE_SYMBOL)):
+            symbol_name = str(descriptor.get("symbol") or symbol_name or "")
+            if symbol_name and not runtime.route_visible_for_symbol(devid, symbol_name):
+                return False
+    elif symbol_name and not runtime.route_visible_for_symbol(devid, symbol_name):
+        return False
     return bool(has_value) and module_is_reachable(runtime, devid)
 
 

--- a/custom_components/habragerone/entity_common.py
+++ b/custom_components/habragerone/entity_common.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping
 from typing import Any
 
 from homeassistant.config_entries import ConfigEntry
@@ -21,6 +21,7 @@ from .const import (
     CONF_OPTIONS,
     CONF_PLATFORM,
     CONF_RAW_TO_LABEL,
+    CONF_ROUTE_VISIBILITY_DEPS,
     CONF_UI_ROUTE_SYMBOL,
     DATA_ENTITY_STATS,
     DATA_RUNTIME,
@@ -215,7 +216,35 @@ def descriptor_refresh_keys(descriptor: dict[str, Any]) -> set[str]:
                     if address is not None:
                         keys.add(address)
 
+    route_deps = descriptor.get(CONF_ROUTE_VISIBILITY_DEPS)
+    if isinstance(route_deps, list):
+        for dep in route_deps:
+            if isinstance(dep, str) and dep.strip():
+                keys.add(dep.strip())
+
     return keys
+
+
+def attach_route_visibility_listener(
+    runtime: BragerRuntime,
+    *,
+    devid: str,
+    descriptor: Mapping[str, Any],
+    schedule_update: Callable[[], None],
+) -> Callable[[], None] | None:
+    """Subscribe to SPA route visibility flips for one UI-route entity (#192)."""
+    if not bool(descriptor.get(CONF_UI_ROUTE_SYMBOL)):
+        return None
+    symbol = str(descriptor.get("symbol") or "").strip()
+    if not symbol:
+        return None
+
+    def _on_route_visibility(changed_devid: str, changed_symbol: str, _visible: bool) -> None:
+        if changed_devid != devid or changed_symbol != symbol:
+            return
+        schedule_update()
+
+    return runtime.add_route_visibility_listener(_on_route_visibility)
 
 
 def store_value_for_address(store: ParamStore, address: str) -> Any | None:

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.9.0b3",
+    "py-bragerone==2026.9.0b4",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.9.0b3"
+  "version": "2026.9.0b4"
 }

--- a/custom_components/habragerone/number.py
+++ b/custom_components/habragerone/number.py
@@ -13,6 +13,7 @@ from pybragerone.models.events import ParamUpdate
 
 from .const import DOMAIN
 from .entity_common import (
+    attach_route_visibility_listener,
     descriptor_current_raw_value,
     descriptor_display_name,
     descriptor_enabled_by_default,
@@ -74,6 +75,7 @@ class BragerSymbolNumber(NumberEntity):
         self._refresh_keys = descriptor_refresh_keys(descriptor)
         self._unsubscribe_listener: Any = None
         self._unsubscribe_connectivity: Any = None
+        self._unsubscribe_route_visibility: Any = None
 
         min_value = descriptor.get("min")
         max_value = descriptor.get("max")
@@ -105,6 +107,12 @@ class BragerSymbolNumber(NumberEntity):
         """Attach runtime listeners when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
         self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        self._unsubscribe_route_visibility = attach_route_visibility_listener(
+            self._runtime,
+            devid=self._devid,
+            descriptor=self._descriptor,
+            schedule_update=lambda: self.async_schedule_update_ha_state(True),
+        )
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
@@ -115,6 +123,9 @@ class BragerSymbolNumber(NumberEntity):
         if callable(self._unsubscribe_connectivity):
             self._unsubscribe_connectivity()
             self._unsubscribe_connectivity = None
+        if callable(self._unsubscribe_route_visibility):
+            self._unsubscribe_route_visibility()
+            self._unsubscribe_route_visibility = None
 
     async def async_update(self) -> None:
         """Refresh numeric value from ParamStore using cached unit transform."""

--- a/custom_components/habragerone/number.py
+++ b/custom_components/habragerone/number.py
@@ -123,6 +123,7 @@ class BragerSymbolNumber(NumberEntity):
             self._runtime,
             devid=self._devid,
             has_value=raw_value is not None,
+            descriptor=self._descriptor,
         )
         if raw_value is None:
             return

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -18,6 +18,7 @@ from pybragerone.models.param import ParamStore
 from pybragerone.models.param_resolver import ParamResolver
 
 from .command_write import WriteContext, WriteValidationError, prepare_write
+from .const import CONF_ROUTE_VISIBILITY_DEPS, CONF_ROUTE_VISIBILITY_NAME, CONF_ROUTE_VISIBILITY_PATH, CONF_UI_ROUTE_SYMBOL
 from .numeric_display import descriptor_numeric_transform
 
 UpdateCallback = Callable[[ParamUpdate], None]
@@ -27,6 +28,8 @@ ConnectivityCallback = Callable[[str, bool, bool], None]
 CloudSessionCallback = Callable[[bool, bool], None]
 # Module event-feed (alarms / activity) refresh completed for one devid.
 EventFeedCallback = Callable[[str], None]
+# Route visibility changed for one symbol on a module (devid, symbol, visible).
+RouteVisibilityCallback = Callable[[str, str, bool], None]
 LOGGER = logging.getLogger(__name__)
 
 _ALARM_CHROME_KEYS = ("currentAlarms", "historyAlarms")
@@ -70,6 +73,12 @@ class BragerRuntime:
     _activity_assets_lock: asyncio.Lock = field(default_factory=asyncio.Lock)
     _activity_assets_loaded: bool = False
     _activity_refresh_tasks: dict[str, asyncio.Task[None]] = field(default_factory=dict)
+    _route_visibility_listeners: set[RouteVisibilityCallback] = field(default_factory=set)
+    _symbol_route_visible: dict[str, bool] = field(default_factory=dict)
+    _symbol_route_lookup: dict[str, tuple[str, str, str, str]] = field(default_factory=dict)
+    _route_visibility_dep_to_symbols: dict[str, set[str]] = field(default_factory=dict)
+    _route_visibility_symbol_to_devid: dict[str, str] = field(default_factory=dict)
+    _menu_cache: dict[str, Any] = field(default_factory=dict)
 
     async def start(self) -> None:
         """Start gateway, state store ingestion and update dispatcher."""
@@ -95,6 +104,7 @@ class BragerRuntime:
             raise
         self._seed_module_online_from_gateway()
         self._seed_cloud_session_from_gateway()
+        await self.refresh_route_visibility()
         if self._start_monotonic is not None:
             LOGGER.debug(
                 "Runtime gateway.start completed in %.3fs (modules=%s)",
@@ -113,6 +123,118 @@ class BragerRuntime:
         self._status_resolver = None
         await self.gateway.stop()
         await self.api.close()
+
+    def add_route_visibility_listener(self, callback: RouteVisibilityCallback) -> Callable[[], None]:
+        """Register a route-visibility listener and return unsubscribe callable."""
+        self._route_visibility_listeners.add(callback)
+
+        def _unsubscribe() -> None:
+            self._route_visibility_listeners.discard(callback)
+
+        return _unsubscribe
+
+    def register_route_visibility(self, descriptors: Iterable[Any]) -> None:
+        """Index UI-route symbols and their visibility dependency keys (#192)."""
+        self._route_visibility_dep_to_symbols.clear()
+        self._symbol_route_lookup.clear()
+        self._route_visibility_symbol_to_devid.clear()
+        self._symbol_route_visible.clear()
+        for item in descriptors:
+            if not isinstance(item, Mapping):
+                continue
+            if not bool(item.get(CONF_UI_ROUTE_SYMBOL)):
+                continue
+            devid = str(item.get("devid") or "").strip()
+            symbol = str(item.get("symbol") or "").strip()
+            if not devid or not symbol:
+                continue
+            lookup_key = f"{devid}:{symbol}"
+            route_name = str(item.get(CONF_ROUTE_VISIBILITY_NAME) or "").strip()
+            route_path = str(item.get(CONF_ROUTE_VISIBILITY_PATH) or "").strip()
+            self._symbol_route_lookup[lookup_key] = (devid, symbol, route_name, route_path)
+            self._route_visibility_symbol_to_devid[symbol] = devid
+            deps = item.get(CONF_ROUTE_VISIBILITY_DEPS)
+            if isinstance(deps, list):
+                for dep in deps:
+                    if isinstance(dep, str) and dep.strip():
+                        self._route_visibility_dep_to_symbols.setdefault(dep.strip(), set()).add(symbol)
+
+    def route_visible_for_symbol(self, devid: str, symbol: str) -> bool:
+        """Return whether the everyday-UI route for *symbol* is currently visible."""
+        lookup_key = f"{devid}:{symbol}"
+        if lookup_key not in self._symbol_route_lookup:
+            return True
+        return bool(self._symbol_route_visible.get(lookup_key, True))
+
+    async def refresh_route_visibility(self, symbols: set[str] | None = None) -> None:
+        """Re-evaluate SPA route visibility for indexed UI-route symbols."""
+        if not self._symbol_route_lookup:
+            return
+        resolver = await self._async_get_resolver()
+        if resolver is None:
+            return
+        flat_values = self.store.flatten()
+        changed: list[tuple[str, str, bool]] = []
+        for lookup_key, (devid, symbol, route_name, route_path) in self._symbol_route_lookup.items():
+            if symbols is not None and symbol not in symbols:
+                continue
+            menu = await self._menu_for_devid(devid, resolver)
+            if menu is None:
+                continue
+            route_match = self._find_menu_route(menu, route_name=route_name, route_path=route_path)
+            if route_match is None:
+                continue
+            route, ancestors = route_match
+            visible, _reason = ParamResolver.route_visibility_diagnostics(
+                route,
+                ancestors=ancestors,
+                flat_values=flat_values,
+                all_panels=True,
+                web_ui_only=True,
+            )
+            previous = self._symbol_route_visible.get(lookup_key, True)
+            self._symbol_route_visible[lookup_key] = visible
+            if visible != previous:
+                changed.append((devid, symbol, visible))
+        for devid, symbol, visible in changed:
+            for callback in tuple(self._route_visibility_listeners):
+                try:
+                    callback(devid, symbol, visible)
+                except Exception:
+                    LOGGER.exception("Route visibility listener failed for %s/%s", devid, symbol)
+
+    async def _menu_for_devid(self, devid: str, resolver: ParamResolver) -> Any | None:
+        if devid in self._menu_cache:
+            return self._menu_cache[devid]
+        meta = self.modules_meta.get(devid)
+        if not isinstance(meta, Mapping):
+            return None
+        device_menu = meta.get("device_menu")
+        if not isinstance(device_menu, int):
+            return None
+        perms_raw = meta.get("permissions")
+        permissions = [str(perm) for perm in perms_raw] if isinstance(perms_raw, list) else []
+        try:
+            menu = await resolver.get_module_menu(device_menu=device_menu, permissions=permissions)
+        except Exception:
+            LOGGER.debug("Menu fetch failed for route visibility devid=%s", devid, exc_info=True)
+            return None
+        self._menu_cache[devid] = menu
+        return menu
+
+    @staticmethod
+    def _find_menu_route(menu: Any, *, route_name: str, route_path: str) -> tuple[Any, tuple[Any, ...]] | None:
+        routes = getattr(menu, "routes", None)
+        if not isinstance(routes, list):
+            return None
+        for route, ancestors in ParamResolver._iter_routes_with_ancestors(routes):
+            name = str(getattr(route, "name", "") or "")
+            path = str(getattr(route, "path", "") or "")
+            if route_name and name == route_name:
+                return route, ancestors
+            if route_path and path == route_path:
+                return route, ancestors
+        return None
 
     def add_listener(self, callback: UpdateCallback) -> Callable[[], None]:
         """Register an entity listener and return unsubscribe callable."""
@@ -910,6 +1032,10 @@ class BragerRuntime:
                     update.idx,
                 )
                 self._first_update_logged = True
+            update_key = f"{update.pool}.{update.chan}{update.idx}"
+            affected_symbols = self._route_visibility_dep_to_symbols.get(update_key)
+            if affected_symbols:
+                await self.refresh_route_visibility(set(affected_symbols))
             for callback in tuple(self._listeners):
                 try:
                     callback(update)

--- a/custom_components/habragerone/select.py
+++ b/custom_components/habragerone/select.py
@@ -107,6 +107,7 @@ class BragerSymbolSelect(SelectEntity):
             self._runtime,
             devid=self._devid,
             has_value=raw_value is not None,
+            descriptor=self._descriptor,
         )
         if raw_value is None:
             return

--- a/custom_components/habragerone/select.py
+++ b/custom_components/habragerone/select.py
@@ -13,6 +13,7 @@ from pybragerone.models.events import ParamUpdate
 
 from .const import DOMAIN
 from .entity_common import (
+    attach_route_visibility_listener,
     descriptor_current_raw_value,
     descriptor_display_name,
     descriptor_enabled_by_default,
@@ -75,6 +76,7 @@ class BragerSymbolSelect(SelectEntity):
         self._refresh_keys = descriptor_refresh_keys(descriptor)
         self._unsubscribe_listener: Any = None
         self._unsubscribe_connectivity: Any = None
+        self._unsubscribe_route_visibility: Any = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -89,6 +91,12 @@ class BragerSymbolSelect(SelectEntity):
         """Attach runtime listeners when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
         self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        self._unsubscribe_route_visibility = attach_route_visibility_listener(
+            self._runtime,
+            devid=self._devid,
+            descriptor=self._descriptor,
+            schedule_update=lambda: self.async_schedule_update_ha_state(True),
+        )
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
@@ -99,6 +107,9 @@ class BragerSymbolSelect(SelectEntity):
         if callable(self._unsubscribe_connectivity):
             self._unsubscribe_connectivity()
             self._unsubscribe_connectivity = None
+        if callable(self._unsubscribe_route_visibility):
+            self._unsubscribe_route_visibility()
+            self._unsubscribe_route_visibility = None
 
     async def async_update(self) -> None:
         """Refresh current option from ParamStore value."""

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -24,6 +24,7 @@ from pybragerone.models.events import ParamUpdate
 
 from .const import DOMAIN
 from .entity_common import (
+    attach_route_visibility_listener,
     descriptor_current_raw_value,
     descriptor_display_name,
     descriptor_enabled_by_default,
@@ -105,11 +106,18 @@ class BragerSymbolSensor(SensorEntity):
 
         self._unsubscribe_listener: Any = None
         self._unsubscribe_connectivity: Any = None
+        self._unsubscribe_route_visibility: Any = None
 
     async def async_added_to_hass(self) -> None:
         """Subscribe to push updates when entity is added to HA."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
         self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        self._unsubscribe_route_visibility = attach_route_visibility_listener(
+            self._runtime,
+            devid=self._devid,
+            descriptor=self._descriptor,
+            schedule_update=lambda: self.async_schedule_update_ha_state(True),
+        )
         if self._try_apply_initial_state_sync():
             self.async_write_ha_state()
             return
@@ -155,6 +163,9 @@ class BragerSymbolSensor(SensorEntity):
         if callable(self._unsubscribe_connectivity):
             self._unsubscribe_connectivity()
             self._unsubscribe_connectivity = None
+        if callable(self._unsubscribe_route_visibility):
+            self._unsubscribe_route_visibility()
+            self._unsubscribe_route_visibility = None
 
     @property
     def device_info(self) -> DeviceInfo:

--- a/custom_components/habragerone/sensor.py
+++ b/custom_components/habragerone/sensor.py
@@ -125,6 +125,7 @@ class BragerSymbolSensor(SensorEntity):
             self._runtime,
             devid=self._devid,
             has_value=has_value,
+            descriptor=self._descriptor,
         )
         if raw_value is not None:
             mapped_by_unit = self._raw_to_label.get(str(raw_value))
@@ -171,6 +172,7 @@ class BragerSymbolSensor(SensorEntity):
             self._runtime,
             devid=self._devid,
             has_value=raw_value is not None,
+            descriptor=self._descriptor,
         )
         if raw_value is None:
             return

--- a/custom_components/habragerone/switch.py
+++ b/custom_components/habragerone/switch.py
@@ -102,6 +102,7 @@ class BragerSymbolSwitch(SwitchEntity):
             self._runtime,
             devid=self._devid,
             has_value=raw_value is not None,
+            descriptor=self._descriptor,
         )
         if raw_value is None:
             return

--- a/custom_components/habragerone/switch.py
+++ b/custom_components/habragerone/switch.py
@@ -13,6 +13,7 @@ from pybragerone.models.events import ParamUpdate
 
 from .const import DOMAIN
 from .entity_common import (
+    attach_route_visibility_listener,
     descriptor_current_raw_value,
     descriptor_display_name,
     descriptor_enabled_by_default,
@@ -70,6 +71,7 @@ class BragerSymbolSwitch(SwitchEntity):
         self._refresh_keys = descriptor_refresh_keys(descriptor)
         self._unsubscribe_listener: Any = None
         self._unsubscribe_connectivity: Any = None
+        self._unsubscribe_route_visibility: Any = None
 
     @property
     def device_info(self) -> DeviceInfo:
@@ -84,6 +86,12 @@ class BragerSymbolSwitch(SwitchEntity):
         """Attach runtime listeners when entity is added."""
         self._unsubscribe_listener = self._runtime.add_listener(self._on_runtime_update)
         self._unsubscribe_connectivity = self._runtime.add_connectivity_listener(self._on_connectivity)
+        self._unsubscribe_route_visibility = attach_route_visibility_listener(
+            self._runtime,
+            devid=self._devid,
+            descriptor=self._descriptor,
+            schedule_update=lambda: self.async_schedule_update_ha_state(True),
+        )
         self.async_schedule_update_ha_state(True)
 
     async def async_will_remove_from_hass(self) -> None:
@@ -94,6 +102,9 @@ class BragerSymbolSwitch(SwitchEntity):
         if callable(self._unsubscribe_connectivity):
             self._unsubscribe_connectivity()
             self._unsubscribe_connectivity = None
+        if callable(self._unsubscribe_route_visibility):
+            self._unsubscribe_route_visibility()
+            self._unsubscribe_route_visibility = None
 
     async def async_update(self) -> None:
         """Refresh switch state from ParamStore value and command rules."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,3 +168,6 @@ hass-cloud = { shell = "./scripts/cloud_hass_start.sh" }
 docker-up = { cmd = "docker-compose up -d" }
 docker-down = { cmd = "docker-compose down" }
 docker-logs = { cmd = "docker-compose logs -f homeassistant" }
+
+[tool.uv.sources]
+py-bragerone = { path = "../py-bragerone", editable = true }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone==2026.9.0b3",
+    "py-bragerone==2026.9.0b4",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -168,6 +168,3 @@ hass-cloud = { shell = "./scripts/cloud_hass_start.sh" }
 docker-up = { cmd = "docker-compose up -d" }
 docker-down = { cmd = "docker-compose down" }
 docker-logs = { cmd = "docker-compose logs -f homeassistant" }
-
-[tool.uv.sources]
-py-bragerone = { git = "https://github.com/marpi82/py-bragerone", branch = "fix/strefy-czasowe-menu-192" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,4 +170,4 @@ docker-down = { cmd = "docker-compose down" }
 docker-logs = { cmd = "docker-compose logs -f homeassistant" }
 
 [tool.uv.sources]
-py-bragerone = { path = "../py-bragerone", editable = true }
+py-bragerone = { git = "https://github.com/marpi82/py-bragerone", branch = "fix/strefy-czasowe-menu-192" }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -176,6 +176,26 @@ def install_pybragerone_stubs() -> None:
                 return int(total)
             return total
 
+        @staticmethod
+        def _iter_routes_with_ancestors(routes: object) -> list[tuple[object, tuple[object, ...]]]:
+            _ = routes
+            return []
+
+        @staticmethod
+        def _status_paths_for_visibility(mapping: object, flat_values: object) -> list[dict[str, object]]:
+            _ = mapping, flat_values
+            return []
+
+        @staticmethod
+        def route_visibility_dependency_keys(route: object, ancestors: object = ()) -> list[str]:
+            _ = route, ancestors
+            return []
+
+        @staticmethod
+        def panel_route_diagnostics_from_menu(*args: object, **kwargs: object) -> list[dict[str, object]]:
+            _ = args, kwargs
+            return []
+
     pybragerone_models_param_resolver_stub.ParamResolver = _ParamResolverStub
     sys.modules["pybragerone.models.param_resolver"] = pybragerone_models_param_resolver_stub
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -50,6 +50,14 @@ def install_pybragerone_stubs() -> None:
     if getattr(install_pybragerone_stubs, "_installed", False):
         return
 
+    real_param_resolver_cls: type[Any] | None = None
+    try:
+        import pybragerone.models.param_resolver as _real_param_resolver_mod
+
+        real_param_resolver_cls = _real_param_resolver_mod.ParamResolver
+    except ImportError:
+        real_param_resolver_cls = None
+
     for module_name in list(sys.modules):
         if module_name == "pybragerone" or module_name.startswith("pybragerone."):
             del sys.modules[module_name]
@@ -177,6 +185,11 @@ def install_pybragerone_stubs() -> None:
             return total
 
         @staticmethod
+        def panel_route_diagnostics_from_menu(*args: object, **kwargs: object) -> list[dict[str, object]]:
+            _ = args, kwargs
+            return []
+
+        @staticmethod
         def _iter_routes_with_ancestors(routes: object) -> list[tuple[object, tuple[object, ...]]]:
             _ = routes
             return []
@@ -192,9 +205,16 @@ def install_pybragerone_stubs() -> None:
             return []
 
         @staticmethod
-        def panel_route_diagnostics_from_menu(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        def route_visibility_diagnostics(*args: object, **kwargs: object) -> tuple[bool, str]:
             _ = args, kwargs
-            return []
+            return True, "visible:default"
+
+    if real_param_resolver_cls is not None:
+        _ParamResolverStub.route_visibility_diagnostics = real_param_resolver_cls.route_visibility_diagnostics
+        _ParamResolverStub._iter_routes_with_ancestors = real_param_resolver_cls._iter_routes_with_ancestors
+        _ParamResolverStub.route_visibility_dependency_keys = real_param_resolver_cls.route_visibility_dependency_keys
+        _ParamResolverStub.panel_route_diagnostics_from_menu = real_param_resolver_cls.panel_route_diagnostics_from_menu
+        _ParamResolverStub._status_paths_for_visibility = real_param_resolver_cls._status_paths_for_visibility
 
     pybragerone_models_param_resolver_stub.ParamResolver = _ParamResolverStub
     sys.modules["pybragerone.models.param_resolver"] = pybragerone_models_param_resolver_stub

--- a/tests/test_bootstrap_filtering.py
+++ b/tests/test_bootstrap_filtering.py
@@ -27,6 +27,30 @@ def _container(*tokens: str) -> SimpleNamespace:
     return SimpleNamespace(read=[_param(token) for token in tokens], write=[], status=[], special=[])
 
 
+class _BootstrapResolverRouteStubMixin:
+    """Static ParamResolver hooks used during bootstrap route metadata (#192)."""
+
+    @staticmethod
+    def _iter_routes_with_ancestors(routes: object) -> list[tuple[object, tuple[object, ...]]]:
+        _ = routes
+        return []
+
+    @staticmethod
+    def _status_paths_for_visibility(mapping: object, flat_values: object) -> list[dict[str, object]]:
+        _ = mapping, flat_values
+        return []
+
+    @staticmethod
+    def route_visibility_dependency_keys(route: object, ancestors: object = ()) -> list[str]:
+        _ = route, ancestors
+        return []
+
+    @staticmethod
+    def panel_route_diagnostics_from_menu(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        _ = args, kwargs
+        return []
+
+
 def test_collect_symbols_from_menu_walks_nested_routes() -> None:
     leaf = SimpleNamespace(
         meta=SimpleNamespace(parameters=_container("PARAM_LEAF_A")),
@@ -64,7 +88,7 @@ def test_async_build_bootstrap_payload_creates_every_permitted_entity_and_gates_
         def flatten(self) -> dict[str, object]:
             return {"P4.v1": 42}
 
-    class _FakeResolver:
+    class _FakeResolver(_BootstrapResolverRouteStubMixin):
         def __init__(self) -> None:
             self._current_devid = ""
 
@@ -79,8 +103,9 @@ def test_async_build_bootstrap_payload_creates_every_permitted_entity_and_gates_
             permissions: list[str] | None,
             all_panels: bool,
             web_ui_only: bool = False,
+            flat_values: object | None = None,
         ) -> dict[str, list[str]]:
-            _ = permissions, all_panels, web_ui_only
+            _ = permissions, all_panels, web_ui_only, flat_values
             return {"panel": [f"SYM_{device_menu}"]}
 
         async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:
@@ -216,7 +241,7 @@ def test_async_build_bootstrap_payload_includes_non_panel_actions_disabled_by_de
                 ]
             }
 
-    class _FakeResolver:
+    class _FakeResolver(_BootstrapResolverRouteStubMixin):
         def __init__(self) -> None:
             self._assets = _FakeAssets()
 
@@ -232,8 +257,9 @@ def test_async_build_bootstrap_payload_includes_non_panel_actions_disabled_by_de
             permissions: list[str] | None,
             all_panels: bool,
             web_ui_only: bool = False,
+            flat_values: object | None = None,
         ) -> dict[str, list[str]]:
-            _ = device_menu, permissions, all_panels, web_ui_only
+            _ = device_menu, permissions, all_panels, web_ui_only, flat_values
             return {"Kocioł": ["SYM_PANEL"]}
 
         async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:
@@ -356,7 +382,7 @@ def test_async_build_bootstrap_payload_enabled_default_edge_cases(
                 ]
             }
 
-    class _FakeResolver:
+    class _FakeResolver(_BootstrapResolverRouteStubMixin):
         def __init__(self) -> None:
             self._assets = _FakeAssets()
             self._describe_calls = 0
@@ -373,8 +399,9 @@ def test_async_build_bootstrap_payload_enabled_default_edge_cases(
             permissions: list[str] | None,
             all_panels: bool,
             web_ui_only: bool = False,
+            flat_values: object | None = None,
         ) -> dict[str, list[str]]:
-            _ = device_menu, permissions, all_panels
+            _ = device_menu, permissions, all_panels, flat_values
             # Full permission set includes installer-only symbols; everyday UI only sees SYM_UI.
             if web_ui_only:
                 return {"Kocioł": ["SYM_UI", "SYM_VIS_FAIL", "SYM_RESOLVE_FAIL"]}
@@ -529,7 +556,7 @@ def test_async_build_bootstrap_payload_skips_extra_write_without_command_rule(
                 ]
             }
 
-    class _FakeResolver:
+    class _FakeResolver(_BootstrapResolverRouteStubMixin):
         def __init__(self) -> None:
             self._assets = _FakeAssets()
 
@@ -545,8 +572,9 @@ def test_async_build_bootstrap_payload_skips_extra_write_without_command_rule(
             permissions: list[str] | None,
             all_panels: bool,
             web_ui_only: bool = False,
+            flat_values: object | None = None,
         ) -> dict[str, list[str]]:
-            _ = device_menu, permissions, all_panels, web_ui_only
+            _ = device_menu, permissions, all_panels, web_ui_only, flat_values
             return {"Kocioł": ["SYM_PANEL"]}
 
         async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:
@@ -677,7 +705,7 @@ def test_async_build_bootstrap_payload_skips_extra_with_non_action_command_name(
                 ]
             }
 
-    class _FakeResolver:
+    class _FakeResolver(_BootstrapResolverRouteStubMixin):
         def __init__(self) -> None:
             self._assets = _FakeAssets()
 
@@ -693,8 +721,9 @@ def test_async_build_bootstrap_payload_skips_extra_with_non_action_command_name(
             permissions: list[str] | None,
             all_panels: bool,
             web_ui_only: bool = False,
+            flat_values: object | None = None,
         ) -> dict[str, list[str]]:
-            _ = device_menu, permissions, all_panels, web_ui_only
+            _ = device_menu, permissions, all_panels, web_ui_only, flat_values
             return {"Kocioł": ["SYM_PANEL"]}
 
         async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:
@@ -801,7 +830,7 @@ def test_async_build_bootstrap_payload_accepts_sample_cap(
 
     symbols_all = [f"SYM_{idx}" for idx in range(510)]
 
-    class _FakeResolver:
+    class _FakeResolver(_BootstrapResolverRouteStubMixin):
         @classmethod
         def from_api(cls, api: object, store: object, lang: object) -> _FakeResolver:
             _ = api, store, lang
@@ -814,8 +843,9 @@ def test_async_build_bootstrap_payload_accepts_sample_cap(
             permissions: list[str] | None,
             all_panels: bool,
             web_ui_only: bool = False,
+            flat_values: object | None = None,
         ) -> dict[str, list[str]]:
-            _ = device_menu, permissions, all_panels, web_ui_only
+            _ = device_menu, permissions, all_panels, web_ui_only, flat_values
             return {"Kocioł": list(symbols_all)}
 
         async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:

--- a/tests/test_bootstrap_panel_group_fallback.py
+++ b/tests/test_bootstrap_panel_group_fallback.py
@@ -52,8 +52,9 @@ class _RecordingResolver:
         permissions: list[str] | None,
         all_panels: bool,
         web_ui_only: bool = False,
+        flat_values: object | None = None,
     ) -> dict[str, list[str]]:
-        _ = device_menu, all_panels
+        _ = device_menu, all_panels, flat_values
         type(self).calls.append(permissions)
         type(self).web_ui_flags.append(web_ui_only)
         result = self.ungated_groups if permissions is None else self.gated_groups
@@ -92,6 +93,26 @@ class _RecordingResolver:
     ) -> tuple[bool, dict[str, object]]:
         _ = desc, resolved, flat_values
         return True, {}
+
+    @staticmethod
+    def _iter_routes_with_ancestors(routes: object) -> list[tuple[object, tuple[object, ...]]]:
+        _ = routes
+        return []
+
+    @staticmethod
+    def _status_paths_for_visibility(mapping: object, flat_values: object) -> list[dict[str, object]]:
+        _ = mapping, flat_values
+        return []
+
+    @staticmethod
+    def route_visibility_dependency_keys(route: object, ancestors: object = ()) -> list[str]:
+        _ = route, ancestors
+        return []
+
+    @staticmethod
+    def panel_route_diagnostics_from_menu(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        _ = args, kwargs
+        return []
 
 
 class _FakeGateway:
@@ -344,8 +365,9 @@ def test_failing_panel_group_build_propagates_instead_of_caching_emptiness() -> 
             permissions: list[str] | None,
             all_panels: bool,
             web_ui_only: bool = False,
+            flat_values: object | None = None,
         ) -> dict[str, list[str]]:
-            _ = device_menu, permissions, all_panels, web_ui_only
+            _ = device_menu, permissions, all_panels, web_ui_only, flat_values
             raise RuntimeError("extraction failed")
 
     with pytest.raises(RuntimeError, match="extraction failed"):

--- a/tests/test_bootstrap_strefy_czasowe.py
+++ b/tests/test_bootstrap_strefy_czasowe.py
@@ -4,13 +4,17 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
 
 from custom_components.habragerone.bootstrap import (
     _enrich_symbol_routes_from_shell_diagnostics,
+    _primary_route_identity,
     _resolve_menu_key_for_symbol,
+    _route_dep_index_from_menu,
+    _route_visibility_deps_for_symbol,
     _stable_menu_key_from_route_meta,
 )
 
@@ -48,6 +52,25 @@ def test_shell_diagnostics_enrich_symbol_routes() -> None:
     assert _stable_menu_key_from_route_meta(symbol_routes["PARAM_177"]) == "MAINMENU_STREFY_CZASOWE"
 
 
+def test_shell_diagnostics_skip_existing_route_meta() -> None:
+    """Symbols that already have route meta are not overwritten by shell enrichment."""
+    diagnostics = [
+        {
+            "title": "Strefy czasowe",
+            "panel_title": "Strefy czasowe",
+            "name": "MAINMENU_STREFY_CZASOWE",
+            "path": "timezones",
+            "accepted": True,
+            "panel_shell": True,
+        }
+    ]
+    symbol_routes: dict[str, list[dict[str, Any]]] = {
+        "PARAM_177": [{"name": "existing.route", "path": "keep", "ancestors": []}],
+    }
+    _enrich_symbol_routes_from_shell_diagnostics({"PARAM_177": "Strefy czasowe"}, symbol_routes, diagnostics)
+    assert symbol_routes["PARAM_177"][0]["name"] == "existing.route"
+
+
 def test_menu_key_resolves_for_shell_route_meta() -> None:
     """Group-by-menu child device key resolves from enriched shell route meta."""
     routes = [
@@ -64,6 +87,54 @@ def test_menu_key_resolves_for_shell_route_meta() -> None:
         panel_menu_keys={},
     )
     assert key == "MAINMENU_STREFY_CZASOWE"
+
+
+def test_primary_route_identity_returns_first_name_or_path() -> None:
+    """Primary route identity prefers the first non-empty route tuple."""
+    assert _primary_route_identity([{"name": "MAINMENU_X", "path": "timezones"}]) == ("MAINMENU_X", "timezones")
+    assert _primary_route_identity([{"name": "", "path": "circulation"}]) == ("", "circulation")
+    assert _primary_route_identity([]) == ("", "")
+
+
+def test_route_dep_index_from_menu_collects_dependency_keys() -> None:
+    """Bootstrap builds a route dep index from menu status parameters."""
+    menu = SimpleNamespace(
+        routes=[
+            SimpleNamespace(
+                name="MAINMENU_STREFY_CZASOWE",
+                path="timezones",
+                meta=SimpleNamespace(
+                    parameters=SimpleNamespace(
+                        status=[SimpleNamespace(group="P6", number=219, use="s")],
+                    )
+                ),
+                children=[],
+                component=None,
+            )
+        ]
+    )
+    index = _route_dep_index_from_menu(menu)
+    assert index[("MAINMENU_STREFY_CZASOWE", "timezones")] == ["P6.s219"]
+
+
+def test_route_visibility_deps_for_symbol_merges_route_and_payload() -> None:
+    """Descriptor route deps merge route index keys and mapping status paths."""
+    routes = [{"name": "MAINMENU_STREFY_CZASOWE", "path": "timezones"}]
+    dep_index = {("MAINMENU_STREFY_CZASOWE", "timezones"): ["P6.s219"]}
+    payload = {
+        "mapping": {
+            "paths": {
+                "status": [{"group": "P6", "number": 219, "use": "s", "bit": 0, "condition": "INVISIBLE"}],
+            }
+        }
+    }
+    deps = _route_visibility_deps_for_symbol(
+        routes,
+        dep_index,
+        payload=payload,
+        flat_values={"P6.s219": 0},
+    )
+    assert deps == ["P6.s219"]
 
 
 @pytest.mark.skipif(not _FIXTURE.is_file(), reason="shared py-bragerone fixture missing")

--- a/tests/test_bootstrap_strefy_czasowe.py
+++ b/tests/test_bootstrap_strefy_czasowe.py
@@ -1,0 +1,73 @@
+"""Bootstrap regression for static menu route shells (#192)."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from custom_components.habragerone.bootstrap import (
+    _enrich_symbol_routes_from_shell_diagnostics,
+    _resolve_menu_key_for_symbol,
+    _stable_menu_key_from_route_meta,
+)
+
+_FIXTURE = (
+    Path(__file__)
+    .resolve()
+    .parents[1]
+    .joinpath(
+        "..",
+        "py-bragerone",
+        "tests",
+        "fixtures",
+        "menu_strefy_czasowe.json",
+    )
+    .resolve()
+)
+
+
+def test_shell_diagnostics_enrich_symbol_routes() -> None:
+    """Panel-shell diagnostics attach route meta for static-route symbols."""
+    diagnostics = [
+        {
+            "title": "Strefy czasowe",
+            "panel_title": "Strefy czasowe",
+            "name": "MAINMENU_STREFY_CZASOWE",
+            "path": "timezones",
+            "accepted": True,
+            "panel_shell": True,
+        }
+    ]
+    panel_paths = {"PARAM_177": "Strefy czasowe"}
+    symbol_routes: dict[str, list[dict[str, Any]]] = {}
+    _enrich_symbol_routes_from_shell_diagnostics(panel_paths, symbol_routes, diagnostics)
+    assert symbol_routes["PARAM_177"][0]["name"] == "MAINMENU_STREFY_CZASOWE"
+    assert _stable_menu_key_from_route_meta(symbol_routes["PARAM_177"]) == "MAINMENU_STREFY_CZASOWE"
+
+
+def test_menu_key_resolves_for_shell_route_meta() -> None:
+    """Group-by-menu child device key resolves from enriched shell route meta."""
+    routes = [
+        {
+            "name": "MAINMENU_STREFY_CZASOWE",
+            "path": "timezones",
+            "ancestors": [],
+        }
+    ]
+    key = _resolve_menu_key_for_symbol(
+        symbol="PARAM_177",
+        panel_path="Strefy czasowe",
+        symbol_routes={"PARAM_177": routes},
+        panel_menu_keys={},
+    )
+    assert key == "MAINMENU_STREFY_CZASOWE"
+
+
+@pytest.mark.skipif(not _FIXTURE.is_file(), reason="shared py-bragerone fixture missing")
+def test_shared_fixture_describes_strefy_panel() -> None:
+    """Shared fixture keeps the Strefy czasowe panel title stable."""
+    payload = json.loads(_FIXTURE.read_text(encoding="utf-8"))
+    assert payload["routes"][0]["name"] == "MAINMENU_STREFY_CZASOWE"

--- a/tests/test_bootstrap_upstream_fingerprint.py
+++ b/tests/test_bootstrap_upstream_fingerprint.py
@@ -43,8 +43,9 @@ class _FakeResolver:
         permissions: list[str] | None,
         all_panels: bool,
         web_ui_only: bool = False,
+        flat_values: object | None = None,
     ) -> dict[str, list[str]]:
-        _ = device_menu, permissions, all_panels, web_ui_only
+        _ = device_menu, permissions, all_panels, web_ui_only, flat_values
         return cast(dict[str, list[str]], self.gated_groups)
 
     async def describe_symbols(self, symbols: list[str]) -> dict[str, dict[str, object]]:
@@ -78,6 +79,26 @@ class _FakeResolver:
     ) -> tuple[bool, dict[str, object]]:
         _ = desc, resolved, flat_values
         return True, {}
+
+    @staticmethod
+    def _iter_routes_with_ancestors(routes: object) -> list[tuple[object, tuple[object, ...]]]:
+        _ = routes
+        return []
+
+    @staticmethod
+    def _status_paths_for_visibility(mapping: object, flat_values: object) -> list[dict[str, object]]:
+        _ = mapping, flat_values
+        return []
+
+    @staticmethod
+    def route_visibility_dependency_keys(route: object, ancestors: object = ()) -> list[str]:
+        _ = route, ancestors
+        return []
+
+    @staticmethod
+    def panel_route_diagnostics_from_menu(*args: object, **kwargs: object) -> list[dict[str, object]]:
+        _ = args, kwargs
+        return []
 
 
 class _FakeApi:

--- a/tests/test_entity_common.py
+++ b/tests/test_entity_common.py
@@ -14,6 +14,8 @@ install_pybragerone_stubs()
 from custom_components.habragerone.const import (  # noqa: E402
     CONF_ENTITY_DESCRIPTORS,
     CONF_MODULES,
+    CONF_ROUTE_VISIBILITY_DEPS,
+    CONF_UI_ROUTE_SYMBOL,
     DATA_ENTITY_STATS,
     DATA_RUNTIME,
     DEVICE_GROUPING_BY_MENU,
@@ -26,6 +28,7 @@ from custom_components.habragerone.entity_common import (  # noqa: E402
     _mapping_value_selector_entries,
     _menu_device_display_name,
     async_register_module_parent_devices,
+    attach_route_visibility_listener,
     collect_resolver_warm_symbols,
     descriptor_current_raw_value,
     descriptor_enabled_by_default,
@@ -57,6 +60,38 @@ def test_descriptor_enabled_by_default_respects_false() -> None:
 def test_descriptor_enabled_by_default_coerces_truthy_values() -> None:
     assert descriptor_enabled_by_default({"enabled_by_default": 1}) is True
     assert descriptor_enabled_by_default({"enabled_by_default": 0}) is False
+
+
+def test_attach_route_visibility_listener_ignores_non_ui_route_descriptor() -> None:
+    """Non UI-route entities do not subscribe to route visibility fan-out."""
+    runtime, *_rest = make_runtime()
+    seen: list[tuple[str, str, bool]] = []
+    runtime.add_route_visibility_listener(lambda devid, symbol, visible: seen.append((devid, symbol, visible)))
+    unsub = attach_route_visibility_listener(
+        runtime,
+        devid="dev1",
+        descriptor={"symbol": "PARAM_9", CONF_UI_ROUTE_SYMBOL: False},
+        schedule_update=lambda: seen.append(("schedule", "", False)),
+    )
+    assert unsub is None
+    assert seen == []
+
+
+def test_attach_route_visibility_listener_schedules_matching_symbol() -> None:
+    """UI-route entities refresh when their symbol visibility flips."""
+    runtime, *_rest = make_runtime()
+    scheduled: list[str] = []
+    attach_route_visibility_listener(
+        runtime,
+        devid="dev1",
+        descriptor={"symbol": "PARAM_177", CONF_UI_ROUTE_SYMBOL: True},
+        schedule_update=lambda: scheduled.append("update"),
+    )
+    for callback in tuple(runtime._route_visibility_listeners):
+        callback("dev1", "PARAM_177", False)
+        callback("dev1", "PARAM_219", False)
+        callback("dev2", "PARAM_177", False)
+    assert scheduled == ["update"]
 
 
 def test_descriptor_refresh_keys_direct_address() -> None:
@@ -95,6 +130,17 @@ def test_descriptor_refresh_keys_includes_multi_register_value_channels() -> Non
         },
     }
     assert descriptor_refresh_keys(descriptor) == {"P4.v59", "P4.v60"}
+
+
+def test_descriptor_refresh_keys_includes_route_visibility_deps() -> None:
+    """UI-route availability must refresh when route dependency params change (#192)."""
+    descriptor = {
+        "pool": "P6",
+        "chan": "v",
+        "idx": 219,
+        CONF_ROUTE_VISIBILITY_DEPS: ["P6.v219", " P1.s0 ", 42],
+    }
+    assert descriptor_refresh_keys(descriptor) == {"P6.v219", "P1.s0"}
 
 
 def test_descriptor_refresh_keys_skips_invalid_channel_and_path_entries() -> None:

--- a/tests/test_runtime_route_visibility.py
+++ b/tests/test_runtime_route_visibility.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
 
 from custom_components.habragerone.const import (
     CONF_ROUTE_VISIBILITY_DEPS,
@@ -19,7 +22,7 @@ def _runtime_stub(*, route_visible: bool = True) -> BragerRuntime:
         api=MagicMock(),
         gateway=MagicMock(modules=[]),
         store=MagicMock(flatten=MagicMock(return_value={})),
-        modules_meta={"dev1": {"device_menu": 0, "name": "mod"}},
+        modules_meta={"dev1": {"device_menu": 0, "name": "mod", "permissions": []}},
         language="pl",
     )
     runtime.register_route_visibility(
@@ -31,12 +34,29 @@ def _runtime_stub(*, route_visible: bool = True) -> BragerRuntime:
                 CONF_ROUTE_VISIBILITY_NAME: "MAINMENU_STREFY_CZASOWE",
                 CONF_ROUTE_VISIBILITY_PATH: "timezones",
                 CONF_ROUTE_VISIBILITY_DEPS: ["P1.s0"],
-            }
+            },
+            {
+                "devid": "dev1",
+                "symbol": "PARAM_219",
+                CONF_UI_ROUTE_SYMBOL: True,
+                CONF_ROUTE_VISIBILITY_NAME: "modules.menu.circulation",
+                CONF_ROUTE_VISIBILITY_PATH: "circulation",
+                CONF_ROUTE_VISIBILITY_DEPS: ["P6.v219"],
+            },
         ]
     )
     runtime._symbol_route_visible["dev1:PARAM_177"] = route_visible
+    runtime._symbol_route_visible["dev1:PARAM_219"] = route_visible
     runtime._module_online["dev1"] = True
     return runtime
+
+
+def _attach_menu_resolver(runtime: BragerRuntime, *, routes: list[SimpleNamespace]) -> AsyncMock:
+    menu = SimpleNamespace(routes=routes)
+    resolver = AsyncMock()
+    resolver.get_module_menu = AsyncMock(return_value=menu)
+    runtime._status_resolver = resolver
+    return resolver
 
 
 def test_entity_is_available_hides_ui_route_when_route_not_visible() -> None:
@@ -59,6 +79,31 @@ def test_entity_is_available_keeps_non_ui_route_when_route_hidden() -> None:
     assert entity_is_available(runtime, devid="dev1", has_value=True, descriptor=descriptor) is True
 
 
+def test_entity_is_available_uses_symbol_argument_without_descriptor() -> None:
+    """Symbol-only availability checks still honor route visibility."""
+    runtime = _runtime_stub(route_visible=False)
+    assert entity_is_available(runtime, devid="dev1", has_value=True, symbol="PARAM_177") is False
+
+
+def test_route_visible_for_symbol_defaults_true_for_unknown_symbols() -> None:
+    """Symbols outside the route visibility index stay visible."""
+    runtime = _runtime_stub(route_visible=False)
+    assert runtime.route_visible_for_symbol("dev1", "UNKNOWN") is True
+
+
+def test_register_route_visibility_skips_non_ui_descriptors() -> None:
+    """Only UI-route descriptors populate the visibility index."""
+    runtime = BragerRuntime(
+        api=MagicMock(),
+        gateway=MagicMock(modules=[]),
+        store=MagicMock(flatten=MagicMock(return_value={})),
+        modules_meta={},
+        language="pl",
+    )
+    runtime.register_route_visibility([{"devid": "dev1", "symbol": "PARAM_9", CONF_UI_ROUTE_SYMBOL: False}])
+    assert runtime._symbol_route_lookup == {}
+
+
 def test_route_visibility_listener_receives_callbacks() -> None:
     """Registered route-visibility listeners receive fan-out events."""
     runtime = _runtime_stub(route_visible=True)
@@ -67,3 +112,54 @@ def test_route_visibility_listener_receives_callbacks() -> None:
     for callback in tuple(runtime._route_visibility_listeners):
         callback("dev1", "PARAM_177", False)
     assert seen == [("dev1", "PARAM_177", False)]
+
+
+@pytest.mark.asyncio
+async def test_refresh_route_visibility_updates_symbol_state() -> None:
+    """Route visibility refresh re-evaluates indexed symbols from prime values."""
+    runtime = _runtime_stub(route_visible=True)
+    circulation_route = SimpleNamespace(
+        name="modules.menu.circulation",
+        path="circulation",
+        meta=SimpleNamespace(display_dropdown="P6.v219"),
+        children=[],
+    )
+    _attach_menu_resolver(runtime, routes=[circulation_route])
+    runtime.store.flatten.return_value = {"P6.v219": 0}
+
+    await runtime.refresh_route_visibility({"PARAM_219"})
+
+    assert runtime.route_visible_for_symbol("dev1", "PARAM_219") is False
+
+
+@pytest.mark.asyncio
+async def test_refresh_route_visibility_notifies_listeners_on_change() -> None:
+    """Visibility flips notify registered listeners."""
+    runtime = _runtime_stub(route_visible=True)
+    timezone_route = SimpleNamespace(
+        name="MAINMENU_STREFY_CZASOWE",
+        path="timezones",
+        meta=SimpleNamespace(display_dropdown="![]"),
+        children=[],
+    )
+    _attach_menu_resolver(runtime, routes=[timezone_route])
+
+    seen: list[tuple[str, str, bool]] = []
+    runtime.add_route_visibility_listener(lambda devid, symbol, visible: seen.append((devid, symbol, visible)))
+    await runtime.refresh_route_visibility({"PARAM_177"})
+    assert seen == [("dev1", "PARAM_177", False)]
+
+
+@pytest.mark.asyncio
+async def test_menu_for_devid_uses_cached_permissions() -> None:
+    """Route visibility menu fetch passes bootstrap permissions to the resolver."""
+    runtime = _runtime_stub()
+    route = SimpleNamespace(name="MAINMENU_STREFY_CZASOWE", path="timezones", meta=None, children=[])
+    resolver = _attach_menu_resolver(runtime, routes=[route])
+    runtime.modules_meta["dev1"]["permissions"] = ["DISPLAY_PARAMETER_LEVEL_1"]
+
+    menu_first = await runtime._menu_for_devid("dev1", resolver)
+    menu_second = await runtime._menu_for_devid("dev1", resolver)
+
+    assert menu_first is menu_second
+    resolver.get_module_menu.assert_awaited_once_with(device_menu=0, permissions=["DISPLAY_PARAMETER_LEVEL_1"])

--- a/tests/test_runtime_route_visibility.py
+++ b/tests/test_runtime_route_visibility.py
@@ -1,0 +1,69 @@
+"""Runtime route visibility tests (#192)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from custom_components.habragerone.const import (
+    CONF_ROUTE_VISIBILITY_DEPS,
+    CONF_ROUTE_VISIBILITY_NAME,
+    CONF_ROUTE_VISIBILITY_PATH,
+    CONF_UI_ROUTE_SYMBOL,
+)
+from custom_components.habragerone.entity_common import entity_is_available
+from custom_components.habragerone.runtime import BragerRuntime
+
+
+def _runtime_stub(*, route_visible: bool = True) -> BragerRuntime:
+    runtime = BragerRuntime(
+        api=MagicMock(),
+        gateway=MagicMock(modules=[]),
+        store=MagicMock(flatten=MagicMock(return_value={})),
+        modules_meta={"dev1": {"device_menu": 0, "name": "mod"}},
+        language="pl",
+    )
+    runtime.register_route_visibility(
+        [
+            {
+                "devid": "dev1",
+                "symbol": "PARAM_177",
+                CONF_UI_ROUTE_SYMBOL: True,
+                CONF_ROUTE_VISIBILITY_NAME: "MAINMENU_STREFY_CZASOWE",
+                CONF_ROUTE_VISIBILITY_PATH: "timezones",
+                CONF_ROUTE_VISIBILITY_DEPS: ["P1.s0"],
+            }
+        ]
+    )
+    runtime._symbol_route_visible["dev1:PARAM_177"] = route_visible
+    runtime._module_online["dev1"] = True
+    return runtime
+
+
+def test_entity_is_available_hides_ui_route_when_route_not_visible() -> None:
+    """UI-route entities become unavailable when route visibility is false."""
+    runtime = _runtime_stub(route_visible=False)
+    descriptor = {
+        "symbol": "PARAM_177",
+        CONF_UI_ROUTE_SYMBOL: True,
+    }
+    assert entity_is_available(runtime, devid="dev1", has_value=True, descriptor=descriptor) is False
+
+
+def test_entity_is_available_keeps_non_ui_route_when_route_hidden() -> None:
+    """Non UI-route entities ignore route visibility gating."""
+    runtime = _runtime_stub(route_visible=False)
+    descriptor = {
+        "symbol": "PARAM_9",
+        CONF_UI_ROUTE_SYMBOL: False,
+    }
+    assert entity_is_available(runtime, devid="dev1", has_value=True, descriptor=descriptor) is True
+
+
+def test_route_visibility_listener_receives_callbacks() -> None:
+    """Registered route-visibility listeners receive fan-out events."""
+    runtime = _runtime_stub(route_visible=True)
+    seen: list[tuple[str, str, bool]] = []
+    runtime.add_route_visibility_listener(lambda devid, symbol, visible: seen.append((devid, symbol, visible)))
+    for callback in tuple(runtime._route_visibility_listeners):
+        callback("dev1", "PARAM_177", False)
+    assert seen == [("dev1", "PARAM_177", False)]

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", git = "https://github.com/marpi82/py-bragerone?branch=fix%2Fstrefy-czasowe-menu-192" },
+    { name = "py-bragerone", specifier = "==2026.9.0b4" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,8 +2216,8 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.9.0b4.dev3+g29c1e7e7e"
-source = { git = "https://github.com/marpi82/py-bragerone?branch=fix%2Fstrefy-czasowe-menu-192#29c1e7e7e64ba15fd2fe6923be696153cc42e503" }
+version = "2026.9.0b4"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
@@ -2225,6 +2225,10 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/12/ed/dbf44c118866acc366f4608d79f697380153d4c38e3a916301d6f5fe2e9e/py_bragerone-2026.9.0b4.tar.gz", hash = "sha256:c20744dcbe107d89a7640aad66f8859020e0d9ca4844368bbf77fc70cc54d814", size = 124460, upload-time = "2026-08-24T18:25:37.647Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bd/65/6bd56ca48f1396ea3402a775545af8ed86c0b632f0e8f4bd19dceb2a2c40/py_bragerone-2026.9.0b4-py3-none-any.whl", hash = "sha256:46b40d7b1519481ff60feff25cf253678b73f20c408a49ef5da7406e9b7b1f39", size = 131093, upload-time = "2026-08-24T18:25:36.096Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = "==2026.9.0b3" },
+    { name = "py-bragerone", editable = "../py-bragerone" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,8 +2216,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.9.0b3"
-source = { registry = "https://pypi.org/simple" }
+source = { editable = "../py-bragerone" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
@@ -2226,9 +2225,50 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/bc/5bf1dc58e4e24e01aa02dca2f11ac20785870fc608d4f830bb4ab87c44ec/py_bragerone-2026.9.0b3.tar.gz", hash = "sha256:c7342ee3b8be150d1723d70c83550b19273a401451f27ef33ec9baf2dab56dc8", size = 121688, upload-time = "2026-08-23T09:55:54.329Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/14/a1/9dc9c4218c455012baec5bb337f61ee6f9110b6e0d47a89d795376dc490c/py_bragerone-2026.9.0b3-py3-none-any.whl", hash = "sha256:82dafd6082fe4fff7dba7c18bafeb3bcf3a18bd36a1a37548227380f2d88ce37", size = 128201, upload-time = "2026-08-23T09:55:52.776Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "aiofiles", marker = "extra == 'cli'", specifier = ">=24.1" },
+    { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
+    { name = "keyring", marker = "extra == 'keyring'", specifier = ">=25.0.0" },
+    { name = "pydantic", specifier = ">=2.10.4,<3.0.0" },
+    { name = "python-socketio", extras = ["asyncio-client"], specifier = ">=5.14.0,<6.0.0" },
+    { name = "rich", marker = "extra == 'cli'", specifier = ">=12.6.0" },
+    { name = "tree-sitter", specifier = ">=0.21.3" },
+    { name = "tree-sitter-javascript", specifier = ">=0.21.1" },
+    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.16.0" },
+    { name = "typing-extensions", specifier = ">=4.15.0,<5.0.0" },
+]
+provides-extras = ["cli", "keyring"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "bandit", specifier = ">=1.8.4,<2.0.0" },
+    { name = "hatch", specifier = ">=1.12.0,<2.0.0" },
+    { name = "keyring", specifier = ">=25.0.0,<26.0.0" },
+    { name = "mypy", extras = ["dmypy"], specifier = ">=2.3.0,<2.4.0" },
+    { name = "pip-audit", specifier = ">=2.4.0,<3.0.0" },
+    { name = "poethepoet", specifier = ">=0.48.0,<0.49.0" },
+    { name = "pre-commit", specifier = ">=4.3.0,<5.0.0" },
+    { name = "python-dotenv", specifier = ">=1.1.1,<2.0.0" },
+    { name = "ruff", specifier = ">=0.16.2,<0.17.0" },
+]
+docs = [
+    { name = "furo", specifier = ">=2025.9.25,<2026.0.0" },
+    { name = "myst-parser", specifier = ">=4.0.0,<6.0.0" },
+    { name = "sphinx", specifier = ">=8.0.2,<10.0.0" },
+    { name = "sphinx-autodoc-typehints", specifier = ">=3.2.0,<4.0.0" },
+    { name = "sphinx-copybutton", specifier = ">=0.5.2,<0.6.0" },
+]
+fuzz = [{ name = "atheris", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=2.3.0" }]
+test = [
+    { name = "hypothesis", specifier = ">=6.112.0,<7.0.0" },
+    { name = "packaging", specifier = ">=24.1,<27.0.0" },
+    { name = "pytest", specifier = ">=8.3.3,<10.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.2.0,<2.0.0" },
+    { name = "pytest-codspeed", specifier = ">=5.0.3,<5.1.0" },
+    { name = "pytest-cov", specifier = ">=7.0.0,<8.0.0" },
+    { name = "pytest-httpx", specifier = ">=0.35.0,<0.37.0" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", editable = "../py-bragerone" },
+    { name = "py-bragerone", git = "https://github.com/marpi82/py-bragerone?branch=fix%2Fstrefy-czasowe-menu-192" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,7 +2216,8 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-source = { editable = "../py-bragerone" }
+version = "2026.9.0b4.dev3+g29c1e7e7e"
+source = { git = "https://github.com/marpi82/py-bragerone?branch=fix%2Fstrefy-czasowe-menu-192#29c1e7e7e64ba15fd2fe6923be696153cc42e503" }
 dependencies = [
     { name = "httpx" },
     { name = "pydantic" },
@@ -2224,51 +2225,6 @@ dependencies = [
     { name = "tree-sitter" },
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "aiofiles", marker = "extra == 'cli'", specifier = ">=24.1" },
-    { name = "httpx", specifier = ">=0.25.0,<1.0.0" },
-    { name = "keyring", marker = "extra == 'keyring'", specifier = ">=25.0.0" },
-    { name = "pydantic", specifier = ">=2.10.4,<3.0.0" },
-    { name = "python-socketio", extras = ["asyncio-client"], specifier = ">=5.14.0,<6.0.0" },
-    { name = "rich", marker = "extra == 'cli'", specifier = ">=12.6.0" },
-    { name = "tree-sitter", specifier = ">=0.21.3" },
-    { name = "tree-sitter-javascript", specifier = ">=0.21.1" },
-    { name = "typer", marker = "extra == 'cli'", specifier = ">=0.16.0" },
-    { name = "typing-extensions", specifier = ">=4.15.0,<5.0.0" },
-]
-provides-extras = ["cli", "keyring"]
-
-[package.metadata.requires-dev]
-dev = [
-    { name = "bandit", specifier = ">=1.8.4,<2.0.0" },
-    { name = "hatch", specifier = ">=1.12.0,<2.0.0" },
-    { name = "keyring", specifier = ">=25.0.0,<26.0.0" },
-    { name = "mypy", extras = ["dmypy"], specifier = ">=2.3.0,<2.4.0" },
-    { name = "pip-audit", specifier = ">=2.4.0,<3.0.0" },
-    { name = "poethepoet", specifier = ">=0.48.0,<0.49.0" },
-    { name = "pre-commit", specifier = ">=4.3.0,<5.0.0" },
-    { name = "python-dotenv", specifier = ">=1.1.1,<2.0.0" },
-    { name = "ruff", specifier = ">=0.16.2,<0.17.0" },
-]
-docs = [
-    { name = "furo", specifier = ">=2025.9.25,<2026.0.0" },
-    { name = "myst-parser", specifier = ">=4.0.0,<6.0.0" },
-    { name = "sphinx", specifier = ">=8.0.2,<10.0.0" },
-    { name = "sphinx-autodoc-typehints", specifier = ">=3.2.0,<4.0.0" },
-    { name = "sphinx-copybutton", specifier = ">=0.5.2,<0.6.0" },
-]
-fuzz = [{ name = "atheris", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'", specifier = ">=2.3.0" }]
-test = [
-    { name = "hypothesis", specifier = ">=6.112.0,<7.0.0" },
-    { name = "packaging", specifier = ">=24.1,<27.0.0" },
-    { name = "pytest", specifier = ">=8.3.3,<10.0.0" },
-    { name = "pytest-asyncio", specifier = ">=1.2.0,<2.0.0" },
-    { name = "pytest-codspeed", specifier = ">=5.0.3,<5.1.0" },
-    { name = "pytest-cov", specifier = ">=7.0.0,<8.0.0" },
-    { name = "pytest-httpx", specifier = ">=0.35.0,<0.37.0" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- **BOOTSTRAP_VERSION 13**: pass prime `flat_values` into panel groups; enrich route meta for static shell routes; persist `ui_route_symbol` / `route_visibility_*` on descriptors; stable `menu_key` for group-by-menu child device **Strefy czasowe**.
- **Runtime**: re-evaluate route visibility on dependency updates; UI-route entities become unavailable when SPA hides the route (no entity-registry auto disable).
- Tests: `test_bootstrap_strefy_czasowe.py`, `test_runtime_route_visibility.py`; stub updates for new ParamResolver APIs.

Schedule harmonogram grids (OD/DO/zmiana nastawy) are **out of scope** — tracked in #236.

## Merge order

1. Merge and release **py-bragerone** PR (route visibility + static route discovery).
2. Remove `[tool.uv.sources]` path override from this branch, pin `py-bragerone==2026.9.0b4` in `manifest.json` / `pyproject.toml`, refresh `uv.lock` (same pattern as #235).
3. Mark this PR ready and merge.

This draft currently uses editable sibling `py-bragerone` for CI/typecheck against unreleased APIs.

## Test plan

- [x] `uv run poe validate` (with local `py-bragerone`)
- [ ] Reload integration after merge; group-by-menu shows child device **Strefy czasowe**; `select` **Tryb nastaw cyrkulacji** editable

Fixes #192.