### PR TITLE
feat(diagnostics): expose last_live_param_update_age_s in cloud session

### DIFF
--- a/custom_components/habragerone/diagnostics.py
+++ b/custom_components/habragerone/diagnostics.py
@@ -55,10 +55,13 @@ async def async_get_config_entry_diagnostics(hass: HomeAssistant, entry: ConfigE
                 }
             age_fn = getattr(brager_runtime.gateway, "last_param_update_age_s", None)
             age_s = age_fn() if callable(age_fn) else None
+            live_age_fn = getattr(brager_runtime.gateway, "last_live_param_update_age_s", None)
+            live_age_s = live_age_fn() if callable(live_age_fn) else None
             cloud_session = {
                 "up": brager_runtime.cloud_session_up(),
                 "supported": brager_runtime.supports_cloud_session,
                 "last_param_update_age_s": round(age_s, 1) if isinstance(age_s, (int, float)) else None,
+                "last_live_param_update_age_s": round(live_age_s, 1) if isinstance(live_age_s, (int, float)) else None,
             }
 
     platform_counter: Counter[str] = Counter()

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -75,6 +75,7 @@ class FakeGateway:
         self._cloud_session_callbacks: list[Any] = []
         self._ws_session_up = False
         self._last_param_update_age_s: float | None = None
+        self._last_live_param_update_age_s: float | None = None
         self._start_error = start_error
         self._start_delay = start_delay
         self.started = False
@@ -120,6 +121,13 @@ class FakeGateway:
     def last_param_update_age_s(self) -> float | None:
         """Return seconds since the last fake ParamUpdate, or ``None``."""
         age = self._last_param_update_age_s
+        if isinstance(age, bool) or not isinstance(age, int | float):
+            return None
+        return float(age)
+
+    def last_live_param_update_age_s(self) -> float | None:
+        """Return seconds since the last fake live WS ParamUpdate, or ``None``."""
+        age = self._last_live_param_update_age_s
         if isinstance(age, bool) or not isinstance(age, int | float):
             return None
         return float(age)

--- a/tests/test_diagnostics.py
+++ b/tests/test_diagnostics.py
@@ -135,7 +135,12 @@ async def test_diagnostics_includes_module_connectivity(hass: HomeAssistant) -> 
     assert connectivity["DEV1"]["online"] is True
     assert connectivity["DEV1"]["connectedAt"] == 99
     assert "DEV2" in connectivity
-    assert payload["cloud_session"] == {"up": None, "supported": True, "last_param_update_age_s": None}
+    assert payload["cloud_session"] == {
+        "up": None,
+        "supported": True,
+        "last_param_update_age_s": None,
+        "last_live_param_update_age_s": None,
+    }
 
 
 @pytest.mark.asyncio
@@ -145,12 +150,18 @@ async def test_diagnostics_reports_last_param_update_age(hass: HomeAssistant) ->
 
     runtime, _api, gateway, _store = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
     gateway._last_param_update_age_s = 12.34
+    gateway._last_live_param_update_age_s = 45.67
     runtime._cloud_session_up = True
     entry = register_config_entry(hass, runtime=runtime, descriptors=[])
     hass.data[DOMAIN][entry.entry_id][DATA_RUNTIME] = runtime
 
     payload = await async_get_config_entry_diagnostics(hass, entry)
-    assert payload["cloud_session"] == {"up": True, "supported": True, "last_param_update_age_s": 12.3}
+    assert payload["cloud_session"] == {
+        "up": True,
+        "supported": True,
+        "last_param_update_age_s": 12.3,
+        "last_live_param_update_age_s": 45.7,
+    }
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add `last_live_param_update_age_s` to config-entry diagnostics `cloud_session` block.
- Companion to py-bragerone zombie-session fix — helps distinguish REST snapshots from a frozen WS push stream.

Depends on py-bragerone exposing `last_live_param_update_age_s()` (py-bragerone#346); field is optional via `getattr` until the library pin is bumped.

## Test plan
- [x] `uv run poe test -- tests/test_diagnostics.py`
- [ ] After py-bragerone release + manifest pin bump, verify diagnostics show both ages under load