### PR TITLE
chore: pin py-bragerone 2026.9.2 for integration stable

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -79,7 +79,7 @@ Supported path:
 2. Bump the exact pin here:
 
    ```bash
-   ./scripts/pin_pybragerone.sh 2026.9.2rc4
+   ./scripts/pin_pybragerone.sh 2026.9.2
    uv lock
    ```
 

--- a/custom_components/habragerone/manifest.json
+++ b/custom_components/habragerone/manifest.json
@@ -16,8 +16,8 @@
     "custom_components.habragerone"
   ],
   "requirements": [
-    "py-bragerone==2026.9.2rc4",
+    "py-bragerone==2026.9.2",
     "tree-sitter==0.26.0"
   ],
-  "version": "2026.9.2rc4"
+  "version": "2026.9.2"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ keywords = [
 ]
 dependencies = [
     "homeassistant>=2026.3.0",
-    "py-bragerone==2026.9.2rc4",
+    "py-bragerone==2026.9.2",
 ]
 classifiers = [
   "Development Status :: 5 - Production/Stable",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -8,7 +8,7 @@ This directory contains development helper scripts for ha-bragerone.
 Bump the exact `py-bragerone==…` pin in `manifest.json` and `pyproject.toml` (then run `uv lock`). For HassOS field-tests, only pin published PyPI pre-releases — see DEVELOPMENT.md.
 
 ```bash
-./scripts/pin_pybragerone.sh 2026.9.2rc4
+./scripts/pin_pybragerone.sh 2026.9.2
 uv lock
 ```
 

--- a/uv.lock
+++ b/uv.lock
@@ -1216,7 +1216,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "homeassistant", specifier = ">=2026.3.0" },
-    { name = "py-bragerone", specifier = "==2026.9.2rc4" },
+    { name = "py-bragerone", specifier = "==2026.9.2" },
 ]
 
 [package.metadata.requires-dev]
@@ -2273,7 +2273,7 @@ wheels = [
 
 [[package]]
 name = "py-bragerone"
-version = "2026.9.2rc4"
+version = "2026.9.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -2283,9 +2283,9 @@ dependencies = [
     { name = "tree-sitter-javascript" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/a2/c69ceafe37b974c1fa4116d6a5f3ee43d2e44158126cf220a31b07364fad/py_bragerone-2026.9.2rc4.tar.gz", hash = "sha256:97a4931c789344ab7ff4745e588ec691b620302fa05f0e346ba0d52c0f275193", size = 146155, upload-time = "2026-09-10T07:46:02.752Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ff/e0/1b9bab3641bacdbaef78982e221b4b5b2c102f5bcceefde85d5a2a99ba5b/py_bragerone-2026.9.2.tar.gz", hash = "sha256:305ff02b11b4fbc557be8f3760bc63ce159d5235c668007827f105688be1c9b7", size = 146214, upload-time = "2026-09-11T22:36:30.267Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/41/d55aaef2abfaf5f0a01a869f80b112ccdad774d8dc2ddd8ee3a75bc43176/py_bragerone-2026.9.2rc4-py3-none-any.whl", hash = "sha256:2468bbf0f34fd691b1a8b510c9a450b1575c096401d63667446cd95f6903a7c6", size = 158009, upload-time = "2026-09-10T07:46:01.313Z" },
+    { url = "https://files.pythonhosted.org/packages/60/b4/c173fc79f790a55868ef9b93adee5843d92ffb63d049de7361c12b84673b/py_bragerone-2026.9.2-py3-none-any.whl", hash = "sha256:92cc5ce0e9b4ae61f409680b39930ce23d5c8745a5e0dd40c4e350039bf6d45e", size = 158009, upload-time = "2026-09-11T22:36:28.865Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Pin \`py-bragerone==2026.9.2\` (manifest + pyproject + lock).
- Bump integration \`version\` to \`2026.9.2\` for the HACS stable tag.
- Refresh pin-script examples.

Library stable includes connectivity clarity (#393–#396) and EventBus ParamUpdate-only docs (#386 Phase A).

## Test plan
- [x] \`uv lock --upgrade-package py-bragerone\` resolves 2026.9.2 from PyPI
- [ ] CI green; then tag \`2026.9.2\` on main