### PR TITLE
Release/2026.9.1

### DIFF
--- a/.github/instructions/tests.instructions.md
+++ b/.github/instructions/tests.instructions.md
@@ -13,4 +13,4 @@ applyTo: "tests/**/*.py"
    - command route selection (`parameter_write` vs `raw_command`).
 4. **Bootstrap**: classification/filtering changes need descriptor fixtures covering each platform type.
 5. **Naming tests**: entity naming/unique_id patterns are contractual — keep regression tests for them.
-6. **Style**: same ruff/mypy rules as the integration; coverage gate is `--cov-fail-under=80` (pre-push). CI uploads to Codecov (patch target 100%, project informational).
+6. **Style**: same ruff/mypy rules as the integration; **pre-push** enforces 80% project coverage and 100% patch vs `merge-base origin/main` via `scripts/check_patch_coverage.sh` (`uv run poe patch-cov`). CI uploads to Codecov (patch target 100%, project informational).

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -82,12 +82,12 @@ repos:
         files: ^custom_components/.*/strings\.json$
         pass_filenames: false
 
-  # --- Tests on pre-push with coverage gate ---
+  # --- Tests on pre-push: project 80% + patch 100% vs main (Codecov parity) ---
   - repo: local
     hooks:
       - id: pytest-pre-push
-        name: pytest (coverage gate on push)
+        name: pytest (coverage gates on push)
         language: system
-        entry: bash -lc 'uv run --group test pytest --maxfail=1 --disable-warnings -q --cov=custom_components.habragerone --cov-report=term-missing --cov-fail-under=80'
+        entry: bash scripts/check_patch_coverage.sh
         pass_filenames: false
         stages: [pre-push]

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,10 +19,11 @@ uv run poe lint                  # ruff check --fix
 uv run poe typecheck             # mypy --strict (python_version 3.14, pydantic plugin)
 uv run poe test                  # pytest (pytest-homeassistant-custom-component)
 uv run poe cov                   # coverage report (the 80% threshold is enforced only by the pre-push hook)
+uv run poe patch-cov             # pre-push parity: 80% project + 100% patch vs merge-base origin/main
 uv run poe validate              # fmt + lint + typecheck + security + test
 ```
 
-CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable. CI uploads `coverage.xml` to Codecov (`codecov-commenter` on PRs; skip Dependabot/Renovate and forks). Patch coverage target is 100% on pull requests only (`only_pulls` in `codecov.yml` — avoids false failures on main merge commits with a bad compare base); project coverage is informational — the 80% floor stays on pre-push. `manifest.json` is ignored so release version bumps do not affect patch.
+CI additionally runs hassfest, HACS action, manifest/strings JSON validation, wheel-compat checks, and a Docker matrix against HA `2026.3.0` (declared minimum — bump together with `hacs.json`/`pyproject.toml`) / `latest` / `dev`. Each workflow ends in an aggregate **gate job** (`CI`, `HA Integration Tests`, `HACS Validation`) that fails if any required job fails; the `protect-main` ruleset requires only these gates, so renaming jobs or matrix legs never requires ruleset changes — keep the gate job names stable. CI uploads `coverage.xml` to Codecov (`codecov-commenter` on PRs; skip Dependabot/Renovate and forks). Patch coverage target is 100% on pull requests only (`only_pulls` in `codecov.yml` — avoids false failures on main merge commits with a bad compare base); project coverage is informational — the 80% floor stays on pre-push via `scripts/check_patch_coverage.sh` (`diff-cover` vs `merge-base origin/main`, same diff basis as Codecov PR patch). `manifest.json` is ignored so release version bumps do not affect patch.
 
 ## Architecture in one paragraph
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -16,7 +16,7 @@ uv sync --group dev --group test
 # Install pre-commit hooks (commit-stage checks)
 uv run pre-commit install
 
-# Install pre-push hook (80% coverage gate on git push)
+# Install pre-push hook (80% project + 100% patch coverage vs origin/main)
 uv run pre-commit install --hook-type pre-push
 
 # Start development environment
@@ -44,7 +44,7 @@ uv run pytest
 uv run pytest --cov=custom_components.habragerone --cov-report=term-missing
 ```
 
-CI uploads `coverage.xml` to Codecov (skipped for Dependabot/Renovate and fork PRs). Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational (the 80% floor is the pre-push hook — see setup commands above).
+CI uploads `coverage.xml` to Codecov (skipped for Dependabot/Renovate and fork PRs). Pull requests get a `codecov-commenter` report. Patch coverage target is 100%; overall project coverage is informational. **Pre-push** enforces 80% project coverage and 100% patch vs `merge-base origin/main` via `scripts/check_patch_coverage.sh` (`uv run poe patch-cov` — same diff basis as Codecov PR patch).
 
 Issue and PR templates live under `.github/ISSUE_TEMPLATE/` and `.github/PULL_REQUEST_TEMPLATE.md`. Optional Copilot code review is configured in the GitHub repo settings (not via a workflow).
 

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.9.0",
+    "py-bragerone==2026.9.1",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.9.0"
+  "version": "2026.9.1"
 }

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -197,10 +197,13 @@ class BragerRuntime:
         if resolver is None:
             return
         changed: list[tuple[str, str, bool]] = []
+        flat_by_devid: dict[str, dict[str, Any]] = {}
         for lookup_key, (devid, symbol, route_name, route_path) in self._symbol_route_lookup.items():
             if symbols is not None and symbol not in symbols:
                 continue
-            flat_values = self.store.flatten_for_devid(devid)
+            if devid not in flat_by_devid:
+                flat_by_devid[devid] = self.store.flatten_for_devid(devid)
+            flat_values = flat_by_devid[devid]
             menu = await self._menu_for_devid(devid, resolver)
             if menu is None:
                 continue
