### PR TITLE
fix: HA 2026.9 device registry compatibility

### DIFF
--- a/custom_components/habragerone/entity_common.py
+++ b/custom_components/habragerone/entity_common.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
-from typing import Any
+from collections.abc import Callable, Iterable, Mapping, MutableMapping
+from typing import Any, cast
 
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
@@ -426,12 +426,7 @@ async def async_remove_legacy_connection_devices(
         if not devid:
             continue
         legacy_identifier = (DOMAIN, f"{devid}:{CONNECTION_MENU_KEY}")
-        get_by_identifier = getattr(device_registry, "async_get_device_by_identifier", None)
-        if callable(get_by_identifier):
-            device = get_by_identifier(legacy_identifier, entry.entry_id)
-        else:
-            # HA < 2026.7 — identifiers were globally unique; remove with the next train.
-            device = device_registry.async_get_device(identifiers={legacy_identifier})
+        device = _lookup_device_by_identifier(device_registry, legacy_identifier, entry.entry_id)
         if device is None:
             continue
         entities = er.async_entries_for_device(
@@ -442,6 +437,37 @@ async def async_remove_legacy_connection_devices(
         if entities:
             continue
         device_registry.async_remove_device(device.id)
+
+
+def _lookup_device_by_identifier(
+    device_registry: dr.DeviceRegistry,
+    identifier: tuple[str, str],
+    config_entry_id: str,
+) -> dr.DeviceEntry | None:
+    """Resolve a device by identifier without using deprecated ``async_get_device``.
+
+    Prefers ``async_get_device_by_identifier`` (HA 2026.7+). On older cores, scan
+    ``async_entries_for_config_entry`` — mapping-style ``devices`` access and
+    ``async_get_device`` are hard errors under HA 2026.9+ outside a stable frame.
+    """
+    get_by_identifier = getattr(device_registry, "async_get_device_by_identifier", None)
+    if callable(get_by_identifier):
+        found = get_by_identifier(identifier, config_entry_id)
+        return found if isinstance(found, dr.DeviceEntry) else None
+    for device in dr.async_entries_for_config_entry(device_registry, config_entry_id):
+        if identifier in device.identifiers:
+            return device
+    return None
+
+
+def _set_legacy_via_device(info: DeviceInfo, parent_identifier: tuple[str, str]) -> None:
+    """Attach deprecated ``via_device`` for HA < 2026.7.
+
+    Home Assistant 2026.9 removed ``via_device`` from the ``DeviceInfo`` TypedDict
+    (``via_device_id`` only). The key remains valid at runtime on older cores, so
+    write through a mutable mapping cast instead of a TypedDict key access.
+    """
+    cast(MutableMapping[str, Any], info)["via_device"] = parent_identifier
 
 
 def device_info_from_descriptor(
@@ -519,10 +545,10 @@ def _attach_menu_via_device(
                 )
             except ValueError:
                 # Parent not registered yet — keep a deprecated identifier link.
-                info["via_device"] = parent_identifier
+                _set_legacy_via_device(info, parent_identifier)
             return
     # HA < 2026.7 or callers without hass (pure unit tests of naming/identifiers).
-    info["via_device"] = parent_identifier
+    _set_legacy_via_device(info, parent_identifier)
 
 
 def module_is_reachable(runtime: BragerRuntime, devid: str) -> bool:

--- a/tests/test_entity_common.py
+++ b/tests/test_entity_common.py
@@ -449,6 +449,9 @@ def test_device_info_from_descriptor_group_mode_keeps_parent_without_menu_key() 
 
 def test_device_info_group_by_menu_without_hass_falls_back_to_via_device() -> None:
     """Pure unit callers without hass keep deprecated via_device for HA < 2026.7 shim."""
+    from collections.abc import MutableMapping
+    from typing import Any, cast
+
     descriptor = writable_parameter_descriptor(devid="DEV9", symbol="TEMP")
     descriptor.update(
         {
@@ -458,7 +461,7 @@ def test_device_info_group_by_menu_without_hass_falls_back_to_via_device() -> No
         },
     )
     info = device_info_from_descriptor(descriptor, domain=DOMAIN, grouping=DEVICE_GROUPING_BY_MENU)
-    assert info["via_device"] == (DOMAIN, "DEV9")
+    assert cast(MutableMapping[str, Any], info).get("via_device") == (DOMAIN, "DEV9")
     assert "via_device_id" not in info
 
 
@@ -859,7 +862,7 @@ async def test_async_remove_legacy_connection_devices_falls_back_without_scoped_
     hass: HomeAssistant,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """HA < 2026.7 path uses deprecated async_get_device when scoped lookup is absent."""
+    """HA < 2026.7 path scans devices when scoped lookup is absent."""
     from homeassistant.helpers import device_registry as dr
 
     runtime, *_rest = make_runtime()
@@ -876,7 +879,8 @@ async def test_async_remove_legacy_connection_devices_falls_back_without_scoped_
 
     await async_remove_legacy_connection_devices(hass, entry, devids=["DEV1"])
 
-    assert registry.async_get_device(identifiers={(DOMAIN, "DEV1:module.connection")}) is None
+    legacy_id = (DOMAIN, "DEV1:module.connection")
+    assert not any(legacy_id in device.identifiers for device in dr.async_entries_for_config_entry(registry, entry.entry_id))
 
 
 @pytest.mark.asyncio
@@ -885,6 +889,9 @@ async def test_device_info_falls_back_when_via_device_id_helper_missing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """When async_get_device_id_by_identifier is unavailable, keep via_device."""
+    from collections.abc import MutableMapping
+    from typing import Any, cast
+
     from homeassistant.helpers import device_registry as dr
 
     runtime, *_rest = make_runtime()
@@ -900,13 +907,16 @@ async def test_device_info_falls_back_when_via_device_id_helper_missing(
         hass=hass,
         config_entry_id=entry.entry_id,
     )
-    assert info["via_device"] == (DOMAIN, "DEV9")
+    assert cast(MutableMapping[str, Any], info).get("via_device") == (DOMAIN, "DEV9")
     assert "via_device_id" not in info
 
 
 @pytest.mark.asyncio
 async def test_device_info_falls_back_when_parent_device_missing(hass: HomeAssistant) -> None:
     """Missing parent device (ValueError from helper) keeps via_device link."""
+    from collections.abc import MutableMapping
+    from typing import Any, cast
+
     runtime, *_rest = make_runtime()
     descriptor = writable_parameter_descriptor(devid="DEV9", symbol="TEMP")
     descriptor.update({"menu_key": "modules.menu.thermostats", "menu_group_title": "Menu"})
@@ -920,7 +930,7 @@ async def test_device_info_falls_back_when_parent_device_missing(hass: HomeAssis
         hass=hass,
         config_entry_id=entry.entry_id,
     )
-    assert info["via_device"] == (DOMAIN, "DEV9")
+    assert cast(MutableMapping[str, Any], info).get("via_device") == (DOMAIN, "DEV9")
     assert "via_device_id" not in info
 
 

--- a/tests/test_entity_common.py
+++ b/tests/test_entity_common.py
@@ -25,6 +25,7 @@ from custom_components.habragerone.const import (  # noqa: E402
 from custom_components.habragerone.entity_common import (  # noqa: E402
     _address_selectors_need_compose,
     _is_address_selector_entry,
+    _lookup_device_by_identifier,
     _mapping_value_selector_entries,
     _menu_device_display_name,
     async_register_module_parent_devices,
@@ -881,6 +882,48 @@ async def test_async_remove_legacy_connection_devices_falls_back_without_scoped_
 
     legacy_id = (DOMAIN, "DEV1:module.connection")
     assert not any(legacy_id in device.identifiers for device in dr.async_entries_for_config_entry(registry, entry.entry_id))
+
+
+@pytest.mark.asyncio
+async def test_lookup_device_by_identifier_rejects_non_device_entry(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Scoped lookup returning a non-DeviceEntry is treated as a miss."""
+    from homeassistant.helpers import device_registry as dr
+
+    runtime, *_rest = make_runtime()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    registry = dr.async_get(hass)
+    monkeypatch.setattr(registry, "async_get_device_by_identifier", lambda *_a, **_k: object(), raising=False)
+
+    assert _lookup_device_by_identifier(registry, (DOMAIN, "DEV1:module.connection"), entry.entry_id) is None
+
+
+@pytest.mark.asyncio
+async def test_lookup_device_by_identifier_scan_misses_without_match(
+    hass: HomeAssistant,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """HA < 2026.7 scan returns None when the entry has no matching identifier."""
+    from homeassistant.helpers import device_registry as dr
+
+    runtime, *_rest = make_runtime()
+    entry = register_config_entry(hass, runtime=runtime, descriptors=[])
+    registry = dr.async_get(hass)
+    registry.async_get_or_create(
+        config_entry_id=entry.entry_id,
+        identifiers={(DOMAIN, "DEV1")},
+        manufacturer="BragerOne",
+        name="Boiler",
+        model="Brager module",
+    )
+    monkeypatch.setattr(registry, "async_get_device_by_identifier", None, raising=False)
+
+    assert _lookup_device_by_identifier(registry, (DOMAIN, "DEV1:module.connection"), entry.entry_id) is None
+    # No-op remove when the legacy connection device is absent (also covers blank devid skip).
+    await async_remove_legacy_connection_devices(hass, entry, devids=["DEV1", ""])
+    assert any((DOMAIN, "DEV1") in device.identifiers for device in dr.async_entries_for_config_entry(registry, entry.entry_id))
 
 
 @pytest.mark.asyncio

--- a/tests/test_init_lifecycle.py
+++ b/tests/test_init_lifecycle.py
@@ -82,7 +82,7 @@ async def test_async_setup_entry_registers_parents_and_warms_resolver(hass: Home
         assert await async_setup_entry(hass, entry) is True
 
     fake_runtime.async_warm_status_resolver.assert_awaited_once_with(["STATUS_P5_11"])
-    assert dr.async_get(hass).async_get_device(identifiers={(DOMAIN, "DEV1")}) is not None
+    assert dr.async_get(hass).async_get_device_by_identifier((DOMAIN, "DEV1"), entry.entry_id) is not None
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Stop using deprecated `device_registry.async_get_device` / `devices` mapping lookups that Home Assistant 2026.9 treats as hard errors.
- Keep HA &lt; 2026.7 `via_device` fallback via a TypedDict cast after `DeviceInfo` dropped that key in 2026.9 stubs.
- Unblocks Renovate lock maintenance (#269), which bumps HA to 2026.9.0.

## Test plan
- [x] `poe typecheck` / entity_common + init lifecycle tests on HA 2026.8.3 (main lock)
- [x] Full `poe validate` against Renovate’s HA 2026.9.0 lock locally
- [ ] CI green on this PR
- [ ] Rebase/retry #269 after merge