### PR TITLE
fix(#258): avoid blocking alarm_names import in the event loop

### DIFF
--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -21,14 +21,21 @@ from .command_write import WriteContext, WriteValidationError, prepare_write
 from .const import CONF_ROUTE_VISIBILITY_DEPS, CONF_ROUTE_VISIBILITY_NAME, CONF_ROUTE_VISIBILITY_PATH, CONF_UI_ROUTE_SYMBOL
 from .numeric_display import descriptor_numeric_transform
 
-_parse_alarm_name_enum: Any | None
-_resolve_alarm_label: Any | None
-try:
-    from pybragerone.models.alarm_names import parse_alarm_name_enum as _parse_alarm_name_enum
-    from pybragerone.models.alarm_names import resolve_alarm_label as _resolve_alarm_label
-except ImportError:  # Older py-bragerone wheels omit AlarmName helpers.
-    _parse_alarm_name_enum = None
-    _resolve_alarm_label = None
+
+def _import_alarm_name_helpers() -> tuple[Any, Any]:
+    """Import AlarmName helpers; return ``(None, None)`` when unavailable.
+
+    Runs at module load (and in unit tests) so async alarm refresh never calls
+    ``importlib.import_module`` on the event loop.
+    """
+    try:
+        from pybragerone.models.alarm_names import parse_alarm_name_enum, resolve_alarm_label
+    except ImportError:  # Older py-bragerone wheels omit AlarmName helpers.
+        return None, None
+    return parse_alarm_name_enum, resolve_alarm_label
+
+
+_parse_alarm_name_enum, _resolve_alarm_label = _import_alarm_name_helpers()
 
 UpdateCallback = Callable[[ParamUpdate], None]
 # devid, online, online_changed — metadata-only updates set online_changed=False.

--- a/custom_components/habragerone/runtime.py
+++ b/custom_components/habragerone/runtime.py
@@ -21,6 +21,15 @@ from .command_write import WriteContext, WriteValidationError, prepare_write
 from .const import CONF_ROUTE_VISIBILITY_DEPS, CONF_ROUTE_VISIBILITY_NAME, CONF_ROUTE_VISIBILITY_PATH, CONF_UI_ROUTE_SYMBOL
 from .numeric_display import descriptor_numeric_transform
 
+_parse_alarm_name_enum: Any | None
+_resolve_alarm_label: Any | None
+try:
+    from pybragerone.models.alarm_names import parse_alarm_name_enum as _parse_alarm_name_enum
+    from pybragerone.models.alarm_names import resolve_alarm_label as _resolve_alarm_label
+except ImportError:  # Older py-bragerone wheels omit AlarmName helpers.
+    _parse_alarm_name_enum = None
+    _resolve_alarm_label = None
+
 UpdateCallback = Callable[[ParamUpdate], None]
 # devid, online, online_changed — metadata-only updates set online_changed=False.
 ConnectivityCallback = Callable[[str, bool, bool], None]
@@ -1459,14 +1468,8 @@ def _extract_alarm_rows(result: Any) -> list[Mapping[str, Any]]:
 
 
 def _alarm_name_helpers() -> tuple[Any, Any]:
-    """Import AlarmName helpers when present; otherwise return ``(None, None)``."""
-    try:
-        import importlib
-
-        module = importlib.import_module("pybragerone.models.alarm_names")
-    except ImportError:
-        return None, None
-    return getattr(module, "parse_alarm_name_enum", None), getattr(module, "resolve_alarm_label", None)
+    """Return AlarmName helpers when the installed library exposes them."""
+    return _parse_alarm_name_enum, _resolve_alarm_label
 
 
 def _try_live_assets_catalog(api: Any) -> Any | None:

--- a/tests/test_runtime_patch_coverage.py
+++ b/tests/test_runtime_patch_coverage.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import sys
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -27,6 +28,7 @@ from custom_components.habragerone.runtime import (  # noqa: E402
     _alarm_name_helpers,
     _extract_activity_rows,
     _extract_alarm_rows,
+    _import_alarm_name_helpers,
     _module_events_rest_ok,
     _resolve_activity_display_value,
     _resolve_activity_i18n_token,
@@ -673,6 +675,42 @@ def test_alarm_name_helpers_missing_symbols(monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setattr("custom_components.habragerone.runtime._parse_alarm_name_enum", None)
     monkeypatch.setattr("custom_components.habragerone.runtime._resolve_alarm_label", None)
     assert _alarm_name_helpers() == (None, None)
+
+
+def test_import_alarm_name_helpers_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    """ImportError from older wheels yields ``(None, None)`` without raising."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def _mock_import(name: str, globals: object = None, locals: object = None, fromlist: object = (), level: int = 0) -> object:
+        if name == "pybragerone.models.alarm_names":
+            raise ImportError("missing")
+        return real_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", _mock_import)
+    assert _import_alarm_name_helpers() == (None, None)
+
+
+def test_import_alarm_name_helpers_returns_callables(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Successful import binds parse/resolve callables used by the runtime."""
+    import types
+
+    fake = types.ModuleType("pybragerone.models.alarm_names")
+
+    def _parse(_source: object) -> dict[int, str]:
+        return {38: "ERROR_X"}
+
+    def _resolve(_alarm_id: int, *, alarm_names: object, errors_i18n: object) -> str:
+        return "Fuel"
+
+    fake.parse_alarm_name_enum = _parse  # type: ignore[attr-defined]
+    fake.resolve_alarm_label = _resolve  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "pybragerone.models.alarm_names", fake)
+
+    parse_fn, resolve_fn = _import_alarm_name_helpers()
+    assert parse_fn is _parse
+    assert resolve_fn is _resolve
 
 
 def test_try_live_assets_catalog_import_error(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_runtime_patch_coverage.py
+++ b/tests/test_runtime_patch_coverage.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import sys
 import types
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -669,23 +668,11 @@ async def test_resolve_activity_display_value_more_branches() -> None:
     assert await _resolve_activity_display_value(1, unit_code=1, resolver=resolver4) == 1
 
 
-def test_alarm_name_helpers_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Missing AlarmName helpers import as ``(None, None)``."""
-    import importlib
-    import sys
-
-    monkeypatch.delitem(sys.modules, "pybragerone.models.alarm_names", raising=False)
-    real_import_module = importlib.import_module
-
-    def _broken_import_module(name: str, *args: object, **kwargs: object) -> object:
-        if name == "pybragerone.models.alarm_names":
-            raise ImportError("missing")
-        return real_import_module(name, *args, **kwargs)
-
-    monkeypatch.setattr(importlib, "import_module", _broken_import_module)
-    from custom_components.habragerone.runtime import _alarm_name_helpers as reload_helpers
-
-    assert reload_helpers() == (None, None)
+def test_alarm_name_helpers_missing_symbols(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Missing AlarmName helpers surface as ``(None, None)``."""
+    monkeypatch.setattr("custom_components.habragerone.runtime._parse_alarm_name_enum", None)
+    monkeypatch.setattr("custom_components.habragerone.runtime._resolve_alarm_label", None)
+    assert _alarm_name_helpers() == (None, None)
 
 
 def test_try_live_assets_catalog_import_error(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -704,13 +691,16 @@ def test_try_live_assets_catalog_import_error(monkeypatch: pytest.MonkeyPatch) -
 
 
 def test_alarm_name_helpers_returns_imported_symbols(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Helper import returns parse/resolve callables when the module is present."""
-    import types
+    """Helper accessor returns parse/resolve callables when bound at import time."""
 
-    fake = types.ModuleType("pybragerone.models.alarm_names")
-    fake.parse_alarm_name_enum = lambda _source: {38: "ERROR_X"}
-    fake.resolve_alarm_label = lambda alarm_id, *, alarm_names, errors_i18n: "Fuel"
-    monkeypatch.setitem(sys.modules, "pybragerone.models.alarm_names", fake)
+    def _parse(_source: object) -> dict[int, str]:
+        return {38: "ERROR_X"}
+
+    def _resolve(_alarm_id: int, *, alarm_names: object, errors_i18n: object) -> str:
+        return "Fuel"
+
+    monkeypatch.setattr("custom_components.habragerone.runtime._parse_alarm_name_enum", _parse)
+    monkeypatch.setattr("custom_components.habragerone.runtime._resolve_alarm_label", _resolve)
     parse_fn, resolve_fn = _alarm_name_helpers()
     assert callable(parse_fn)
     assert callable(resolve_fn)


### PR DESCRIPTION
## Summary
- Import `pybragerone.models.alarm_names` at module load (optional `ImportError` fallback) instead of `importlib.import_module` during async alarm refresh.
- Keep `_alarm_name_helpers()` as a thin accessor so existing monkeypatches still work.
- Update unit tests to patch the bound callables rather than `import_module`.

Closes #258

## Test plan
- [x] `pytest tests/test_runtime_patch_coverage.py tests/test_platform_alarms.py`
- [x] `poe lint` / `poe typecheck`
- [ ] Reload integration and confirm no `util.loop` blocking `import_module` warning for `alarm_names`