### PR TITLE
chore(release): pin py-bragerone 2026.9.0b5 for train beta

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,7 +16,7 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.9.0b4",
+    "py-bragerone==2026.9.0b5",
     "tree-sitter==0.26.0"
   ],
   "version": "2026.9.0b4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone==2026.9.0b4",
+    "py-bragerone==2026.9.0b5",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = "==2026.9.0b4" },
+    { name = "py-bragerone", specifier = "==2026.9.0b5" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.9.0b4"
+version = "2026.9.0b5"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2226,9 +2226,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/ed/dbf44c118866acc366f4608d79f697380153d4c38e3a916301d6f5fe2e9e/py_bragerone-2026.9.0b4.tar.gz", hash = "sha256:c20744dcbe107d89a7640aad66f8859020e0d9ca4844368bbf77fc70cc54d814", size = 124460, upload-time = "2026-08-24T18:25:37.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/18/c9/27ade7d91fb04de1304e550c031a4a4a41d4a6ec1d67b8ca2427a81fe56e/py_bragerone-2026.9.0b5.tar.gz", hash = "sha256:ab2ba2a78ec4198bbb4509e7f347636a6d1fa9ffe723af2ccc68d788a410e865", size = 125250, upload-time = "2026-08-24T19:29:54.849Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/65/6bd56ca48f1396ea3402a775545af8ed86c0b632f0e8f4bd19dceb2a2c40/py_bragerone-2026.9.0b4-py3-none-any.whl", hash = "sha256:46b40d7b1519481ff60feff25cf253678b73f20c408a49ef5da7406e9b7b1f39", size = 131093, upload-time = "2026-08-24T18:25:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/41/20/07dc220e5ae002bc51bf703a26267f454fe6a73b76c9728b31f51114e857/py_bragerone-2026.9.0b5-py3-none-any.whl", hash = "sha256:fea723f1fdfa105f1c49c104657e0bf0bcb3da2a639ca6aa20e5396434dea007", size = 131873, upload-time = "2026-08-24T19:29:53.568Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `py-bragerone==2026.9.0b5` (PyPI pre-release from rebased `release/2026.9`, tag after #347).
- Bump integration `manifest.json` version to `2026.9.0b5`.
- Refresh `uv.lock`.

Replaces closed #244 (manifest-only bump without library pin).

## Test plan
- [x] `uv run poe validate` locally
- [ ] CI / HACS gates green
- [ ] Tag `2026.9.0b5` on `release/2026.9` after merge