### PR TITLE
fix(#192): Strefy czasowe menu_key via localized shell diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The integration can be configured through the Home Assistant UI. You will need:
 - Installation and module selection
 - Device grouping (flat = one HA device per internet module for parameters, connectivity, alarms, and activity; group by menu = parameter entities on child devices per **parent** menu route with `via_device`, while connectivity/alarms/activity stay on the parent module — remaps device membership when changed).
 
-After upgrading to a release that bumps `BOOTSTRAP_VERSION` (currently **13** for static menu routes / #192), reload the integration or re-add it so entity descriptors pick up new menu metadata.
+After upgrading to a release that bumps `BOOTSTRAP_VERSION` (currently **14** for static menu routes / #192), reload the integration or re-add it so entity descriptors pick up new menu metadata.
 
 Every permission-gated parameter becomes an entity — there is no separate UI/permissions filtering mode to choose. Entities that are outside the everyday BragerOne web UI (installer-only panels, or panels the SPA itself hides) are still created, but start **disabled** in the entity registry; enable them manually if you need them. Enable/disable state can be changed per-entity at any time from the entity registry.
 

--- a/custom_components/habragerone/bootstrap.py
+++ b/custom_components/habragerone/bootstrap.py
@@ -1213,7 +1213,10 @@ async def async_build_bootstrap_payload(
                 per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu)
                 per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu)
                 module_route_dep_index = _route_dep_index_from_menu(menu)
-                routes_i18n = await resolver._i18n.get_namespace("routes")
+                # Must match build_panel_groups titles (menu + string-default overlays),
+                # not bare ``routes`` namespace — otherwise shell enrich misses localized
+                # panel paths like ``Strefy czasowe`` vs ``MAINMENU_STREFY_CZASOWE`` (#192).
+                routes_i18n = await resolver._panel_title_i18n(menu)
                 per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
                     menu,
                     all_panels=True,
@@ -1238,7 +1241,7 @@ async def async_build_bootstrap_payload(
                 per_module_symbol_kinds[module.devid] = _collect_symbol_kinds_from_menu(menu_retry)
                 per_module_symbol_routes[module.devid] = _collect_symbol_route_meta_from_menu(menu_retry)
                 module_route_dep_index = _route_dep_index_from_menu(menu_retry)
-                routes_i18n = await resolver._i18n.get_namespace("routes")
+                routes_i18n = await resolver._panel_title_i18n(menu_retry)
                 per_module_route_diagnostics[module.devid] = resolver.panel_route_diagnostics_from_menu(
                     menu_retry,
                     all_panels=True,

--- a/custom_components/habragerone/const.py
+++ b/custom_components/habragerone/const.py
@@ -40,7 +40,7 @@ CONF_RAW_TO_LABEL: Final = "raw_to_label"
 CONF_BOOTSTRAP_DEBUG: Final = "bootstrap_debug"
 CONF_BOOTSTRAP_VERSION: Final = "bootstrap_version"
 CONF_UPSTREAM_ASSETS_FINGERPRINT: Final = "upstream_assets_fingerprint"
-BOOTSTRAP_VERSION: Final = 13
+BOOTSTRAP_VERSION: Final = 14
 
 # Stable non-menu source key for module connectivity (SPA ``module.connection.*`` i18n).
 # Kept separate from menu-router paths so HA #165 can place these on a child device.

--- a/tests/test_bootstrap_strefy_czasowe.py
+++ b/tests/test_bootstrap_strefy_czasowe.py
@@ -45,11 +45,47 @@ def test_shell_diagnostics_enrich_symbol_routes() -> None:
             "panel_shell": True,
         }
     ]
-    panel_paths = {"PARAM_177": "Strefy czasowe"}
+    panel_paths = {"PARAM_177": "Strefy czasowe", "PARAM_219": "Strefy czasowe"}
     symbol_routes: dict[str, list[dict[str, Any]]] = {}
     _enrich_symbol_routes_from_shell_diagnostics(panel_paths, symbol_routes, diagnostics)
     assert symbol_routes["PARAM_177"][0]["name"] == "MAINMENU_STREFY_CZASOWE"
+    assert symbol_routes["PARAM_219"][0]["path"] == "timezones"
     assert _stable_menu_key_from_route_meta(symbol_routes["PARAM_177"]) == "MAINMENU_STREFY_CZASOWE"
+    assert (
+        _resolve_menu_key_for_symbol(
+            symbol="PARAM_219",
+            panel_path="Strefy czasowe",
+            symbol_routes=symbol_routes,
+            panel_menu_keys={},
+        )
+        == "MAINMENU_STREFY_CZASOWE"
+    )
+
+
+def test_shell_diagnostics_enrich_requires_localized_panel_title() -> None:
+    """Unresolved MAINMENU_* titles must not silently match localized panel paths.
+
+    Live bootstrap used bare ``routes`` i18n for diagnostics while panel groups used
+    ``_panel_title_i18n`` — enrichment then left PARAM_219 without ``menu_key`` and
+    group-by-menu hid the Strefy czasowe child device. Bootstrap must localize both.
+    """
+    diagnostics = [
+        {
+            "title": "MAINMENU_STREFY_CZASOWE",
+            "panel_title": "MAINMENU_STREFY_CZASOWE",
+            "name": "MAINMENU_STREFY_CZASOWE",
+            "path": "timezones",
+            "accepted": True,
+            "panel_shell": True,
+        }
+    ]
+    symbol_routes: dict[str, list[dict[str, Any]]] = {}
+    _enrich_symbol_routes_from_shell_diagnostics(
+        {"PARAM_219": "Strefy czasowe"},
+        symbol_routes,
+        diagnostics,
+    )
+    assert symbol_routes == {}
 
 
 def test_shell_diagnostics_skip_existing_route_meta() -> None:


### PR DESCRIPTION
## Summary
- Live dump (`2026.9.0b5`, `bootstrap_version: 13`, `device_grouping: group_by_menu`) showed `PARAM_219` with `panel_path: Strefy czasowe` but `menu_key: null` and empty `accepted_symbol_routes_sample`.
- Root cause: shell route diagnostics used bare `routes` i18n (`MAINMENU_STREFY_CZASOWE`) while panel groups used `_panel_title_i18n` (`Strefy czasowe`), so `_enrich_symbol_routes_from_shell_diagnostics` never attached route meta.
- Fix: use `resolver._panel_title_i18n(menu)` for diagnostics (same titles as panel groups). Bump `BOOTSTRAP_VERSION` to **14**.

## Test plan
- [x] `uv run poe validate`
- [ ] After merge + beta: reload integration (rebootstrap v14) with group-by-menu → child device **Strefy czasowe** with select **Tryb nastaw cyrkulacji**