### PR TITLE
chore(release): pin py-bragerone 2026.9.0b6 for train beta

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.9.0b5",
+    "py-bragerone==2026.9.0b6",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.9.0b5"
+  "version": "2026.9.0b6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone==2026.9.0b5",
+    "py-bragerone==2026.9.0b6",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = "==2026.9.0b5" },
+    { name = "py-bragerone", specifier = "==2026.9.0b6" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.9.0b5"
+version = "2026.9.0b6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2226,9 +2226,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/18/c9/27ade7d91fb04de1304e550c031a4a4a41d4a6ec1d67b8ca2427a81fe56e/py_bragerone-2026.9.0b5.tar.gz", hash = "sha256:ab2ba2a78ec4198bbb4509e7f347636a6d1fa9ffe723af2ccc68d788a410e865", size = 125250, upload-time = "2026-08-24T19:29:54.849Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/df/00/f68dc83e1784123ceef5330c1ac082e14a0b19b511ecf62efd454923928d/py_bragerone-2026.9.0b6.tar.gz", hash = "sha256:986693ccddc9cc49cca9d080c77b1298ee2cdae6073724acdd85285b933e8580", size = 126664, upload-time = "2026-08-25T08:56:06.309Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/41/20/07dc220e5ae002bc51bf703a26267f454fe6a73b76c9728b31f51114e857/py_bragerone-2026.9.0b5-py3-none-any.whl", hash = "sha256:fea723f1fdfa105f1c49c104657e0bf0bcb3da2a639ca6aa20e5396434dea007", size = 131873, upload-time = "2026-08-24T19:29:53.568Z" },
+    { url = "https://files.pythonhosted.org/packages/49/2f/8ec255a5769f74cfbd5b1fd4b2a0f415e92d53e2869bc3e68d490470b5bb/py_bragerone-2026.9.0b6-py3-none-any.whl", hash = "sha256:fdb3da7fabcbdc42f2c230ef9617e3da98c2114779f5dee98067525eb9510e26", size = 133299, upload-time = "2026-08-25T08:56:04.683Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `py-bragerone==2026.9.0b6` (PyPI pre-release after merging main → `release/2026.9`, including zombie recovery #348).
- Bump integration `manifest.json` version to `2026.9.0b6`.
- Refresh `uv.lock`.

Also ships with already-merged [#247](https://github.com/marpi82/ha-bragerone/pull/247) (Strefy czasowe `menu_key` / localized shell diagnostics, `BOOTSTRAP_VERSION=14`).

## Test plan
- [x] `uv run poe validate` locally
- [ ] CI / HACS gates green
- [ ] Tag `2026.9.0b6` on `release/2026.9` after merge
- [ ] Reload integration → rebootstrap v14 → Strefy czasowe child device under group-by-menu