### PR TITLE
docs: HassOS field-test flow for py-bragerone pins (#275)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,7 +71,7 @@ Per-module diagnostic sensors expose the SPA **Activity** feed (`routes.activity
 
 ### Field-testing a library pre-release on HassOS (#275)
 
-On **HassOS / HACS**, do **not** pin `py-bragerone` with `git+https://…@sha` in `manifest.json`. HACS updates overwrite local edits, and git installs are a poor fit for HAOS/musl wheels.
+On **HassOS / HACS**, do **not** pin `py-bragerone` with `git+https://…@sha` in `manifest.json`. HACS updates overwrite local edits, and git installs are a poor fit for HassOS (Alpine/musl) wheels.
 
 Supported path:
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -69,6 +69,29 @@ Per-module diagnostic sensors expose SPA **current** and **history** alarms (`al
 Per-module diagnostic sensors expose the SPA **Activity** feed (`routes.activity.index`) with state = loaded row count (first page, SPA default `limit=20`) and an `activities` attribute list (`id`, `devid`, `parameter`, `parameter_key`, `value`, `value_raw`, `prev_value`, `prev_value_raw`, `state`, `state_key`, `created_at`, `created_by`). Labels come from SPA i18n (`activity.state.*`, parameters/units via `ParamResolver` / catalog) — never hardcoded PL/EN. Lists refresh on platform setup, when a module connectivity flip goes online, and after successful Home Assistant writes (SPA logs parameter changes) — no blind polling. Soft-depends on `py-bragerone` `modules_activity` (library PR #338); older pins skip entity creation.
 
 
+### Field-testing a library pre-release on HassOS (#275)
+
+On **HassOS / HACS**, do **not** pin `py-bragerone` with `git+https://…@sha` in `manifest.json`. HACS updates overwrite local edits, and git installs are a poor fit for HAOS/musl wheels.
+
+Supported path:
+
+1. Publish a library pre-release to **PyPI** from [py-bragerone](https://github.com/marpi82/py-bragerone) (`YYYY.M.NrcN` / `bN` / `aN`).
+2. Bump the exact pin here:
+
+   ```bash
+   ./scripts/pin_pybragerone.sh 2026.9.2rc2
+   uv lock
+   ```
+
+   That updates `custom_components/habragerone/manifest.json` `requirements` and
+   `pyproject.toml`. It does **not** change the integration `"version"` field
+   (use `scripts/release.sh` for HACS tags).
+3. Commit the pin + lock, then cut an integration pre-release (`./scripts/release.sh … rc` / `beta`).
+4. On the live HA instance: HACS → **Show beta versions** → install/update BragerOne.
+5. Smoke config flow, entities, reconnect / cloud session, and (when the pin includes it) diagnostics `connectivity_episodes`.
+
+For **native / Cursor Cloud** HA only, `USE_LOCAL_PYBRAGERONE=1 uv run poe hass-prepare` still uses an editable sibling checkout — that path is not available on HassOS.
+
 ### Publishing Releases
 
 Do **not** cut a stable HACS tag until the same version has been smoke-tested as a HACS **pre-release** on a live Home Assistant install. Tooling already supports this (`scripts/release.sh` + `.github/workflows/release.yml`); skipping the beta/rc step is a process failure, not a tooling gap.

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This custom component provides integration between Home Assistant and the Brager
 3. Restart Home Assistant
 4. Configure the integration
 
-Testers: enable HACS **Show beta versions** to install `alpha` / `beta` / `rc` tags before they hit the default (stable) channel. Maintainers always smoke-test a pre-release on a live HA instance before cutting the matching stable tag — see [DEVELOPMENT.md](DEVELOPMENT.md#publishing-releases).
+Testers: enable HACS **Show beta versions** to install `alpha` / `beta` / `rc` tags before they hit the default (stable) channel. Maintainers always smoke-test a pre-release on a live HA instance before cutting the matching stable tag — see [DEVELOPMENT.md](DEVELOPMENT.md#publishing-releases). Field-testing a **library** pre-release on HassOS uses a PyPI pin (not `git+`); see [DEVELOPMENT.md](DEVELOPMENT.md#field-testing-a-library-pre-release-on-hassos-275).
 
 ## Configuration
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -4,6 +4,14 @@ This directory contains development helper scripts for ha-bragerone.
 
 ## Scripts
 
+### pin_pybragerone.sh
+Bump the exact `py-bragerone==…` pin in `manifest.json` and `pyproject.toml` (then run `uv lock`). For HassOS field-tests, only pin published PyPI pre-releases — see DEVELOPMENT.md.
+
+```bash
+./scripts/pin_pybragerone.sh 2026.9.2rc2
+uv lock
+```
+
 ### setup.sh
 Initial development environment setup script. Installs dependencies, sets up pre-commit hooks, creates configuration files.
 

--- a/scripts/pin_pybragerone.sh
+++ b/scripts/pin_pybragerone.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+#
+# Bump the exact py-bragerone pin in manifest.json + pyproject.toml.
+# Usage: ./scripts/pin_pybragerone.sh <version>
+#
+# Example:
+#   ./scripts/pin_pybragerone.sh 2026.9.2rc2
+#   uv lock
+#
+# Does NOT bump the integration "version" field (use release.sh for that).
+# Does NOT rewrite uv.lock — run `uv lock` after this script.
+# HassOS / HACS: only pin published PyPI versions (never git+…@sha).
+
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
+
+log_info() { echo -e "${GREEN}[INFO]${NC} $1"; }
+log_error() { echo -e "${RED}[ERROR]${NC} $1"; }
+
+VERSION="${1:-}"
+if [[ -z "${VERSION}" ]]; then
+  log_error "Version is required"
+  echo "Usage: $0 <py-bragerone-version>"
+  echo "Example: $0 2026.9.2rc2"
+  exit 1
+fi
+
+# CalVer + optional pre-release suffix (matches library tags / PyPI).
+if [[ ! "${VERSION}" =~ ^[0-9]{4}\.[0-9]+(\.[0-9]+)?((a|b|rc)[0-9]+)?$ ]]; then
+  log_error "Unexpected version shape: ${VERSION}"
+  echo "Expected CalVer like 2026.9.2 or 2026.9.2rc2"
+  exit 1
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+MANIFEST="${REPO_ROOT}/custom_components/habragerone/manifest.json"
+PYPROJECT="${REPO_ROOT}/pyproject.toml"
+
+if [[ ! -f "${MANIFEST}" || ! -f "${PYPROJECT}" ]]; then
+  log_error "manifest.json or pyproject.toml not found under ${REPO_ROOT}"
+  exit 1
+fi
+
+python3 - "${MANIFEST}" "${VERSION}" <<'PY'
+import json
+import sys
+from pathlib import Path
+
+manifest_path = Path(sys.argv[1])
+version = sys.argv[2]
+data = json.loads(manifest_path.read_text(encoding="utf-8"))
+reqs = data.get("requirements")
+if not isinstance(reqs, list):
+    raise SystemExit("manifest.json requirements must be a list")
+pin = f"py-bragerone=={version}"
+updated: list[str] = []
+found = False
+for item in reqs:
+    if not isinstance(item, str):
+        updated.append(item)  # type: ignore[arg-type]
+        continue
+    if item.startswith("py-bragerone==") or item.startswith("py-bragerone@"):
+        updated.append(pin)
+        found = True
+    else:
+        updated.append(item)
+if not found:
+    updated.insert(0, pin)
+data["requirements"] = updated
+manifest_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+print(pin)
+PY
+
+python3 - "${PYPROJECT}" "${VERSION}" <<'PY'
+import re
+import sys
+from pathlib import Path
+
+path = Path(sys.argv[1])
+version = sys.argv[2]
+text = path.read_text(encoding="utf-8")
+pattern = re.compile(r'(["\'])py-bragerone==[^"\']+\1')
+replacement = f'\\1py-bragerone=={version}\\1'
+new_text, count = pattern.subn(replacement, text, count=1)
+if count != 1:
+    raise SystemExit(f"expected exactly one py-bragerone== pin in pyproject.toml, found {count}")
+path.write_text(new_text, encoding="utf-8")
+PY
+
+log_info "Pinned py-bragerone==${VERSION} in manifest.json and pyproject.toml"
+log_info "Next: uv lock && commit, then tag/release the integration when ready"
+log_info "HassOS: install via HACS beta — do not use git+ pins on HAOS"

--- a/scripts/pin_pybragerone.sh
+++ b/scripts/pin_pybragerone.sh
@@ -28,8 +28,8 @@ if [[ -z "${VERSION}" ]]; then
   exit 1
 fi
 
-# CalVer + optional pre-release suffix (matches library tags / PyPI).
-if [[ ! "${VERSION}" =~ ^[0-9]{4}\.[0-9]+(\.[0-9]+)?((a|b|rc)[0-9]+)?$ ]]; then
+# Three-segment CalVer + optional pre-release suffix (matches library tags / PyPI).
+if [[ ! "${VERSION}" =~ ^[0-9]{4}\.[0-9]+\.[0-9]+((a|b|rc)[0-9]+)?$ ]]; then
   log_error "Unexpected version shape: ${VERSION}"
   echo "Expected CalVer like 2026.9.2 or 2026.9.2rc2"
   exit 1
@@ -56,13 +56,10 @@ reqs = data.get("requirements")
 if not isinstance(reqs, list):
     raise SystemExit("manifest.json requirements must be a list")
 pin = f"py-bragerone=={version}"
-updated: list[str] = []
+updated: list[object] = []
 found = False
 for item in reqs:
-    if not isinstance(item, str):
-        updated.append(item)  # type: ignore[arg-type]
-        continue
-    if item.startswith("py-bragerone==") or item.startswith("py-bragerone@"):
+    if isinstance(item, str) and (item.startswith("py-bragerone==") or item.startswith("py-bragerone@")):
         updated.append(pin)
         found = True
     else:
@@ -83,13 +80,16 @@ path = Path(sys.argv[1])
 version = sys.argv[2]
 text = path.read_text(encoding="utf-8")
 pattern = re.compile(r'(["\'])py-bragerone==[^"\']+\1')
+matches = pattern.findall(text)
+if len(matches) != 1:
+    raise SystemExit(f"expected exactly one py-bragerone== pin in pyproject.toml, found {len(matches)}")
 replacement = f'\\1py-bragerone=={version}\\1'
-new_text, count = pattern.subn(replacement, text, count=1)
+new_text, count = pattern.subn(replacement, text)
 if count != 1:
-    raise SystemExit(f"expected exactly one py-bragerone== pin in pyproject.toml, found {count}")
+    raise SystemExit(f"failed to rewrite py-bragerone pin (replacements={count})")
 path.write_text(new_text, encoding="utf-8")
 PY
 
 log_info "Pinned py-bragerone==${VERSION} in manifest.json and pyproject.toml"
 log_info "Next: uv lock && commit, then tag/release the integration when ready"
-log_info "HassOS: install via HACS beta — do not use git+ pins on HAOS"
+log_info "HassOS: install via HACS beta — do not use git+ pins on HassOS"


### PR DESCRIPTION
## Summary
- Document HassOS / HACS field-test path: **PyPI library pre-release → exact pin → HACS beta** (never `git+` on HAOS).
- Add `scripts/pin_pybragerone.sh` to bump `manifest.json` + `pyproject.toml` consistently.
- README + scripts/README pointers.

## Test plan
- [x] `./scripts/pin_pybragerone.sh 2026.9.2rc2` updates both files
- [ ] Docs review

Closes #275