### PR TITLE
ci: BragerOne triage bot caller and path labeler

### DIFF
--- a/.github/branch-protection-checklist.md
+++ b/.github/branch-protection-checklist.md
@@ -65,3 +65,21 @@ on **Enforce release channel** in `release.yml` (and `release.sh` on
 
 Re-run Scorecard / Security Checks if those workflows are enabled for this repo
 so BranchProtection re-evaluates.
+
+## BragerOne triage bot
+
+`bragerone-triage.yml` calls the reusable workflow in `py-bragerone` on `main`.
+Set the same `BRAGERONE_*` repository variables as documented in
+`py-bragerone/.github/branch-protection-checklist.md` (section **BragerOne triage
+bot**).
+
+**User-owned projects** cannot link repositories in Manage access — add secret
+**`PROJECTS_TOKEN`** (fine-grained PAT with Projects read/write) in both repos.
+Status option IDs are opaque strings (`PVTSSG_…`), not numbers; copy from
+`py-bragerone/scripts/github_project_setup.sh marpi82 2`.
+
+Enable Actions **Read and write** workflow permissions.
+
+Path labels: `pull-request-labeler.yml` + `.github/labeler.yml`. Repo label
+`ha-bragerone` is added by triage; type labels on PRs come from linked issues or
+title prefixes (`bug:`, `feat:`, `docs:`).

--- a/.github/branch-protection-checklist.md
+++ b/.github/branch-protection-checklist.md
@@ -74,8 +74,9 @@ Set the same `BRAGERONE_*` repository variables as documented in
 bot**).
 
 **User-owned projects** cannot link repositories in Manage access — add secret
-**`PROJECTS_TOKEN`** (fine-grained PAT with Projects read/write) in both repos.
-Status option IDs are opaque strings (`PVTSSG_…`), not numbers; copy from
+**`PROJECTS_TOKEN`** (classic PAT with **`project`** + **`repo`** scopes; fine-grained
+PATs do not work for user Projects v2) in both repos. Status option IDs are opaque
+strings (`f75ad846`, …), not board column numbers; copy from
 `py-bragerone/scripts/github_project_setup.sh marpi82 2`.
 
 Enable Actions **Read and write** workflow permissions.

--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,32 @@
+documentation:
+  - changed-files:
+      - any-glob-to-any-file:
+          - docs/**
+          - README.md
+
+ci:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/**
+
+github_actions:
+  - changed-files:
+      - any-glob-to-any-file:
+          - .github/workflows/**
+
+testing:
+  - changed-files:
+      - any-glob-to-any-file:
+          - tests/**
+
+python:
+  - changed-files:
+      - any-glob-to-any-file:
+          - custom_components/habragerone/**
+
+dependencies:
+  - changed-files:
+      - any-glob-to-any-file:
+          - pyproject.toml
+          - uv.lock
+          - manifest.json

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -34,15 +34,24 @@
 - name: good first issue
   description: Good for newcomers
   color: 7057ff
+- name: ha-bragerone
+  description: ha-bragerone repository (BragerOne triage)
+  color: 1d76db
 - name: help wanted
   description: Extra attention is needed
   color: 008672
+- name: homeassistant
+  description: Home Assistant core or integration platform updates
+  color: 5319e7
 - name: invalid
   description: This doesn't seem right
   color: e4e669
 - name: performance
   description: Performance
   color: "016175"
+- name: py-bragerone
+  description: py-bragerone repository (BragerOne triage)
+  color: 1d76db
 - name: python
   description: Pull requests that update Python code
   color: 2b67c6
@@ -55,6 +64,9 @@
 - name: removal
   description: Removals and Deprecations
   color: 9ae7ea
+- name: renovate
+  description: Renovate dependency updates
+  color: 1d76db
 - name: style
   description: Style
   color: c120e5

--- a/.github/workflows/bragerone-triage.yml
+++ b/.github/workflows/bragerone-triage.yml
@@ -4,7 +4,7 @@ on:
   issues:
     types: [opened, reopened, closed]
   pull_request:
-    types: [opened, reopened, ready_for_review, closed]
+    types: [opened, reopened, ready_for_review, converted_to_draft, closed]
 
 permissions:
   issues: write

--- a/.github/workflows/bragerone-triage.yml
+++ b/.github/workflows/bragerone-triage.yml
@@ -1,0 +1,48 @@
+name: BragerOne triage
+
+on:
+  issues:
+    types: [opened, reopened, closed]
+  pull_request:
+    types: [opened, reopened, ready_for_review, closed]
+
+permissions:
+  issues: write
+  pull-requests: write
+  contents: read
+  projects: write
+
+jobs:
+  triage-issue:
+    name: Triage issue
+    if: github.event_name == 'issues'
+    uses: marpi82/py-bragerone/.github/workflows/bragerone-triage-reusable.yml@main
+    secrets: inherit
+    with:
+      repo_label: ha-bragerone
+      content_type: issue
+      content_number: ${{ github.event.issue.number }}
+      content_node_id: ${{ github.event.issue.node_id }}
+      title: ${{ github.event.issue.title }}
+      body: ${{ github.event.issue.body || '' }}
+      action: ${{ github.event.action }}
+      labels_json: ${{ toJSON(github.event.issue.labels) }}
+      actor: ${{ github.event.issue.user.login }}
+
+  triage-pull-request:
+    name: Triage pull request
+    if: github.event_name == 'pull_request'
+    uses: marpi82/py-bragerone/.github/workflows/bragerone-triage-reusable.yml@main
+    secrets: inherit
+    with:
+      repo_label: ha-bragerone
+      content_type: pull_request
+      content_number: ${{ github.event.pull_request.number }}
+      content_node_id: ${{ github.event.pull_request.node_id }}
+      title: ${{ github.event.pull_request.title }}
+      body: ${{ github.event.pull_request.body || '' }}
+      action: ${{ github.event.action }}
+      is_draft: ${{ github.event.pull_request.draft }}
+      merged: ${{ github.event.pull_request.merged }}
+      labels_json: ${{ toJSON(github.event.pull_request.labels) }}
+      actor: ${{ github.event.pull_request.user.login }}

--- a/.github/workflows/pull-request-labeler.yml
+++ b/.github/workflows/pull-request-labeler.yml
@@ -1,0 +1,22 @@
+name: Pull request labeler
+
+on:
+  pull_request:
+    types: [opened, reopened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  labeler:
+    name: Label changed paths
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
+
+      - name: Run path labeler
+        uses: actions/labeler@634933edcd8ababfe52f92936142cc22ac488b1b # v6.0.1
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Call `marpi82/py-bragerone` reusable triage workflow on issue/PR events.
- Path-based PR labeler; extend `labels.yml` with repo / renovate / homeassistant labels.
- Document `PROJECTS_TOKEN` (user project cannot link repos in Manage access).

## Depends on
Merge **py-bragerone** triage PR first so `bragerone-triage-reusable.yml@main` exists.

## Test plan
- [ ] After py-bragerone is on `main`, open a test issue here → `ha-bragerone` label + project Status **Backlog**.
- [ ] PR touching `docs/**` gets `documentation`.