### PR TITLE
chore(release): bump manifest to 2026.9.0b5

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -19,5 +19,5 @@
     "py-bragerone==2026.9.0b4",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.9.0b4"
+  "version": "2026.9.0b5"
 }


### PR DESCRIPTION
## Summary
- Bump `manifest.json` to `2026.9.0b5` after rebasing `release/2026.9` onto `main` (#243).
- Prerequisite for tagging the next HACS pre-release on the current train tip.

## Test plan
- [ ] CI green
- [ ] Tag `2026.9.0b5` from `release/2026.9` after merge