### PR TITLE
chore: release 2026.8.9 (py-bragerone 2026.8.9)

### DIFF
--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.8.9rc7",
+    "py-bragerone==2026.8.9",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.8.6rc9"
+  "version": "2026.8.9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone>=2026.8.9rc7",
+    "py-bragerone==2026.8.9",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/uv.lock
+++ b/uv.lock
@@ -1163,7 +1163,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = ">=2026.8.9rc7" },
+    { name = "py-bragerone", specifier = "==2026.8.9" },
 ]
 
 [package.metadata.requires-dev]
@@ -2216,7 +2216,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.9.0b4"
+version = "2026.8.9"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2226,9 +2226,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/12/ed/dbf44c118866acc366f4608d79f697380153d4c38e3a916301d6f5fe2e9e/py_bragerone-2026.9.0b4.tar.gz", hash = "sha256:c20744dcbe107d89a7640aad66f8859020e0d9ca4844368bbf77fc70cc54d814", size = 124460, upload-time = "2026-08-24T18:25:37.647Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/84/19/d7242b4018f2147d69a952069f7fbfbbd24351b47dc59ecd0c2c1723db0c/py_bragerone-2026.8.9.tar.gz", hash = "sha256:8df708ddcf58898a5ecbc26a25cc79ad59478a1bcb52e7b6ba9e5ecaeaa07d38", size = 121763, upload-time = "2026-08-26T05:07:57.051Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bd/65/6bd56ca48f1396ea3402a775545af8ed86c0b632f0e8f4bd19dceb2a2c40/py_bragerone-2026.9.0b4-py3-none-any.whl", hash = "sha256:46b40d7b1519481ff60feff25cf253678b73f20c408a49ef5da7406e9b7b1f39", size = 131093, upload-time = "2026-08-24T18:25:36.096Z" },
+    { url = "https://files.pythonhosted.org/packages/36/25/5e5c38c7f75c3ac1bc3c2f4f7f1b3751433debe12b7ef27873da75697247/py_bragerone-2026.8.9-py3-none-any.whl", hash = "sha256:731580997ca8ec2c899283f684cc23164272aa3b2b0446c0b1057ad336254915", size = 127418, upload-time = "2026-08-26T05:07:55.749Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pins ``py-bragerone==2026.8.9`` (PyPI stable from ``main``) in ``manifest.json``, ``pyproject.toml``, and ``uv.lock``.
- Sets ``manifest.json`` ``version`` to ``2026.8.9`` so the HACS zip matches the upcoming tag.
- Uses an exact library pin so ``uv lock`` cannot pick ``2026.9.0b6`` (PEP 440-newer pre-release already on PyPI).

After merge, tag ``2026.8.9`` from ``main`` (``scripts/release.sh 2026.8.9`` / annotated tag push).

## Test plan
- [ ] CI / HA Integration Tests / HACS Validation green
- [ ] Wheel-compat resolves ``py-bragerone==2026.8.9`` from PyPI
- [ ] After merge, push tag ``2026.8.9`` from ``origin/main``