### PR TITLE
chore: pin py-bragerone 2026.9.2rc3 for integration rc

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,7 +79,7 @@ Supported path:
 2. Bump the exact pin here:
 
    ```bash
-   ./scripts/pin_pybragerone.sh 2026.9.2rc2
+   ./scripts/pin_pybragerone.sh 2026.9.2rc3
    uv lock
    ```
 

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.9.2rc2",
+    "py-bragerone==2026.9.2rc3",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.9.2rc2"
+  "version": "2026.9.2rc3"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone==2026.9.2rc2",
+    "py-bragerone==2026.9.2rc3",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,7 @@ This directory contains development helper scripts for ha-bragerone.
 Bump the exact `py-bragerone==…` pin in `manifest.json` and `pyproject.toml` (then run `uv lock`). For HassOS field-tests, only pin published PyPI pre-releases — see DEVELOPMENT.md.
 
 ```bash
-./scripts/pin_pybragerone.sh 2026.9.2rc2
+./scripts/pin_pybragerone.sh 2026.9.2rc3
 uv lock
 ```
 

--- a/uv.lock
+++ b/uv.lock
@@ -1216,7 +1216,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = "==2026.9.2rc2" },
+    { name = "py-bragerone", specifier = "==2026.9.2rc3" },
 ]
 
 [package.metadata.requires-dev]
@@ -2273,7 +2273,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.9.2rc2"
+version = "2026.9.2rc3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2283,9 +2283,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5a/a3/9a020021645ed041d79db8cbcbebefa58a0b7b3960f889bf401b0b7be3d4/py_bragerone-2026.9.2rc2.tar.gz", hash = "sha256:95c0817aeac9de87ec6c6b277caf7df61f93da0ba21f351505cfdbb04ea67a61", size = 142023, upload-time = "2026-09-06T14:13:59.166Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/eb/ced9f15bb6ab4ae3b088bec4984b50d5555ad672b2437d98c015eef37d73/py_bragerone-2026.9.2rc3.tar.gz", hash = "sha256:42ba598a920e8f25d0475caf52e8823927a378e70f89d3e3ef0cc6bae5d11382", size = 145237, upload-time = "2026-09-08T21:16:39.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/40/82f0642517f9eba3e58d5954c0270e5b2a12a360922e679ca2612e4547fb/py_bragerone-2026.9.2rc2-py3-none-any.whl", hash = "sha256:890438e4f1ee7067150a30f71bf34cf017ca4bc047543c09f2505fc76cab1e0a", size = 154151, upload-time = "2026-09-06T14:13:57.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/00/4158f23c47edb259c5ed75a471fdc60d27c30cee1160ef2bd7c16b72d03f/py_bragerone-2026.9.2rc3-py3-none-any.whl", hash = "sha256:c41174c651fbf5e5fb8f0452e7586bfe38927a272367202b1208ff618bb688af", size = 157170, upload-time = "2026-09-08T21:16:37.575Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin `py-bragerone==2026.9.2rc3` (manifest + pyproject + lock).
- Bump integration `version` to `2026.9.2rc3` for the HACS pre-release tag.
- Refresh pin-script examples in DEVELOPMENT.md / scripts/README.md.

## Test plan
- [x] `uv lock --upgrade-package py-bragerone` resolves rc3 from PyPI
- [ ] CI green; then tag `2026.9.2rc3` on main