@@ -1407,7 +1410,6 @@ async def _resolve_activity_display_value(raw: Any, *, unit_code: Any, resolver:
             return await resolve_display(raw, unit_code=unit_code)
         except Exception:
             LOGGER.debug("resolve_raw_display_value failed", exc_info=True)
-            return raw
     resolve_unit = getattr(resolver, "resolve_unit", None)
     if not callable(resolve_unit):
         return raw

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -96,6 +96,9 @@ class BragerRuntime:
         register_session = getattr(self.gateway, "on_cloud_session", None)
         if self.supports_cloud_session and callable(register_session):
             register_session(self._on_gateway_cloud_session)
+        register_alarm_qty = getattr(self.gateway, "on_alarm_quantity", None)
+        if self.supports_alarm_quantity and callable(register_alarm_qty):
+            register_alarm_qty(self._on_gateway_alarm_quantity)
         try:
             await self.gateway.start()
         except Exception:
@@ -193,11 +196,11 @@ class BragerRuntime:
         resolver = await self._async_get_resolver()
         if resolver is None:
             return
-        flat_values = self.store.flatten()
         changed: list[tuple[str, str, bool]] = []
         for lookup_key, (devid, symbol, route_name, route_path) in self._symbol_route_lookup.items():
             if symbols is not None and symbol not in symbols:
                 continue
+            flat_values = self.store.flatten_for_devid(devid)
             menu = await self._menu_for_devid(devid, resolver)
             if menu is None:
                 continue
@@ -324,6 +327,11 @@ class BragerRuntime:
         return callable(getattr(self.gateway, "on_cloud_session", None)) and callable(
             getattr(self.gateway, "ws_session_up", None)
         )
+
+    @property
+    def supports_alarm_quantity(self) -> bool:
+        """Return whether the gateway exposes alarm-quantity push callbacks (#254)."""
+        return callable(getattr(self.gateway, "on_alarm_quantity", None))
 
     @property
     def supports_module_alarms(self) -> bool:
@@ -507,7 +515,10 @@ class BragerRuntime:
                 if isinstance(errors, Mapping):
                     self._errors_i18n = dict(errors)
             if callable(parse_fn):
-                source = await _fetch_alarms_chunk_source(catalog, self.api)
+                fetch_source = getattr(catalog, "fetch_alarm_name_source", None)
+                source: str | bytes | None = None
+                if callable(fetch_source):
+                    source = await fetch_source()
                 if source:
                     parsed = parse_fn(source)
                     if isinstance(parsed, dict):
@@ -781,6 +792,24 @@ class BragerRuntime:
         if not isinstance(up, bool):
             return
         self._apply_cloud_session(up)
+
+    def _on_gateway_alarm_quantity(self, event: Any) -> None:
+        """Refresh alarm feed when SPA alarm count changes for a subscribed module."""
+        if not getattr(event, "changed", True):
+            return
+        devid = str(getattr(event, "devid", "") or "").strip()
+        if not devid:
+            return
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        task = asyncio.create_task(
+            self.async_refresh_alarms(devid),
+            name=f"habragerone-alarms-qty-{devid}",
+        )
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)
 
     def _apply_module_online(
         self,
@@ -1111,7 +1140,7 @@ class BragerRuntime:
             # Store and dispatcher are independent bus subscribers; upsert first so
             # route visibility sees this delta rather than the previous snapshot.
             if getattr(update, "value", None) is not None:
-                self.store.upsert(update_key, update.value)
+                self.store.upsert(update_key, update.value, devid=update.devid)
             affected_symbols = self._route_visibility_dep_to_symbols.get(update_key)
             if affected_symbols:
                 await self.refresh_route_visibility(set(affected_symbols))
@@ -1369,9 +1398,16 @@ async def _resolve_activity_i18n_token(token: str | None, *, resolver: Any) -> s
 
 
 async def _resolve_activity_display_value(raw: Any, *, unit_code: Any, resolver: Any) -> Any:
-    """Map a raw activity value through unit enum tables when possible."""
+    """Map a raw activity value through unit enum tables and numeric transforms."""
     if resolver is None or unit_code is None or raw is None:
         return raw
+    resolve_display = getattr(resolver, "resolve_raw_display_value", None)
+    if callable(resolve_display):
+        try:
+            return await resolve_display(raw, unit_code=unit_code)
+        except Exception:
+            LOGGER.debug("resolve_raw_display_value failed", exc_info=True)
+            return raw
     resolve_unit = getattr(resolver, "resolve_unit", None)
     if not callable(resolve_unit):
         return raw
@@ -1464,41 +1500,3 @@ def _resolve_alarm_row_name(
         return None
     value = errors_i18n.get(key)
     return value.strip() if isinstance(value, str) and value.strip() else None
-
-
-async def _fetch_alarms_chunk_source(catalog: Any, api: Any) -> str | bytes | None:
-    """Best-effort fetch of the SPA Alarms chunk for ``AlarmName`` parsing."""
-    idx = getattr(catalog, "_idx", None)
-    assets = getattr(idx, "assets_by_basename", None)
-    find_basename = getattr(idx, "find_asset_for_basename", None)
-    asset = None
-    if callable(find_basename):
-        for candidate in ("Alarms", "alarms"):
-            asset = find_basename(candidate)
-            if asset is not None:
-                break
-    if asset is None and isinstance(assets, Mapping):
-        for basename, refs in assets.items():
-            if not isinstance(basename, str) or not basename.casefold().startswith("alarms"):
-                continue
-            if isinstance(refs, list) and refs:
-                asset = refs[-1]
-                break
-    if asset is None:
-        return None
-    url = getattr(asset, "url", None)
-    if not isinstance(url, str) or not url.strip():
-        return None
-    get_bytes = getattr(api, "get_bytes", None)
-    if not callable(get_bytes):
-        return None
-    try:
-        payload = await get_bytes(url)
-    except Exception:
-        LOGGER.debug("Failed to fetch Alarms chunk from %s", url, exc_info=True)
-        return None
-    if isinstance(payload, (bytes, str)):
-        return payload
-    if isinstance(payload, bytearray):
-        return bytes(payload)
-    return None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ test = [
   "aioresponses>=0.7.8,<0.8.0",
   "packaging>=24.1,<27.0.0",
   "pytest-homeassistant-custom-component>=0.13.205",
+  "diff-cover>=10.5.1,<10.6.0",
 ]
 
 # ---------------- Ruff (formatter + linter) ----------------
@@ -159,6 +160,7 @@ validate = ["fmt", "lint", "typecheck", "security", "test"]
 # Tests
 test = { cmd = "pytest -q" }
 cov = { cmd = "pytest -q --cov=custom_components.habragerone --cov-report=term-missing" }
+patch-cov = { shell = "scripts/check_patch_coverage.sh" }
 # HA Development
 hass = { shell = "python -m homeassistant --config config --debug" }
 hass-restart = { shell = "pkill -f homeassistant || true && python -m homeassistant --config config --debug" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone==2026.9.0",
+    "py-bragerone==2026.9.1",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/scripts/check_patch_coverage.sh
+++ b/scripts/check_patch_coverage.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+# Pre-push test gates: 80% project coverage + 100% patch vs main (Codecov parity).
+set -euo pipefail
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "${repo_root}"
+
+uv run --group test pytest --maxfail=1 --disable-warnings -q \
+  --cov=custom_components.habragerone \
+  --cov-branch \
+  --cov-report=term-missing \
+  --cov-report=xml \
+  --cov-fail-under=80
+
+if ! git rev-parse --verify origin/main >/dev/null 2>&1; then
+  echo "patch coverage: skip (origin/main unavailable)"
+  exit 0
+fi
+
+compare_ref="$(git merge-base HEAD origin/main)"
+echo "patch coverage vs ${compare_ref}"
+uv run --group test diff-cover coverage.xml \
+  --compare-branch="${compare_ref}" \
+  --fail-under=100 \
+  --show-uncovered

--- a/tests/helpers/fakes.py
+++ b/tests/helpers/fakes.py
@@ -73,6 +73,7 @@ class FakeGateway:
         self._gateway: dict[str, dict[str, object]] = {}
         self._connectivity_callbacks: list[Any] = []
         self._cloud_session_callbacks: list[Any] = []
+        self._alarm_quantity_callbacks: list[Any] = []
         self._ws_session_up = False
         self._last_param_update_age_s: float | None = None
         self._last_live_param_update_age_s: float | None = None
@@ -100,6 +101,10 @@ class FakeGateway:
     def on_cloud_session(self, callback: Any) -> None:
         """Register a CloudSessionConnectivity callback (mirrors BragerOneGateway)."""
         self._cloud_session_callbacks.append(callback)
+
+    def on_alarm_quantity(self, callback: Any) -> None:
+        """Register an AlarmQuantityChanged callback (mirrors BragerOneGateway)."""
+        self._alarm_quantity_callbacks.append(callback)
 
     def module_online(self, devid: str) -> bool | None:
         """Return cached online flag, or ``None`` when unknown."""
@@ -173,14 +178,24 @@ class FakeStore:
 
     def __init__(self, *, flat_values: dict[str, object] | None = None) -> None:
         self._flat = dict(flat_values or {})
+        self._by_devid: dict[str, dict[str, object]] = {}
         self.run_started = False
         self.run_cancelled = False
 
     def flatten(self) -> dict[str, object]:
         return dict(self._flat)
 
-    def upsert(self, key: str, value: object) -> None:
+    def flatten_for_devid(self, devid: str) -> dict[str, object]:
+        bucket = self._by_devid.get(devid)
+        if bucket is None:
+            return {}
+        return dict(bucket)
+
+    def upsert(self, key: str, value: object, *, devid: str | None = None) -> None:
         """Mirror ``ParamStore.upsert`` so dispatch can apply deltas before flatten()."""
+        if devid is not None:
+            bucket = self._by_devid.setdefault(devid, {})
+            bucket[str(key)] = value
         self._flat[str(key)] = value
 
     def get_family(self, pool: str, idx: int) -> dict[str, object] | None:

--- a/tests/test_platform_alarms.py
+++ b/tests/test_platform_alarms.py
@@ -27,7 +27,6 @@ from custom_components.habragerone.event_feeds import (  # noqa: E402
 )
 from custom_components.habragerone.runtime import (  # noqa: E402
     _extract_alarm_rows,
-    _fetch_alarms_chunk_source,
     _resolve_alarm_row_name,
 )
 from custom_components.habragerone.sensor import async_setup_entry  # noqa: E402
@@ -511,25 +510,6 @@ async def test_async_get_alarm_chrome_labels_caches_results() -> None:
 
 
 @pytest.mark.asyncio
-async def test_fetch_alarms_chunk_source_reads_bytes_payload() -> None:
-    """Alarms chunk fetch accepts bytes/str/bytearray API payloads."""
-    catalog = types.SimpleNamespace(
-        _idx=types.SimpleNamespace(
-            find_asset_for_basename=lambda _name: types.SimpleNamespace(url="https://example/alarms.js"),
-            assets_by_basename={},
-        )
-    )
-
-    async def _get_bytes(_url: str) -> bytes:
-        return b'38:"ERROR_BYTES"'
-
-    api = types.SimpleNamespace(get_bytes=_get_bytes)
-
-    source = await _fetch_alarms_chunk_source(catalog, api)
-    assert source == b'38:"ERROR_BYTES"'
-
-
-@pytest.mark.asyncio
 async def test_iter_alarm_feed_entities_fail_closed_without_api(hass: HomeAssistant) -> None:
     """No entities when the API client lacks alarms helpers."""
     runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
@@ -592,10 +572,7 @@ async def test_async_refresh_alarms_loads_name_maps_from_catalog(monkeypatch: py
     catalog = types.SimpleNamespace(
         refresh_index_minimal=AsyncMock(),
         get_i18n=AsyncMock(return_value={"ERROR_FOO": "Foo alarm"}),
-        _idx=types.SimpleNamespace(
-            find_asset_for_basename=lambda _name: types.SimpleNamespace(url="https://example/alarms.js"),
-            assets_by_basename={},
-        ),
+        fetch_alarm_name_source=AsyncMock(return_value=b'9:"ERROR_FOO"'),
     )
     monkeypatch.setattr(
         "custom_components.habragerone.runtime._try_live_assets_catalog",
@@ -617,11 +594,6 @@ async def test_async_refresh_alarms_loads_name_maps_from_catalog(monkeypatch: py
     }
     runtime, *_rest = make_runtime(api=api, modules_meta={"DEV1": {"name": "Boiler"}})
     runtime.language = "en"
-
-    async def _get_bytes(_url: str) -> bytes:
-        return b'9:"ERROR_FOO"'
-
-    api.get_bytes = _get_bytes  # type: ignore[attr-defined]
 
     await runtime.async_refresh_alarms("DEV1")
     current = runtime.alarms_current("DEV1")
@@ -640,10 +612,7 @@ async def test_async_refresh_alarms_resolves_names_without_refresh_index(monkeyp
     catalog = types.SimpleNamespace(
         refresh_index=_broken_refresh_index,
         get_i18n=get_i18n,
-        _idx=types.SimpleNamespace(
-            find_asset_for_basename=lambda _name: types.SimpleNamespace(url="https://example/alarms.js"),
-            assets_by_basename={},
-        ),
+        fetch_alarm_name_source=AsyncMock(return_value=b'9:"ERROR_FOO"'),
     )
     monkeypatch.setattr(
         "custom_components.habragerone.runtime._try_live_assets_catalog",
@@ -665,11 +634,6 @@ async def test_async_refresh_alarms_resolves_names_without_refresh_index(monkeyp
     }
     runtime, *_rest = make_runtime(api=api, modules_meta={"DEV1": {"name": "Boiler"}})
     runtime.language = "en"
-
-    async def _get_bytes(_url: str) -> bytes:
-        return b'9:"ERROR_FOO"'
-
-    api.get_bytes = _get_bytes  # type: ignore[attr-defined]
 
     await runtime.async_refresh_alarms("DEV1")
     assert runtime.alarms_current("DEV1")[0]["name"] == "Foo alarm"
@@ -707,60 +671,6 @@ def test_resolve_alarm_row_name_swallows_resolver_errors(monkeypatch: pytest.Mon
 
     monkeypatch.setattr("custom_components.habragerone.runtime._alarm_name_helpers", lambda: (None, _boom))
     assert _resolve_alarm_row_name(1, alarm_names={1: "ERROR_X"}, errors_i18n={}) is None
-
-
-@pytest.mark.asyncio
-async def test_fetch_alarms_chunk_source_uses_assets_by_basename_fallback() -> None:
-    """When find_asset_for_basename misses, scan assets_by_basename for alarms*.js."""
-    asset = types.SimpleNamespace(url="https://example/Alarms-abc.js")
-    catalog = types.SimpleNamespace(
-        _idx=types.SimpleNamespace(
-            find_asset_for_basename=lambda _name: None,
-            assets_by_basename={"Alarms-abc.js": [asset]},
-        )
-    )
-
-    async def _get_bytes(_url: str) -> str:
-        return '1:"ERROR_ONE"'
-
-    source = await _fetch_alarms_chunk_source(catalog, types.SimpleNamespace(get_bytes=_get_bytes))
-    assert source == '1:"ERROR_ONE"'
-
-
-@pytest.mark.asyncio
-async def test_fetch_alarms_chunk_source_returns_none_on_failures() -> None:
-    """Missing URL/get_bytes or transport errors yield None."""
-    catalog = types.SimpleNamespace(_idx=types.SimpleNamespace(find_asset_for_basename=lambda _n: None, assets_by_basename={}))
-    assert await _fetch_alarms_chunk_source(catalog, types.SimpleNamespace()) is None
-
-    bad_asset = types.SimpleNamespace(url="")
-    catalog2 = types.SimpleNamespace(
-        _idx=types.SimpleNamespace(find_asset_for_basename=lambda _n: bad_asset, assets_by_basename={})
-    )
-    assert await _fetch_alarms_chunk_source(catalog2, types.SimpleNamespace(get_bytes=AsyncMock())) is None
-
-    good_asset = types.SimpleNamespace(url="https://example/a.js")
-
-    async def _boom(_url: str) -> bytes:
-        raise OSError("network")
-
-    catalog3 = types.SimpleNamespace(
-        _idx=types.SimpleNamespace(find_asset_for_basename=lambda _n: good_asset, assets_by_basename={})
-    )
-    assert await _fetch_alarms_chunk_source(catalog3, types.SimpleNamespace(get_bytes=_boom)) is None
-
-
-@pytest.mark.asyncio
-async def test_fetch_alarms_chunk_source_accepts_bytearray_payload() -> None:
-    """Bytearray payloads are normalized to bytes."""
-    asset = types.SimpleNamespace(url="https://example/a.js")
-    catalog = types.SimpleNamespace(_idx=types.SimpleNamespace(find_asset_for_basename=lambda _n: asset, assets_by_basename={}))
-
-    async def _get_bytes(_url: str) -> bytearray:
-        return bytearray(b'2:"ERROR_TWO"')
-
-    source = await _fetch_alarms_chunk_source(catalog, types.SimpleNamespace(get_bytes=_get_bytes))
-    assert source == b'2:"ERROR_TWO"'
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_patch_coverage.py
+++ b/tests/test_runtime_patch_coverage.py
@@ -223,8 +223,10 @@ async def test_resolve_activity_i18n_and_display_value() -> None:
 
     failing_display = SimpleNamespace(
         resolve_raw_display_value=AsyncMock(side_effect=RuntimeError("display boom")),
+        resolve_unit=AsyncMock(return_value={"1": "units.one"}),
+        _unit_mapping_value_label=lambda _unit, _raw: "legacy.mapped",
     )
-    assert await _resolve_activity_display_value(53, unit_code=49, resolver=failing_display) == 53
+    assert await _resolve_activity_display_value(53, unit_code=49, resolver=failing_display) == "legacy.mapped"
 
 
 @pytest.mark.asyncio

--- a/tests/test_runtime_patch_coverage.py
+++ b/tests/test_runtime_patch_coverage.py
@@ -221,6 +221,11 @@ async def test_resolve_activity_i18n_and_display_value() -> None:
     )
     assert await _resolve_activity_display_value(5, unit_code=1, resolver=broken) == 5
 
+    failing_display = SimpleNamespace(
+        resolve_raw_display_value=AsyncMock(side_effect=RuntimeError("display boom")),
+    )
+    assert await _resolve_activity_display_value(53, unit_code=49, resolver=failing_display) == 53
+
 
 @pytest.mark.asyncio
 async def test_normalize_activity_row_coerces_scalar_ids() -> None:
@@ -1012,3 +1017,24 @@ async def test_on_gateway_alarm_quantity_schedules_refresh() -> None:
         runtime._on_gateway_alarm_quantity(types.SimpleNamespace(devid="DEV1", changed=False))
         await asyncio.sleep(0)
         assert scheduled == []
+
+
+def test_on_gateway_alarm_quantity_ignores_blank_devid() -> None:
+    """Blank devid must not schedule alarm refresh work."""
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+
+    with patch.object(BragerRuntime, "async_refresh_alarms", AsyncMock()) as refresh:
+        runtime._on_gateway_alarm_quantity(types.SimpleNamespace(devid="   ", changed=True))
+        refresh.assert_not_called()
+
+
+def test_on_gateway_alarm_quantity_requires_running_loop() -> None:
+    """Without a running event loop the callback must not spawn background work."""
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+
+    with (
+        patch.object(asyncio, "get_running_loop", side_effect=RuntimeError),
+        patch.object(BragerRuntime, "async_refresh_alarms", AsyncMock()) as refresh,
+    ):
+        runtime._on_gateway_alarm_quantity(types.SimpleNamespace(devid="DEV1", changed=True))
+        refresh.assert_not_called()

--- a/tests/test_runtime_patch_coverage.py
+++ b/tests/test_runtime_patch_coverage.py
@@ -28,7 +28,6 @@ from custom_components.habragerone.runtime import (  # noqa: E402
     _alarm_name_helpers,
     _extract_activity_rows,
     _extract_alarm_rows,
-    _fetch_alarms_chunk_source,
     _module_events_rest_ok,
     _resolve_activity_display_value,
     _resolve_activity_i18n_token,
@@ -210,6 +209,11 @@ async def test_resolve_activity_i18n_and_display_value() -> None:
     )
     assert await _resolve_activity_i18n_token("units.one", resolver=resolver) == "Resolved"
     assert await _resolve_activity_display_value(1, unit_code=38, resolver=resolver) == "Resolved"
+
+    display_resolver = SimpleNamespace(
+        resolve_raw_display_value=AsyncMock(return_value=5.3),
+    )
+    assert await _resolve_activity_display_value(53, unit_code=49, resolver=display_resolver) == 5.3
 
     broken = SimpleNamespace(
         resolve_unit=AsyncMock(side_effect=RuntimeError("boom")),
@@ -467,24 +471,6 @@ def test_alarm_helper_and_catalog_edge_paths(monkeypatch: pytest.MonkeyPatch) ->
         __import__("sys").modules, "pybragerone.models.catalog", types.SimpleNamespace(LiveAssetsCatalog=_broken_catalog)
     )
     assert _try_live_assets_catalog(object()) is None
-
-
-@pytest.mark.asyncio
-async def test_fetch_alarms_chunk_source_asset_scan_and_failures() -> None:
-    """Alarm chunk fetch scans basename map and tolerates network errors."""
-    asset = types.SimpleNamespace(url="https://example/Alarms-x.js")
-    catalog = types.SimpleNamespace(
-        _idx=types.SimpleNamespace(
-            find_asset_for_basename=lambda _n: None,
-            assets_by_basename={"AlarmsChunk": [asset]},
-        )
-    )
-    assert await _fetch_alarms_chunk_source(catalog, types.SimpleNamespace(get_bytes=None)) is None
-
-    async def _get_bytes(_url: str) -> bytes:
-        raise OSError("offline")
-
-    assert await _fetch_alarms_chunk_source(catalog, types.SimpleNamespace(get_bytes=_get_bytes)) is None
 
 
 @pytest.mark.asyncio
@@ -751,25 +737,6 @@ def test_resolve_alarm_row_name_swallows_helper_errors(monkeypatch: pytest.Monke
 
 
 @pytest.mark.asyncio
-async def test_fetch_alarms_chunk_source_scans_assets_and_rejects_payload_type() -> None:
-    """Alarm chunk fetch scans basename maps and rejects unknown payload types."""
-    asset = types.SimpleNamespace(url="https://example/Alarms-x.js")
-    other = types.SimpleNamespace(url="https://example/menu.js")
-    catalog = types.SimpleNamespace(
-        _idx=types.SimpleNamespace(
-            find_asset_for_basename=lambda _n: None,
-            assets_by_basename={"menu.js": [other], "AlarmsChunk": [asset]},
-        )
-    )
-
-    async def _get_bytes(_url: str) -> object:
-        return 42
-
-    source = await _fetch_alarms_chunk_source(catalog, types.SimpleNamespace(get_bytes=_get_bytes))
-    assert source is None
-
-
-@pytest.mark.asyncio
 async def test_load_alarm_name_maps_partial_branches(monkeypatch: pytest.MonkeyPatch) -> None:
     """Alarm name loading covers non-callable/empty/non-mapping branches."""
     catalog = types.SimpleNamespace(
@@ -791,7 +758,7 @@ async def test_load_alarm_name_maps_partial_branches(monkeypatch: pytest.MonkeyP
 
     catalog2 = types.SimpleNamespace(
         get_i18n=AsyncMock(return_value="not-a-mapping"),
-        _idx=types.SimpleNamespace(find_asset_for_basename=lambda _n: None, assets_by_basename={}),
+        fetch_alarm_name_source=AsyncMock(return_value=b"source"),
     )
     monkeypatch.setattr(
         "custom_components.habragerone.runtime._try_live_assets_catalog",
@@ -801,18 +768,18 @@ async def test_load_alarm_name_maps_partial_branches(monkeypatch: pytest.MonkeyP
         "custom_components.habragerone.runtime._alarm_name_helpers",
         lambda: (lambda _src: "not-dict", None),
     )
-    monkeypatch.setattr(
-        "custom_components.habragerone.runtime._fetch_alarms_chunk_source",
-        AsyncMock(return_value=b"source"),
-    )
     runtime2, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
     runtime2.language = "en"
     await runtime2._load_alarm_name_maps()
     assert runtime2._alarm_names == {}
 
+    catalog3 = types.SimpleNamespace(
+        get_i18n=AsyncMock(return_value={"ERROR_X": "Fuel"}),
+        fetch_alarm_name_source=AsyncMock(return_value=None),
+    )
     monkeypatch.setattr(
-        "custom_components.habragerone.runtime._fetch_alarms_chunk_source",
-        AsyncMock(return_value=None),
+        "custom_components.habragerone.runtime._try_live_assets_catalog",
+        lambda _api: catalog3,
     )
     monkeypatch.setattr(
         "custom_components.habragerone.runtime._alarm_name_helpers",
@@ -920,36 +887,6 @@ async def test_resolve_activity_display_value_without_mapping_label_hook() -> No
     assert await _resolve_activity_display_value(1, unit_code=1, resolver=resolver) == "units.one"
 
 
-@pytest.mark.asyncio
-async def test_fetch_alarms_chunk_without_find_basename() -> None:
-    """Chunk fetch can scan assets when ``find_asset_for_basename`` is absent."""
-    asset = types.SimpleNamespace(url="https://example/Alarms-x.js")
-    catalog = types.SimpleNamespace(
-        _idx=types.SimpleNamespace(
-            find_asset_for_basename=None,
-            assets_by_basename={"menu": [], "AlarmsEmpty": [], "AlarmsChunk": [asset]},
-        )
-    )
-
-    async def _get_bytes(_url: str) -> bytes:
-        return b'1:"ERROR_X"'
-
-    source = await _fetch_alarms_chunk_source(catalog, types.SimpleNamespace(get_bytes=_get_bytes))
-    assert source == b'1:"ERROR_X"'
-
-
-@pytest.mark.asyncio
-async def test_fetch_alarms_chunk_skips_non_list_alarm_basenames() -> None:
-    """Basename scan ignores alarms keys whose refs are empty or not lists."""
-    catalog = types.SimpleNamespace(
-        _idx=types.SimpleNamespace(
-            find_asset_for_basename=None,
-            assets_by_basename={"AlarmsBroken": "nope", "alarmsEmpty": []},
-        )
-    )
-    assert await _fetch_alarms_chunk_source(catalog, types.SimpleNamespace(get_bytes=AsyncMock())) is None
-
-
 def test_module_events_rest_ok() -> None:
     """REST tuple guard accepts only 200/204 success tuples with app-level status."""
     assert _module_events_rest_ok((200, {"alarms": []})) is True
@@ -1055,3 +992,23 @@ async def test_async_refresh_activity_task_ownership_race() -> None:
 
     with patch.object(BragerRuntime, "_async_refresh_activity_impl", _hijack):
         await runtime.async_refresh_activity("DEV1")
+
+
+@pytest.mark.asyncio
+async def test_on_gateway_alarm_quantity_schedules_refresh() -> None:
+    """Alarm quantity push events schedule async_refresh_alarms for the devid."""
+    runtime, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    scheduled: list[str] = []
+
+    async def _refresh(_self: BragerRuntime, devid: str) -> None:
+        scheduled.append(devid)
+
+    with patch.object(BragerRuntime, "async_refresh_alarms", _refresh):
+        runtime._on_gateway_alarm_quantity(types.SimpleNamespace(devid="DEV1", changed=True))
+        await asyncio.sleep(0)
+        assert scheduled == ["DEV1"]
+
+        scheduled.clear()
+        runtime._on_gateway_alarm_quantity(types.SimpleNamespace(devid="DEV1", changed=False))
+        await asyncio.sleep(0)
+        assert scheduled == []

--- a/tests/test_runtime_patch_coverage.py
+++ b/tests/test_runtime_patch_coverage.py
@@ -797,6 +797,33 @@ async def test_load_alarm_name_maps_partial_branches(monkeypatch: pytest.MonkeyP
     await runtime3._load_alarm_name_maps()
     assert runtime3._alarm_names == {}
 
+    catalog4 = types.SimpleNamespace(get_i18n=AsyncMock(return_value={}))
+    monkeypatch.setattr(
+        "custom_components.habragerone.runtime._try_live_assets_catalog",
+        lambda _api: catalog4,
+    )
+    monkeypatch.setattr(
+        "custom_components.habragerone.runtime._alarm_name_helpers",
+        lambda: (lambda _src: {38: "ERROR_X"}, None),
+    )
+    runtime4, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    runtime4.language = "en"
+    await runtime4._load_alarm_name_maps()
+    assert runtime4._alarm_names == {}
+
+    catalog5 = types.SimpleNamespace(
+        get_i18n=AsyncMock(return_value={}),
+        fetch_alarm_name_source=AsyncMock(return_value=b"alarms-chunk"),
+    )
+    monkeypatch.setattr(
+        "custom_components.habragerone.runtime._try_live_assets_catalog",
+        lambda _api: catalog5,
+    )
+    runtime5, *_rest = make_runtime(modules_meta={"DEV1": {"name": "Boiler"}})
+    runtime5.language = "en"
+    await runtime5._load_alarm_name_maps()
+    assert runtime5._alarm_names == {38: "ERROR_X"}
+
 
 @pytest.mark.asyncio
 async def test_load_activity_assets_partial_branches(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_runtime_resolve.py
+++ b/tests/test_runtime_resolve.py
@@ -373,7 +373,7 @@ async def test_dispatch_upserts_store_before_route_visibility() -> None:
 
     async def _refresh(_self: BragerRuntime, symbols: set[str] | None = None) -> None:
         _ = symbols
-        seen.append(_self.store.flatten().get("P6.v219"))
+        seen.append(_self.store.flatten_for_devid("DEV1").get("P6.v219"))
         refreshed.set()
 
     await runtime.start()

--- a/tests/test_runtime_route_visibility.py
+++ b/tests/test_runtime_route_visibility.py
@@ -21,7 +21,7 @@ def _runtime_stub(*, route_visible: bool = True) -> BragerRuntime:
     runtime = BragerRuntime(
         api=MagicMock(),
         gateway=MagicMock(modules=[]),
-        store=MagicMock(flatten=MagicMock(return_value={})),
+        store=MagicMock(flatten=MagicMock(return_value={}), flatten_for_devid=MagicMock(return_value={})),
         modules_meta={"dev1": {"device_menu": 0, "name": "mod", "permissions": []}},
         language="pl",
     )
@@ -96,7 +96,7 @@ def test_register_route_visibility_skips_non_ui_descriptors() -> None:
     runtime = BragerRuntime(
         api=MagicMock(),
         gateway=MagicMock(modules=[]),
-        store=MagicMock(flatten=MagicMock(return_value={})),
+        store=MagicMock(flatten=MagicMock(return_value={}), flatten_for_devid=MagicMock(return_value={})),
         modules_meta={},
         language="pl",
     )
@@ -125,7 +125,7 @@ async def test_refresh_route_visibility_updates_symbol_state() -> None:
         children=[],
     )
     _attach_menu_resolver(runtime, routes=[circulation_route])
-    runtime.store.flatten.return_value = {"P6.v219": 0}
+    runtime.store.flatten_for_devid.return_value = {"P6.v219": 0}
 
     await runtime.refresh_route_visibility({"PARAM_219"})
 

--- a/tests/test_runtime_route_visibility.py
+++ b/tests/test_runtime_route_visibility.py
@@ -130,6 +130,31 @@ async def test_refresh_route_visibility_updates_symbol_state() -> None:
     await runtime.refresh_route_visibility({"PARAM_219"})
 
     assert runtime.route_visible_for_symbol("dev1", "PARAM_219") is False
+    runtime.store.flatten_for_devid.assert_called_once_with("dev1")
+
+
+@pytest.mark.asyncio
+async def test_refresh_route_visibility_caches_flat_values_per_devid() -> None:
+    """Per-module flatten snapshots are computed once per refresh pass."""
+    runtime = _runtime_stub(route_visible=True)
+    route_a = SimpleNamespace(
+        name="modules.menu.circulation",
+        path="circulation",
+        meta=SimpleNamespace(display_dropdown="P6.v219"),
+        children=[],
+    )
+    route_b = SimpleNamespace(
+        name="MAINMENU_STREFY_CZASOWE",
+        path="timezones",
+        meta=SimpleNamespace(display_dropdown="![]"),
+        children=[],
+    )
+    _attach_menu_resolver(runtime, routes=[route_a, route_b])
+
+    await runtime.refresh_route_visibility(None)
+
+    assert runtime.store.flatten_for_devid.call_count == 1
+    runtime.store.flatten_for_devid.assert_called_with("dev1")
 
 
 @pytest.mark.asyncio

--- a/uv.lock
+++ b/uv.lock
@@ -709,6 +709,25 @@ wheels = [
 ]
 
 [[package]]
+name = "chardet"
+version = "7.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/cd61c567092a6cec796144510a68aff158ebfc1df82950a45bae65f28413/chardet-7.6.0.tar.gz", hash = "sha256:93d9df6089ded42ed1fe9f57e272c0b74bd0464d45c0c7d50f09f26f31105c3c", size = 914462, upload-time = "2026-08-14T20:36:59.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cf/78/e14991c9487277ed7d006fff58f3084ac792ed94cced081788abb95df70c/chardet-7.6.0-cp314-cp314-macosx_10_15_x86_64.whl", hash = "sha256:c6061adf247ab5dda173b67010e13904c6071717660c7c8077fb50aca362b264", size = 1087678, upload-time = "2026-08-14T20:36:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/40/0f95e04cb1820e0a582cd6d86bbf26be8302a94ccf330f8ba5f69735389d/chardet-7.6.0-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:fc1e1571321baf8927582fe34363ad7f02279f11c8c2839c14b4c76894148db6", size = 1065310, upload-time = "2026-08-14T20:36:44.489Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/a1/04404dcc9d6e1253b02583e562d2c7ddca50a7e91f460d62eff7e1d07c92/chardet-7.6.0-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:8900f6c7cf6b015b17a51767cc6144689059ba1cdceaa383d29eb037ac28579e", size = 1485028, upload-time = "2026-08-14T20:36:45.797Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/88/360064c4c7d9d0664561dae03b74c871d2f5332b329f5c99f1c997fb869a/chardet-7.6.0-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:cedbc584789eb2edfde20fd03669972a833ce6019e60014ae613f9bfc440e8e3", size = 1510242, upload-time = "2026-08-14T20:36:47.206Z" },
+    { url = "https://files.pythonhosted.org/packages/43/4c/302869fa1c69a5a41e4e78782680b12552ffd4286c3ae3c839b7b8df53d4/chardet-7.6.0-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:d5dc835e40e0e09c2c3eab43731a8b5127834f42786dda09ba2f4b699ccd527a", size = 1456456, upload-time = "2026-08-14T20:36:48.668Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/a9/ff4fef15ed25fc3f945a3b981ae0f43c8559b3fbedb40267e59e583d105b/chardet-7.6.0-cp314-cp314-win_amd64.whl", hash = "sha256:0f304de7041afaec0195ad6464937cd112392002e9d72ed15d55f20a9abd3a13", size = 1159103, upload-time = "2026-08-14T20:36:50.107Z" },
+    { url = "https://files.pythonhosted.org/packages/31/44/94e6f89485ce6c630e8fec6d388e3fa747e58b7246b0cc8c5c532ba98650/chardet-7.6.0-cp314-cp314t-macosx_10_15_x86_64.whl", hash = "sha256:a4f0a368ad04d5def08bdfaa17c7e15e71552f93923dc2aa9b2f7d9dee02fbb6", size = 1120302, upload-time = "2026-08-14T20:36:51.484Z" },
+    { url = "https://files.pythonhosted.org/packages/e0/cd/8e68ba12f13aaf4ee82d54ef8a1f83d62942e7a6bc1e579dd2d530a3e26e/chardet-7.6.0-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:75d6c3a4d2046d49e83d2d2206eb073a1f390743e856d90c1bbc19949b26acf4", size = 1093157, upload-time = "2026-08-14T20:36:52.987Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/f6/6a35342b9efa69dcceab0ea8966571c6442a59c336bf460f0a2af95ed234/chardet-7.6.0-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:459e2b1c98f9a86a4698112aa42dffa802bbbff883c1ff144071f87224125862", size = 1521213, upload-time = "2026-08-14T20:36:54.812Z" },
+    { url = "https://files.pythonhosted.org/packages/df/8c/8f09bfabbaedae45caa72b996e96d5e3f6436dfddc55c1311ffa2f6bd7d2/chardet-7.6.0-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0bdb6f03107b7ace3f44e0edd91aa24456ee558787df265cc19daf45785b31c7", size = 1528427, upload-time = "2026-08-14T20:36:56.224Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/6e/5a0b348fa4cd7847567a28c6e697ccf58391960bfd13a6e7473ee23ca2f2/chardet-7.6.0-py3-none-any.whl", hash = "sha256:4076d795897ce45239825956a1334e134322ecc4bfe84dbb12acd5390de0fbc1", size = 680279, upload-time = "2026-08-14T20:36:57.763Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.5.1"
 source = { registry = "https://pypi.org/simple" }
@@ -963,6 +982,21 @@ wheels = [
 ]
 
 [[package]]
+name = "diff-cover"
+version = "10.5.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "chardet" },
+    { name = "jinja2" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e6/74/b71a61b2610b5866aa29a9388bc1b58738e49600345dbe0598676b436717/diff_cover-10.5.1.tar.gz", hash = "sha256:f1c9417c62111e40a81c482c692c5cdd131ff93317baa993044cb291912ebba3", size = 113297, upload-time = "2026-08-16T18:09:19.466Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3d/da/ac0ad341c7377e82f7d6dcb18461029579da224c3923f73ff6537d8591cf/diff_cover-10.5.1-py3-none-any.whl", hash = "sha256:67ce07494e605b5d7d7b04aeec2cf524950ed0c12f026dd176883cf33c74fba0", size = 62924, upload-time = "2026-08-16T18:09:18.387Z" },
+]
+
+[[package]]
 name = "distlib"
 version = "0.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -1170,6 +1204,7 @@ dev = [
 ]
 test = [
     { name = "aioresponses" },
+    { name = "diff-cover" },
     { name = "packaging" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
@@ -1197,6 +1232,7 @@ dev = [
 ]
 test = [
     { name = "aioresponses", specifier = ">=0.7.8,<0.8.0" },
+    { name = "diff-cover", specifier = ">=10.5.1,<10.6.0" },
     { name = "packaging", specifier = ">=24.1,<27.0.0" },
     { name = "pytest", specifier = ">=8.3.3,<10.0.0" },
     { name = "pytest-asyncio", specifier = ">=1.2.0,<2.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1180,7 +1180,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = "==2026.9.0" },
+    { name = "py-bragerone", specifier = "==2026.9.1" },
 ]
 
 [package.metadata.requires-dev]
@@ -2233,7 +2233,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.9.0"
+version = "2026.9.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2243,9 +2243,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/b8/86/9180effe68379e807111b3d3028fc5506b2a4e2c3b3c0d51ef7925a3a644/py_bragerone-2026.9.0.tar.gz", hash = "sha256:5f2b142f4ef635051c3df9ef0a3f886a602b27ca750f027aa82cb5598f5a45ff", size = 130650, upload-time = "2026-09-01T06:58:15.476Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/94/a33023ddab3a6595c38d064b497a585151e7231808679534791860d56743/py_bragerone-2026.9.1.tar.gz", hash = "sha256:4df75f1e3743c62ae1a77cdf5b539213d71d0da4f6d3ea3e0679c635ab0c3acb", size = 133544, upload-time = "2026-09-01T13:45:13.718Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/f6/0a1fd26d56f3f2279f2df4eb072d3ce4bbf8fa2e0b2740f4b3e0f293ecf0/py_bragerone-2026.9.0-py3-none-any.whl", hash = "sha256:8b2586a2fc8e695f8b144157198263c0309a4520974f31cc054985d8cea939f8", size = 137405, upload-time = "2026-09-01T06:58:14.069Z" },
+    { url = "https://files.pythonhosted.org/packages/dd/ef/9207572025d430b31dd453ac3ecef1af452d688e13cc7f51a8c3bc495b82/py_bragerone-2026.9.1-py3-none-any.whl", hash = "sha256:b97e29b8f9e9f9f2c348fde7347793a09ce44f7205ec44e5dbb9d11b904247be", size = 140275, upload-time = "2026-09-01T13:45:12.393Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Pins `py-bragerone==2026.9.1` (PyPI release from py-bragerone#366).
- Consumes new library APIs for alarms chunk fetch, per-module route visibility, alarm-quantity refresh, and activity display transforms.

Closes #252
Closes #253
Closes #254
Closes #255

## Test plan

- [x] `uv run poe validate`
- [ ] After merge: tag HACS release `2026.9.1` via `scripts/release.sh 2026.9.1`