### PR TITLE
chore(release): set manifest version to 2026.9.0b5

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -19,5 +19,5 @@
     "py-bragerone==2026.9.0b5",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.9.0b4"
+  "version": "2026.9.0b5"
 }


### PR DESCRIPTION
Follow-up to #245 — manifest `version` was still `2026.9.0b4` while pin was bumped.